### PR TITLE
Completes the loop on machines changing clock rate dynamically

### DIFF
--- a/Machines/Atari2600/Atari2600.cpp
+++ b/Machines/Atari2600/Atari2600.cpp
@@ -58,6 +58,7 @@ Machine::Machine() :
 void Machine::setup_output(float aspect_ratio)
 {
 	_crt = new Outputs::CRT::CRT(228, 1, 263, Outputs::CRT::ColourSpace::YIQ, 228, 1, 1);
+	_crt->set_output_device(Outputs::CRT::Television);
 
 	// this is the NTSC phase offset function; see below for PAL
 	_crt->set_composite_sampling_function(
@@ -70,8 +71,6 @@ void Machine::setup_output(float aspect_ratio)
 			"float phaseOffset = 6.283185308 * float(iPhase - 1u) / 13.0;"
 			"return mix(float(y) / 14.0, step(1, iPhase) * cos(phase + phaseOffset), amplitude);"
 		"}");
-	_crt->set_output_device(Outputs::CRT::Television);
-
 	_speaker.set_input_rate((float)(get_clock_rate() / 38.0));
 }
 
@@ -90,10 +89,13 @@ void Machine::switch_region()
 			"phaseOffset *= 6.283185308 / 12.0;"
 			"return mix(float(y) / 14.0, step(4, (iPhase + 2u) & 15u) * cos(phase + phaseOffset), amplitude);"
 		"}");
+
 	_crt->set_new_timing(228, 312, Outputs::CRT::ColourSpace::YUV, 228, 1);
+
 	_is_pal_region = true;
-	if(delegate) delegate->machine_did_change_clock_rate(this);
 	_speaker.set_input_rate((float)(get_clock_rate() / 38.0));
+
+	if(delegate) delegate->machine_did_change_clock_rate(this);
 }
 
 void Machine::close_output()

--- a/Machines/Atari2600/Atari2600.hpp
+++ b/Machines/Atari2600/Atari2600.hpp
@@ -95,7 +95,7 @@ class Machine: public CPU6502::Processor<Machine>, public CRTMachine::Machine {
 		virtual Outputs::CRT::CRT *get_crt() { return _crt; }
 		virtual Outputs::Speaker *get_speaker() { return &_speaker; }
 		virtual void run_for_cycles(int number_of_cycles) { CPU6502::Processor<Machine>::run_for_cycles(number_of_cycles); }
-		virtual double get_clock_rate() { return 1194720; }
+		virtual double get_clock_rate();
 		// TODO: different rate for PAL
 
 	private:
@@ -199,6 +199,9 @@ class Machine: public CPU6502::Processor<Machine>, public CRTMachine::Machine {
 		// outputs
 		Outputs::CRT::CRT *_crt;
 		Speaker _speaker;
+
+		// current mode
+		bool _is_pal_region;
 
 		// speaker backlog accumlation counter
 		unsigned int _cycles_since_speaker_update;

--- a/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
+++ b/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
@@ -12,6 +12,7 @@ import AudioToolbox
 class MachineDocument:
 	NSDocument,
 	NSWindowDelegate,
+	CSMachineDelegate,
 	CSOpenGLViewDelegate,
 	CSOpenGLViewResponderDelegate,
 	CSBestEffortUpdaterDelegate,
@@ -56,6 +57,14 @@ class MachineDocument:
 			self.machine().setView(self.openGLView, aspectRatio: Float(displayAspectRatio.width / displayAspectRatio.height))
 		})
 
+		setupClockRate()
+	}
+
+	func machineDidChangeClockRate(machine: CSMachine!) {
+		setupClockRate()
+	}
+
+	private func setupClockRate() {
 		// establish and provide the audio queue, taking advice as to an appropriate sampling rate
 		let maximumSamplingRate = CSAudioQueue.preferredSamplingRate()
 		let selectedSamplingRate = self.machine().idealSamplingRateFromRange(NSRange(location: 0, length: NSInteger(maximumSamplingRate)))

--- a/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
+++ b/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
@@ -58,6 +58,7 @@ class MachineDocument:
 		})
 
 		setupClockRate()
+		self.machine().delegate = self
 	}
 
 	func machineDidChangeClockRate(machine: CSMachine!) {


### PR DESCRIPTION
Which is used specifically so that the 2600 now implements its different PAL and NTSC operation frequencies.

... it's lucky the sound code was generalised to accept non-integral input and output rates.