### PR TITLE
Implemented deferred setting of shader uniforms

### DIFF
--- a/Machines/Atari2600/Atari2600.cpp
+++ b/Machines/Atari2600/Atari2600.cpp
@@ -39,7 +39,7 @@ void Machine::setup_output(float aspect_ratio)
 			"uint y = c & 14u;"
 			"uint iPhase = (c >> 4);"
 
-			"float phaseOffset = 6.283185308 * float(iPhase + 13u) / 14.0;"
+			"float phaseOffset = 6.283185308 * float(iPhase - 1u) / 13.0;"
 			"return (float(y) / 14.0) * (1.0 - amplitude) + step(1, iPhase) * amplitude * cos(phase + phaseOffset);"
 		"}");
 	_crt->set_output_device(Outputs::CRT::Television);
@@ -55,8 +55,10 @@ void Machine::switch_region()
 			"uint y = c & 14u;"
 			"uint iPhase = (c >> 4);"
 
-			"float phaseOffset = (0.5 + 2.0 * (float(iPhase&1u) - 0.5) * (float((iPhase >> 1) + (iPhase&1u)) / 14.0));"
-			"return (float(y) / 14.0) * (1.0 - amplitude) + step(4, (iPhase + 2u) & 15u) * amplitude * cos(phase + 6.283185308 * phaseOffset);"
+			"uint direction = iPhase & 1u;"
+			"float phaseOffset = float(7u - direction) + (float(direction) - 0.5) * 2.0 * float(iPhase >> 1);"
+			"phaseOffset *= 6.283185308 / 12.0;"
+			"return (float(y) / 14.0) * (1.0 - amplitude) + step(4, (iPhase + 2u) & 15u) * amplitude * cos(phase + phaseOffset);"
 		"}");
 	_crt->set_new_timing(228, 312, Outputs::CRT::ColourSpace::YUV, 228, 1);
 }
@@ -171,6 +173,9 @@ void Machine::get_output_pixel(uint8_t *pixel, int offset)
 	}
 
 	// store colour
+//	static int lc;
+//	if(_vSyncEnabled) lc = 0; else lc += (offset == 159) ? 1 : 0;
+//	*pixel = (uint8_t)(((offset  / 10) << 4) | (((lc >> 4)&7) << 1));
 	*pixel = outputColour;
 }
 

--- a/Outputs/CRT/Internals/Shaders/IntermediateShader.hpp
+++ b/Outputs/CRT/Internals/Shaders/IntermediateShader.hpp
@@ -88,15 +88,6 @@ public:
 
 private:
 	static std::unique_ptr<IntermediateShader> make_shader(const char *fragment_shader, bool use_usampler, bool input_is_inputPosition);
-
-	GLint texIDUniform;
-	GLint outputTextureSizeUniform;
-	GLint weightsUniform;
-	GLint phaseCyclesPerTickUniform;
-	GLint extensionUniform;
-	GLint rgbToLumaChromaUniform;
-	GLint lumaChromaToRGBUniform;
-	GLint offsetsUniform;
 };
 
 }

--- a/Outputs/CRT/Internals/Shaders/IntermediateShader.hpp
+++ b/Outputs/CRT/Internals/Shaders/IntermediateShader.hpp
@@ -55,34 +55,36 @@ public:
 	static std::unique_ptr<IntermediateShader> make_rgb_filter_shader();
 
 	/*!
-		Binds this shader and configures it for output to an area of `output_width` and `output_height` pixels.
+		Queues the configuration of this shader for output to an area of `output_width` and `output_height` pixels
+		to occur upon the next `bind`.
 	*/
 	void set_output_size(unsigned int output_width, unsigned int output_height);
 
 	/*!
-		Binds this shader and sets the texture unit (as an enum, e.g. `GL_TEXTURE0`) to sample as source data.
+		Queues setting the texture unit (as an enum, e.g. `GL_TEXTURE0`) for source data to occur upon the next `bind`.
 	*/
 	void set_source_texture_unit(GLenum unit);
 
 	/*!
-		Binds this shader and sets filtering coefficients for a lowpass filter based on the cutoff.
+		Queues setting filtering coefficients for a lowpass filter based on the cutoff frequency to occur upon the next `bind`.
 	*/
 	void set_filter_coefficients(float sampling_rate, float cutoff_frequency);
 
 	/*!
-		Binds this shader and configures filtering to separate luminance and chrominance based on a colour
-		subcarrier of the given frequency.
+		Queues configuration of filtering to separate luminance and chrominance based on a colour
+		subcarrier of the given frequency to occur upon the next `bind`.
 	*/
 	void set_separation_frequency(float sampling_rate, float colour_burst_frequency);
 
 	/*!
-		Binds this shader and sets the number of colour phase cycles per sample, indicating whether output
-		geometry should be extended so that a complete colour cycle is included at both the beginning and end.
+		Queues setting of the number of colour phase cycles per sample, indicating whether output
+		geometry should be extended so that a complete colour cycle is included at both the beginning and end,
+		to occur upon the next `bind`.
 	*/
 	void set_phase_cycles_per_sample(float phase_cycles_per_sample, bool extend_runs_to_full_cycle);
 
 	/*!
-		Binds this shader and sets the matrices that convert between RGB and chrominance/luminance.
+		Queues setting the matrices that convert between RGB and chrominance/luminance to occur on the next `bind`.
 	*/
 	void set_colour_conversion_matrices(float *fromRGB, float *toRGB);
 

