### PR TITLE
Ensured that calling `return_from_subroutine` really does unjam the processor if required

### DIFF
--- a/Processors/6502/CPU6502.hpp
+++ b/Processors/6502/CPU6502.hpp
@@ -678,7 +678,7 @@ template <class T> class Processor {
 
 							if(_jam_handler) {
 								_jam_handler->processor_did_jam(this, _pc.full - 1);
-								checkSchedule(_is_jammed = false);
+								checkSchedule(_is_jammed = false; program = _scheduledPrograms[scheduleProgramsReadPointer]);
 							}
 						} break;
 


### PR DESCRIPTION
… causing all unit tests once again to pass.