--- a/Outputs/CRT/Internals/Shaders/OutputShader.hpp
+++ b/Outputs/CRT/Internals/Shaders/OutputShader.hpp
@@ -56,9 +56,6 @@ public:
 		Binds this shader and configures its understanding of how to map from the source vertex stream to screen coordinates.
 	*/
 	void set_timing(unsigned int height_of_display, unsigned int cycles_per_line, unsigned int horizontal_scan_period, unsigned int vertical_scan_period, unsigned int vertical_period_divider);
-
-	private:
-		GLint boundsOriginUniform, boundsSizeUniform, texIDUniform, scanNormalUniform, positionConversionUniform;
 };
 
 }

--- a/Outputs/CRT/Internals/Shaders/OutputShader.hpp
+++ b/Outputs/CRT/Internals/Shaders/OutputShader.hpp
@@ -42,18 +42,20 @@ public:
 	using Shader::Shader;
 
 	/*!
-		Binds this shader and configures it for output to an area of `output_width` and `output_height` pixels, ensuring
-		the largest possible drawing size that allows everything within `visible_area` to be visible.
+		Queues configuration for output to an area of `output_width` and `output_height` pixels, ensuring
+		the largest possible drawing size that allows everything within `visible_area` to be visible, to
+		occur upon the next `bind`.
 	*/
 	void set_output_size(unsigned int output_width, unsigned int output_height, Outputs::CRT::Rect visible_area);
 
 	/*!
-		Binds this shader and sets the texture unit (as an enum, e.g. `GL_TEXTURE0`) to sample as source data.
+		Queues setting of the texture unit (as an enum, e.g. `GL_TEXTURE0`) for source data upon the next `bind`.
 	*/
 	void set_source_texture_unit(GLenum unit);
 
 	/*!
-		Binds this shader and configures its understanding of how to map from the source vertex stream to screen coordinates.
+		Queues configuring this shader's understanding of how to map from the source vertex stream to screen coordinates,
+		to occur upon the next `bind`.
 	*/
 	void set_timing(unsigned int height_of_display, unsigned int cycles_per_line, unsigned int horizontal_scan_period, unsigned int vertical_scan_period, unsigned int vertical_period_divider);
 };

--- a/Outputs/CRT/Internals/Shaders/Shader.cpp
+++ b/Outputs/CRT/Internals/Shaders/Shader.cpp
@@ -120,3 +120,119 @@ void Shader::enable_vertex_attribute_with_pointer(const char *name, GLint size, 
 	glVertexAttribPointer((GLuint)location, size, type, normalised, stride, pointer);
 	glVertexAttribDivisor((GLuint)location, divisor);
 }
+
+// The various set_uniforms...
+GLint Shader::location_for_bound_uniform(const GLchar *name)
+{
+	bind();
+	return glGetUniformLocation(_shader_program, name);
+}
+
+void Shader::set_uniform(const GLchar *name, GLint value)
+{
+	glUniform1i(location_for_bound_uniform(name), value);
+}
+
+void Shader::set_uniform(const GLchar *name, GLint value1, GLint value2)
+{
+	glUniform2i(location_for_bound_uniform(name), value1, value2);
+}
+
+void Shader::set_uniform(const GLchar *name, GLint value1, GLint value2, GLint value3)
+{
+	glUniform3i(location_for_bound_uniform(name), value1, value2, value3);
+}
+
+void Shader::set_uniform(const GLchar *name, GLint value1, GLint value2, GLint value3, GLint value4)
+{
+	glUniform4i(location_for_bound_uniform(name), value1, value2, value3, value4);
+}
+
+void Shader::set_uniform(const GLchar *name, GLint size, GLsizei count, const GLint *values)
+{
+	switch(size)
+	{
+		case 1: glUniform1iv(location_for_bound_uniform(name), count, values);	break;
+		case 2: glUniform2iv(location_for_bound_uniform(name), count, values);	break;
+		case 3: glUniform3iv(location_for_bound_uniform(name), count, values);	break;
+		case 4: glUniform4iv(location_for_bound_uniform(name), count, values);	break;
+	}
+}
+
+void Shader::set_uniform(const GLchar *name, GLfloat value)
+{
+	glUniform1f(location_for_bound_uniform(name), value);
+}
+
+void Shader::set_uniform(const GLchar *name, GLfloat value1, GLfloat value2)
+{
+	glUniform2f(location_for_bound_uniform(name), value1, value2);
+}
+
+void Shader::set_uniform(const GLchar *name, GLfloat value1, GLfloat value2, GLfloat value3)
+{
+	glUniform3f(location_for_bound_uniform(name), value1, value2, value3);
+}
+
+void Shader::set_uniform(const GLchar *name, GLfloat value1, GLfloat value2, GLfloat value3, GLfloat value4)
+{
+	glUniform4f(location_for_bound_uniform(name), value1, value2, value3, value4);
+}
+
+void Shader::set_uniform(const GLchar *name, GLint size, GLsizei count, const GLfloat *values)
+{
+	switch(size)
+	{
+		case 1: glUniform1fv(location_for_bound_uniform(name), count, values);	break;
+		case 2: glUniform2fv(location_for_bound_uniform(name), count, values);	break;
+		case 3: glUniform3fv(location_for_bound_uniform(name), count, values);	break;
+		case 4: glUniform4fv(location_for_bound_uniform(name), count, values);	break;
+	}
+}
+
+void Shader::set_uniform(const GLchar *name, GLuint value)
+{
+	glUniform1ui(location_for_bound_uniform(name), value);
+}
+
+void Shader::set_uniform(const GLchar *name, GLuint value1, GLuint value2)
+{
+	glUniform2ui(location_for_bound_uniform(name), value1, value2);
+}
+
+void Shader::set_uniform(const GLchar *name, GLuint value1, GLuint value2, GLuint value3)
+{
+	glUniform3ui(location_for_bound_uniform(name), value1, value2, value3);
+}
+
+void Shader::set_uniform(const GLchar *name, GLuint value1, GLuint value2, GLuint value3, GLuint value4)
+{
+	glUniform4ui(location_for_bound_uniform(name), value1, value2, value3, value4);
+}
+
+void Shader::set_uniform(const GLchar *name, GLint size, GLsizei count, const GLuint *values)
+{
+	switch(size)
+	{
+		case 1: glUniform1uiv(location_for_bound_uniform(name), count, values);	break;
+		case 2: glUniform2uiv(location_for_bound_uniform(name), count, values);	break;
+		case 3: glUniform3uiv(location_for_bound_uniform(name), count, values);	break;
+		case 4: glUniform4uiv(location_for_bound_uniform(name), count, values);	break;
+	}
+}
+
+void Shader::set_uniform_matrix(const GLchar *name, GLint size, bool transpose, const GLfloat *values)
+{
+	set_uniform_matrix(name, size, 1, transpose, values);
+}
+
+void Shader::set_uniform_matrix(const GLchar *name, GLint size, GLsizei count, bool transpose, const GLfloat *values)
+{
+	GLboolean glTranspose = transpose ? GL_TRUE : GL_FALSE;
+	switch(size)
+	{
+		case 2: glUniformMatrix2fv(location_for_bound_uniform(name), count, glTranspose, values);	break;
+		case 3: glUniformMatrix3fv(location_for_bound_uniform(name), count, glTranspose, values);	break;
+		case 4: glUniformMatrix4fv(location_for_bound_uniform(name), count, glTranspose, values);	break;
+	}
+}

--- a/Outputs/CRT/Internals/Shaders/Shader.cpp
+++ b/Outputs/CRT/Internals/Shaders/Shader.cpp
@@ -123,7 +123,13 @@ void Shader::enable_vertex_attribute_with_pointer(const char *name, GLint size, 
 }
 
 // The various set_uniforms...
-#define location() glGetUniformLocation(_shader_program, name.c_str())
+GLint fglGetUniformLocation(GLuint program, const GLchar *name)
+{
+	GLint result = glGetUniformLocation(program, name);
+	printf("Resolved %s to %d\n", name, result);
+	return result;
+}
+#define location() fglGetUniformLocation(_shader_program, name.c_str())
 void Shader::set_uniform(const std::string &name, GLint value)
 {
 	enqueue_function([name, value, this] {
@@ -214,40 +220,49 @@ void Shader::set_uniform(const std::string &name, GLuint value1, GLuint value2, 
 
 void Shader::set_uniform(const std::string &name, GLint size, GLsizei count, const GLint *values)
 {
-	enqueue_function([name, size, count, values, this] {
+	GLint *values_copy = new GLint[count];
+	memcpy(values_copy, values, sizeof(GLint) * (size_t)count);
+	enqueue_function([name, size, count, values_copy, this] {
 		switch(size)
 		{
-			case 1: glUniform1iv(location(), count, values);	break;
-			case 2: glUniform2iv(location(), count, values);	break;
-			case 3: glUniform3iv(location(), count, values);	break;
-			case 4: glUniform4iv(location(), count, values);	break;
+			case 1: glUniform1iv(location(), count, values_copy);	break;
+			case 2: glUniform2iv(location(), count, values_copy);	break;
+			case 3: glUniform3iv(location(), count, values_copy);	break;
+			case 4: glUniform4iv(location(), count, values_copy);	break;
 		}
+		delete[] values_copy;
 	});
 }
 
 void Shader::set_uniform(const std::string &name, GLint size, GLsizei count, const GLfloat *values)
 {
-	enqueue_function([name, size, count, values, this] {
+	GLfloat *values_copy = new GLfloat[count];
+	memcpy(values_copy, values, sizeof(GLfloat) * (size_t)count);
+	enqueue_function([name, size, count, values_copy, this] {
 		switch(size)
 		{
-			case 1: glUniform1fv(location(), count, values);	break;
-			case 2: glUniform2fv(location(), count, values);	break;
-			case 3: glUniform3fv(location(), count, values);	break;
-			case 4: glUniform4fv(location(), count, values);	break;
+			case 1: glUniform1fv(location(), count, values_copy);	break;
+			case 2: glUniform2fv(location(), count, values_copy);	break;
+			case 3: glUniform3fv(location(), count, values_copy);	break;
+			case 4: glUniform4fv(location(), count, values_copy);	break;
 		}
+		delete[] values_copy;
 	});
 }
 
 void Shader::set_uniform(const std::string &name, GLint size, GLsizei count, const GLuint *values)
 {
-	enqueue_function([name, size, count, values, this] {
+	GLuint *values_copy = new GLuint[count];
+	memcpy(values_copy, values, sizeof(GLuint) * (size_t)count);
+	enqueue_function([name, size, count, values_copy, this] {
 		switch(size)
 		{
-			case 1: glUniform1uiv(location(), count, values);	break;
-			case 2: glUniform2uiv(location(), count, values);	break;
-			case 3: glUniform3uiv(location(), count, values);	break;
-			case 4: glUniform4uiv(location(), count, values);	break;
+			case 1: glUniform1uiv(location(), count, values_copy);	break;
+			case 2: glUniform2uiv(location(), count, values_copy);	break;
+			case 3: glUniform3uiv(location(), count, values_copy);	break;
+			case 4: glUniform4uiv(location(), count, values_copy);	break;
 		}
+		delete[] values_copy;
 	});
 }
 
@@ -258,14 +273,17 @@ void Shader::set_uniform_matrix(const std::string &name, GLint size, bool transp
 
 void Shader::set_uniform_matrix(const std::string &name, GLint size, GLsizei count, bool transpose, const GLfloat *values)
 {
-	enqueue_function([name, size, count, transpose, values, this] {
-	GLboolean glTranspose = transpose ? GL_TRUE : GL_FALSE;
+	GLfloat *values_copy = new GLfloat[count*size];
+	memcpy(values_copy, values, sizeof(GLfloat) * (size_t)count * (size_t)size);
+	enqueue_function([name, size, count, transpose, values_copy, this] {
+		GLboolean glTranspose = transpose ? GL_TRUE : GL_FALSE;
 		switch(size)
 		{
-			case 2: glUniformMatrix2fv(location(), count, glTranspose, values);	break;
-			case 3: glUniformMatrix3fv(location(), count, glTranspose, values);	break;
-			case 4: glUniformMatrix4fv(location(), count, glTranspose, values);	break;
+			case 2: glUniformMatrix2fv(location(), count, glTranspose, values_copy);	break;
+			case 3: glUniformMatrix3fv(location(), count, glTranspose, values_copy);	break;
+			case 4: glUniformMatrix4fv(location(), count, glTranspose, values_copy);	break;
 		}
+		delete[] values_copy;
 	});
 }
 

--- a/Outputs/CRT/Internals/Shaders/Shader.cpp
+++ b/Outputs/CRT/Internals/Shaders/Shader.cpp
@@ -123,13 +123,7 @@ void Shader::enable_vertex_attribute_with_pointer(const char *name, GLint size, 
 }
 
 // The various set_uniforms...
-GLint fglGetUniformLocation(GLuint program, const GLchar *name)
-{
-	GLint result = glGetUniformLocation(program, name);
-	printf("Resolved %s to %d\n", name, result);
-	return result;
-}
-#define location() fglGetUniformLocation(_shader_program, name.c_str())
+#define location() glGetUniformLocation(_shader_program, name.c_str())
 void Shader::set_uniform(const std::string &name, GLint value)
 {
 	enqueue_function([name, value, this] {
@@ -220,8 +214,10 @@ void Shader::set_uniform(const std::string &name, GLuint value1, GLuint value2, 
 
 void Shader::set_uniform(const std::string &name, GLint size, GLsizei count, const GLint *values)
 {
-	GLint *values_copy = new GLint[count];
-	memcpy(values_copy, values, sizeof(GLint) * (size_t)count);
+	size_t number_of_values = (size_t)count * (size_t)size;
+	GLint *values_copy = new GLint[number_of_values];
+	memcpy(values_copy, values, sizeof(*values) * (size_t)number_of_values);
+
 	enqueue_function([name, size, count, values_copy, this] {
 		switch(size)
 		{
@@ -236,8 +232,10 @@ void Shader::set_uniform(const std::string &name, GLint size, GLsizei count, con
 
 void Shader::set_uniform(const std::string &name, GLint size, GLsizei count, const GLfloat *values)
 {
-	GLfloat *values_copy = new GLfloat[count];
-	memcpy(values_copy, values, sizeof(GLfloat) * (size_t)count);
+	size_t number_of_values = (size_t)count * (size_t)size;
+	GLfloat *values_copy = new GLfloat[number_of_values];
+	memcpy(values_copy, values, sizeof(*values) * (size_t)number_of_values);
+
 	enqueue_function([name, size, count, values_copy, this] {
 		switch(size)
 		{
@@ -252,8 +250,10 @@ void Shader::set_uniform(const std::string &name, GLint size, GLsizei count, con
 
 void Shader::set_uniform(const std::string &name, GLint size, GLsizei count, const GLuint *values)
 {
-	GLuint *values_copy = new GLuint[count];
-	memcpy(values_copy, values, sizeof(GLuint) * (size_t)count);
+	size_t number_of_values = (size_t)count * (size_t)size;
+	GLuint *values_copy = new GLuint[number_of_values];
+	memcpy(values_copy, values, sizeof(*values) * (size_t)number_of_values);
+
 	enqueue_function([name, size, count, values_copy, this] {
 		switch(size)
 		{
@@ -273,8 +273,10 @@ void Shader::set_uniform_matrix(const std::string &name, GLint size, bool transp
 
 void Shader::set_uniform_matrix(const std::string &name, GLint size, GLsizei count, bool transpose, const GLfloat *values)
 {
-	GLfloat *values_copy = new GLfloat[count*size];
-	memcpy(values_copy, values, sizeof(GLfloat) * (size_t)count * (size_t)size);
+	size_t number_of_values = (size_t)count * (size_t)size * (size_t)size;
+	GLfloat *values_copy = new GLfloat[number_of_values];
+	memcpy(values_copy, values, sizeof(*values) * number_of_values);
+
 	enqueue_function([name, size, count, transpose, values_copy, this] {
 		GLboolean glTranspose = transpose ? GL_TRUE : GL_FALSE;
 		switch(size)

--- a/Outputs/CRT/Internals/Shaders/Shader.cpp
+++ b/Outputs/CRT/Internals/Shaders/Shader.cpp
@@ -95,6 +95,7 @@ void Shader::bind()
 		glUseProgram(_shader_program);
 		bound_shader = this;
 	}
+	flush_functions();
 }
 
 void Shader::unbind()
@@ -122,117 +123,162 @@ void Shader::enable_vertex_attribute_with_pointer(const char *name, GLint size, 
 }
 
 // The various set_uniforms...
-GLint Shader::location_for_bound_uniform(const GLchar *name)
+#define location() glGetUniformLocation(_shader_program, name.c_str())
+void Shader::set_uniform(const std::string &name, GLint value)
 {
-	bind();
-	return glGetUniformLocation(_shader_program, name);
+	enqueue_function([name, value, this] {
+		glUniform1i(location(), value);
+	});
 }
 
-void Shader::set_uniform(const GLchar *name, GLint value)
+void Shader::set_uniform(const std::string &name, GLuint value)
 {
-	glUniform1i(location_for_bound_uniform(name), value);
+	enqueue_function([name, value, this] {
+		glUniform1ui(location(), value);
+	});
 }
 
-void Shader::set_uniform(const GLchar *name, GLint value1, GLint value2)
+void Shader::set_uniform(const std::string &name, GLfloat value)
 {
-	glUniform2i(location_for_bound_uniform(name), value1, value2);
+	enqueue_function([name, value, this] {
+		glUniform1f(location(), value);
+	});
 }
 
-void Shader::set_uniform(const GLchar *name, GLint value1, GLint value2, GLint value3)
+
+void Shader::set_uniform(const std::string &name, GLint value1, GLint value2)
 {
-	glUniform3i(location_for_bound_uniform(name), value1, value2, value3);
+	enqueue_function([name, value1, value2, this] {
+		glUniform2i(location(), value1, value2);
+	});
 }
 
-void Shader::set_uniform(const GLchar *name, GLint value1, GLint value2, GLint value3, GLint value4)
+void Shader::set_uniform(const std::string &name, GLfloat value1, GLfloat value2)
 {
-	glUniform4i(location_for_bound_uniform(name), value1, value2, value3, value4);
+	enqueue_function([name, value1, value2, this] {
+		glUniform2f(location(), value1, value2);
+	});
 }
 
-void Shader::set_uniform(const GLchar *name, GLint size, GLsizei count, const GLint *values)
+void Shader::set_uniform(const std::string &name, GLuint value1, GLuint value2)
 {
-	switch(size)
-	{
-		case 1: glUniform1iv(location_for_bound_uniform(name), count, values);	break;
-		case 2: glUniform2iv(location_for_bound_uniform(name), count, values);	break;
-		case 3: glUniform3iv(location_for_bound_uniform(name), count, values);	break;
-		case 4: glUniform4iv(location_for_bound_uniform(name), count, values);	break;
-	}
+	enqueue_function([name, value1, value2, this] {
+		glUniform2ui(location(), value1, value2);
+	});
 }
 
-void Shader::set_uniform(const GLchar *name, GLfloat value)
+
+void Shader::set_uniform(const std::string &name, GLint value1, GLint value2, GLint value3)
 {
-	glUniform1f(location_for_bound_uniform(name), value);
+	enqueue_function([name, value1, value2, value3, this] {
+		glUniform3i(location(), value1, value2, value3);
+	});
 }
 
-void Shader::set_uniform(const GLchar *name, GLfloat value1, GLfloat value2)
+void Shader::set_uniform(const std::string &name, GLfloat value1, GLfloat value2, GLfloat value3)
 {
-	glUniform2f(location_for_bound_uniform(name), value1, value2);
+	enqueue_function([name, value1, value2, value3, this] {
+		glUniform3f(location(), value1, value2, value3);
+	});
 }
 
-void Shader::set_uniform(const GLchar *name, GLfloat value1, GLfloat value2, GLfloat value3)
+void Shader::set_uniform(const std::string &name, GLuint value1, GLuint value2, GLuint value3)
 {
-	glUniform3f(location_for_bound_uniform(name), value1, value2, value3);
+	enqueue_function([name, value1, value2, value3, this] {
+		glUniform3ui(location(), value1, value2, value3);
+	});
 }
 
-void Shader::set_uniform(const GLchar *name, GLfloat value1, GLfloat value2, GLfloat value3, GLfloat value4)
+
+void Shader::set_uniform(const std::string &name, GLint value1, GLint value2, GLint value3, GLint value4)
 {
-	glUniform4f(location_for_bound_uniform(name), value1, value2, value3, value4);
+	enqueue_function([name, value1, value2, value3, value4, this] {
+		glUniform4i(location(), value1, value2, value3, value4);
+	});
 }
 
-void Shader::set_uniform(const GLchar *name, GLint size, GLsizei count, const GLfloat *values)
+void Shader::set_uniform(const std::string &name, GLfloat value1, GLfloat value2, GLfloat value3, GLfloat value4)
 {
-	switch(size)
-	{
-		case 1: glUniform1fv(location_for_bound_uniform(name), count, values);	break;
-		case 2: glUniform2fv(location_for_bound_uniform(name), count, values);	break;
-		case 3: glUniform3fv(location_for_bound_uniform(name), count, values);	break;
-		case 4: glUniform4fv(location_for_bound_uniform(name), count, values);	break;
-	}
+	enqueue_function([name, value1, value2, value3, value4, this] {
+		glUniform4f(location(), value1, value2, value3, value4);
+	});
 }
 
-void Shader::set_uniform(const GLchar *name, GLuint value)
+void Shader::set_uniform(const std::string &name, GLuint value1, GLuint value2, GLuint value3, GLuint value4)
 {
-	glUniform1ui(location_for_bound_uniform(name), value);
+	enqueue_function([name, value1, value2, value3, value4, this] {
+		glUniform4ui(location(), value1, value2, value3, value4);
+	});
 }
 
-void Shader::set_uniform(const GLchar *name, GLuint value1, GLuint value2)
+
+void Shader::set_uniform(const std::string &name, GLint size, GLsizei count, const GLint *values)
 {
-	glUniform2ui(location_for_bound_uniform(name), value1, value2);
+	enqueue_function([name, size, count, values, this] {
+		switch(size)
+		{
+			case 1: glUniform1iv(location(), count, values);	break;
+			case 2: glUniform2iv(location(), count, values);	break;
+			case 3: glUniform3iv(location(), count, values);	break;
+			case 4: glUniform4iv(location(), count, values);	break;
+		}
+	});
 }
 
-void Shader::set_uniform(const GLchar *name, GLuint value1, GLuint value2, GLuint value3)
+void Shader::set_uniform(const std::string &name, GLint size, GLsizei count, const GLfloat *values)
 {
-	glUniform3ui(location_for_bound_uniform(name), value1, value2, value3);
+	enqueue_function([name, size, count, values, this] {
+		switch(size)
+		{
+			case 1: glUniform1fv(location(), count, values);	break;
+			case 2: glUniform2fv(location(), count, values);	break;
+			case 3: glUniform3fv(location(), count, values);	break;
+			case 4: glUniform4fv(location(), count, values);	break;
+		}
+	});
 }
 
-void Shader::set_uniform(const GLchar *name, GLuint value1, GLuint value2, GLuint value3, GLuint value4)
+void Shader::set_uniform(const std::string &name, GLint size, GLsizei count, const GLuint *values)
 {
-	glUniform4ui(location_for_bound_uniform(name), value1, value2, value3, value4);
+	enqueue_function([name, size, count, values, this] {
+		switch(size)
+		{
+			case 1: glUniform1uiv(location(), count, values);	break;
+			case 2: glUniform2uiv(location(), count, values);	break;
+			case 3: glUniform3uiv(location(), count, values);	break;
+			case 4: glUniform4uiv(location(), count, values);	break;
+		}
+	});
 }
 
-void Shader::set_uniform(const GLchar *name, GLint size, GLsizei count, const GLuint *values)
-{
-	switch(size)
-	{
-		case 1: glUniform1uiv(location_for_bound_uniform(name), count, values);	break;
-		case 2: glUniform2uiv(location_for_bound_uniform(name), count, values);	break;
-		case 3: glUniform3uiv(location_for_bound_uniform(name), count, values);	break;
-		case 4: glUniform4uiv(location_for_bound_uniform(name), count, values);	break;
-	}
-}
-
-void Shader::set_uniform_matrix(const GLchar *name, GLint size, bool transpose, const GLfloat *values)
+void Shader::set_uniform_matrix(const std::string &name, GLint size, bool transpose, const GLfloat *values)
 {
 	set_uniform_matrix(name, size, 1, transpose, values);
 }
 
-void Shader::set_uniform_matrix(const GLchar *name, GLint size, GLsizei count, bool transpose, const GLfloat *values)
+void Shader::set_uniform_matrix(const std::string &name, GLint size, GLsizei count, bool transpose, const GLfloat *values)
 {
+	enqueue_function([name, size, count, transpose, values, this] {
 	GLboolean glTranspose = transpose ? GL_TRUE : GL_FALSE;
-	switch(size)
+		switch(size)
+		{
+			case 2: glUniformMatrix2fv(location(), count, glTranspose, values);	break;
+			case 3: glUniformMatrix3fv(location(), count, glTranspose, values);	break;
+			case 4: glUniformMatrix4fv(location(), count, glTranspose, values);	break;
+		}
+	});
+}
+
+void Shader::enqueue_function(std::function<void(void)> function)
+{
+	_enqueued_functions.push_back(function);
+}
+
+void Shader::flush_functions()
+{
+	for(std::function<void(void)> function : _enqueued_functions)
 	{
-		case 2: glUniformMatrix2fv(location_for_bound_uniform(name), count, glTranspose, values);	break;
-		case 3: glUniformMatrix3fv(location_for_bound_uniform(name), count, glTranspose, values);	break;
-		case 4: glUniformMatrix4fv(location_for_bound_uniform(name), count, glTranspose, values);	break;
+		function();
 	}
+	_enqueued_functions.clear();
 }

--- a/Outputs/CRT/Internals/Shaders/Shader.cpp
+++ b/Outputs/CRT/Internals/Shaders/Shader.cpp
@@ -291,14 +291,18 @@ void Shader::set_uniform_matrix(const std::string &name, GLint size, GLsizei cou
 
 void Shader::enqueue_function(std::function<void(void)> function)
 {
+	_function_mutex.lock();
 	_enqueued_functions.push_back(function);
+	_function_mutex.unlock();
 }
 
 void Shader::flush_functions()
 {
+	_function_mutex.lock();
 	for(std::function<void(void)> function : _enqueued_functions)
 	{
 		function();
 	}
 	_enqueued_functions.clear();
+	_function_mutex.unlock();
 }

--- a/Outputs/CRT/Internals/Shaders/Shader.hpp
+++ b/Outputs/CRT/Internals/Shaders/Shader.hpp
@@ -47,6 +47,8 @@ public:
 		Performs an @c glUseProgram to make this the active shader unless:
 			(i) it was the previous shader bound; and 
 			(ii) no calls have been received to unbind in the interim.
+
+		Subsequently performs all work queued up for the next bind irrespective of whether a @c glUseProgram call occurred.
 	*/
 	void bind();
 
@@ -106,9 +108,11 @@ private:
 	GLuint compile_shader(const char *source, GLenum type);
 	GLuint _shader_program;
 
-	void enqueue_function(std::function<void(void)> function);
 	void flush_functions();
 	std::list<std::function<void(void)>> _enqueued_functions;
+
+protected:
+	void enqueue_function(std::function<void(void)> function);
 };
 
 }

--- a/Outputs/CRT/Internals/Shaders/Shader.hpp
+++ b/Outputs/CRT/Internals/Shaders/Shader.hpp
@@ -75,9 +75,35 @@ public:
 	*/
 	void enable_vertex_attribute_with_pointer(const char *name, GLint size, GLenum type, GLboolean normalised, GLsizei stride, const GLvoid *pointer, GLuint divisor);
 
+	/*!
+		All @c set_uniforms bind the current shader, look up the uniform by name and set the supplied value or values.
+	*/
+	void set_uniform(const GLchar *name, GLint value);
+	void set_uniform(const GLchar *name, GLint value1, GLint value2);
+	void set_uniform(const GLchar *name, GLint value1, GLint value2, GLint value3);
+	void set_uniform(const GLchar *name, GLint value1, GLint value2, GLint value3, GLint value4);
+	void set_uniform(const GLchar *name, GLint size, GLsizei count, const GLint *values);
+
+	void set_uniform(const GLchar *name, GLfloat value);
+	void set_uniform(const GLchar *name, GLfloat value1, GLfloat value2);
+	void set_uniform(const GLchar *name, GLfloat value1, GLfloat value2, GLfloat value3);
+	void set_uniform(const GLchar *name, GLfloat value1, GLfloat value2, GLfloat value3, GLfloat value4);
+	void set_uniform(const GLchar *name, GLint size, GLsizei count, const GLfloat *values);
+
+	void set_uniform(const GLchar *name, GLuint value);
+	void set_uniform(const GLchar *name, GLuint value1, GLuint value2);
+	void set_uniform(const GLchar *name, GLuint value1, GLuint value2, GLuint value3);
+	void set_uniform(const GLchar *name, GLuint value1, GLuint value2, GLuint value3, GLuint value4);
+	void set_uniform(const GLchar *name, GLint size, GLsizei count, const GLuint *values);
+
+	void set_uniform_matrix(const GLchar *name, GLint size, bool transpose, const GLfloat *values);
+	void set_uniform_matrix(const GLchar *name, GLint size, GLsizei count, bool transpose, const GLfloat *values);
+
 private:
 	GLuint compile_shader(const char *source, GLenum type);
 	GLuint _shader_program;
+
+	GLint location_for_bound_uniform(const GLchar *name);
 };
 
 }

--- a/Outputs/CRT/Internals/Shaders/Shader.hpp
+++ b/Outputs/CRT/Internals/Shaders/Shader.hpp
@@ -10,6 +10,9 @@
 #define Shader_hpp
 
 #include "OpenGL.hpp"
+#include <string>
+#include <functional>
+#include <list>
 
 namespace OpenGL {
 
@@ -76,34 +79,36 @@ public:
 	void enable_vertex_attribute_with_pointer(const char *name, GLint size, GLenum type, GLboolean normalised, GLsizei stride, const GLvoid *pointer, GLuint divisor);
 
 	/*!
-		All @c set_uniforms bind the current shader, look up the uniform by name and set the supplied value or values.
+		All @c set_uniforms queue up the requested uniform changes. Changes are applied automatically the next time the shader is bound.
 	*/
-	void set_uniform(const GLchar *name, GLint value);
-	void set_uniform(const GLchar *name, GLint value1, GLint value2);
-	void set_uniform(const GLchar *name, GLint value1, GLint value2, GLint value3);
-	void set_uniform(const GLchar *name, GLint value1, GLint value2, GLint value3, GLint value4);
-	void set_uniform(const GLchar *name, GLint size, GLsizei count, const GLint *values);
+	void set_uniform(const std::string &name, GLint value);
+	void set_uniform(const std::string &name, GLint value1, GLint value2);
+	void set_uniform(const std::string &name, GLint value1, GLint value2, GLint value3);
+	void set_uniform(const std::string &name, GLint value1, GLint value2, GLint value3, GLint value4);
+	void set_uniform(const std::string &name, GLint size, GLsizei count, const GLint *values);
 
-	void set_uniform(const GLchar *name, GLfloat value);
-	void set_uniform(const GLchar *name, GLfloat value1, GLfloat value2);
-	void set_uniform(const GLchar *name, GLfloat value1, GLfloat value2, GLfloat value3);
-	void set_uniform(const GLchar *name, GLfloat value1, GLfloat value2, GLfloat value3, GLfloat value4);
-	void set_uniform(const GLchar *name, GLint size, GLsizei count, const GLfloat *values);
+	void set_uniform(const std::string &name, GLfloat value);
+	void set_uniform(const std::string &name, GLfloat value1, GLfloat value2);
+	void set_uniform(const std::string &name, GLfloat value1, GLfloat value2, GLfloat value3);
+	void set_uniform(const std::string &name, GLfloat value1, GLfloat value2, GLfloat value3, GLfloat value4);
+	void set_uniform(const std::string &name, GLint size, GLsizei count, const GLfloat *values);
 
-	void set_uniform(const GLchar *name, GLuint value);
-	void set_uniform(const GLchar *name, GLuint value1, GLuint value2);
-	void set_uniform(const GLchar *name, GLuint value1, GLuint value2, GLuint value3);
-	void set_uniform(const GLchar *name, GLuint value1, GLuint value2, GLuint value3, GLuint value4);
-	void set_uniform(const GLchar *name, GLint size, GLsizei count, const GLuint *values);
+	void set_uniform(const std::string &name, GLuint value);
+	void set_uniform(const std::string &name, GLuint value1, GLuint value2);
+	void set_uniform(const std::string &name, GLuint value1, GLuint value2, GLuint value3);
+	void set_uniform(const std::string &name, GLuint value1, GLuint value2, GLuint value3, GLuint value4);
+	void set_uniform(const std::string &name, GLint size, GLsizei count, const GLuint *values);
 
-	void set_uniform_matrix(const GLchar *name, GLint size, bool transpose, const GLfloat *values);
-	void set_uniform_matrix(const GLchar *name, GLint size, GLsizei count, bool transpose, const GLfloat *values);
+	void set_uniform_matrix(const std::string &name, GLint size, bool transpose, const GLfloat *values);
+	void set_uniform_matrix(const std::string &name, GLint size, GLsizei count, bool transpose, const GLfloat *values);
 
 private:
 	GLuint compile_shader(const char *source, GLenum type);
 	GLuint _shader_program;
 
-	GLint location_for_bound_uniform(const GLchar *name);
+	void enqueue_function(std::function<void(void)> function);
+	void flush_functions();
+	std::list<std::function<void(void)>> _enqueued_functions;
 };
 
 }

--- a/Outputs/CRT/Internals/Shaders/Shader.hpp
+++ b/Outputs/CRT/Internals/Shaders/Shader.hpp
@@ -13,6 +13,7 @@
 #include <string>
 #include <functional>
 #include <list>
+#include <mutex>
 
 namespace OpenGL {
 
@@ -110,6 +111,7 @@ private:
 
 	void flush_functions();
 	std::list<std::function<void(void)>> _enqueued_functions;
+	std::mutex _function_mutex;
 
 protected:
 	void enqueue_function(std::function<void(void)> function);


### PR DESCRIPTION
Changes are queued within `Shader` and take place only after the next time the shader is bound. This means that:
* changing uniforms no longer affects the current shader bounding;
* it is more likely that good OpenGL batching will occur; and
* whomever calls `bind` is now the only person that need be able to guarantee that the appropriate OpenGL context is available. So uniforms become safe to set from machine emulation code