### PR TITLE
Adds a small amount of test coverage to the functioning of 6502 interrupts

### DIFF
--- a/Components/6560/6560.cpp
+++ b/Components/6560/6560.cpp
@@ -69,7 +69,7 @@ void MOS6560::set_output_mode(OutputMode output_mode)
 			chrominances = ntsc_chrominances;
 			display_type = Outputs::CRT::NTSC60;
 			_timing.cycles_per_line = 65;
-			_timing.line_counter_increment_offset = 65 - 36;	// TODO: 36 is from memory; need to look up.
+			_timing.line_counter_increment_offset = 65 - 33;	// TODO: this is a bit of a hack; separate vertical and horizontal counting
 			_timing.lines_per_progressive_field = 261;
 			_timing.supports_interlacing = true;
 		break;

--- a/Machines/Atari2600/Atari2600.cpp
+++ b/Machines/Atari2600/Atari2600.cpp
@@ -28,7 +28,6 @@ Machine::Machine() :
 	_is_pal_region(false)
 {
 	memset(_collisions, 0xff, sizeof(_collisions));
-	set_reset_line(true);
 	setup_reported_collisions();
 
 	for(int vbextend = 0; vbextend < 2; vbextend++)
@@ -414,8 +413,6 @@ void Machine::output_pixels(unsigned int count)
 
 unsigned int Machine::perform_bus_operation(CPU6502::BusOperation operation, uint16_t address, uint8_t *value)
 {
-	set_reset_line(false);
-
 	uint8_t returnValue = 0xff;
 	unsigned int cycles_run_for = 3;
 

--- a/Machines/Electron/Electron.cpp
+++ b/Machines/Electron/Electron.cpp
@@ -55,7 +55,6 @@ Machine::Machine() :
 		memset(_roms[c], 0xff, 16384);
 
 	_tape.set_delegate(this);
-	set_reset_line(true);
 }
 
 void Machine::setup_output(float aspect_ratio)
@@ -86,7 +85,6 @@ void Machine::close_output()
 unsigned int Machine::perform_bus_operation(CPU6502::BusOperation operation, uint16_t address, uint8_t *value)
 {
 	unsigned int cycles = 1;
-	set_reset_line(false);
 
 	if(address < 0x8000)
 	{

--- a/Machines/Vic-20/Vic20.cpp
+++ b/Machines/Vic-20/Vic20.cpp
@@ -18,7 +18,6 @@ Machine::Machine() :
 	_userPortVIA.set_delegate(this);
 	_keyboardVIA.set_delegate(this);
 	_tape.set_delegate(this);
-	set_reset_line(true);
 }
 
 Machine::~Machine()
@@ -28,8 +27,6 @@ Machine::~Machine()
 
 unsigned int Machine::perform_bus_operation(CPU6502::BusOperation operation, uint16_t address, uint8_t *value)
 {
-	set_reset_line(false);
-
 	// test for PC at F92F
 	if(_use_fast_tape_hack && address == 0xf92f && operation == CPU6502::BusOperation::ReadOpcode)
 	{

--- a/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
@@ -35,7 +35,7 @@
 		4B73C71A1D036BD90074D992 /* Vic20Document.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B73C7191D036BD90074D992 /* Vic20Document.swift */; };
 		4B73C71D1D036C030074D992 /* Vic20Document.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4B73C71B1D036C030074D992 /* Vic20Document.xib */; };
 		4B886FF21D03B517004291C3 /* Vic20.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B886FF01D03B517004291C3 /* Vic20.cpp */; };
-		4B92EACA1B7C112B00246143 /* TimingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B92EAC91B7C112B00246143 /* TimingTests.swift */; };
+		4B92EACA1B7C112B00246143 /* 6502TimingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B92EAC91B7C112B00246143 /* 6502TimingTests.swift */; };
 		4BB298EE1B587D8400A49093 /* 6502_functional_test.bin in Resources */ = {isa = PBXBuildFile; fileRef = 4BB297E01B587D8300A49093 /* 6502_functional_test.bin */; };
 		4BB298EF1B587D8400A49093 /* AllSuiteA.bin in Resources */ = {isa = PBXBuildFile; fileRef = 4BB297E11B587D8300A49093 /* AllSuiteA.bin */; };
 		4BB298F01B587D8400A49093 /* TestMachine.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4BB297E31B587D8300A49093 /* TestMachine.mm */; };
@@ -323,6 +323,7 @@
 		4BC91B831D1F160E00884B76 /* CommodoreTAP.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4BC91B811D1F160E00884B76 /* CommodoreTAP.cpp */; };
 		4BC9DF451D044FCA00F44158 /* ROMImages in Resources */ = {isa = PBXBuildFile; fileRef = 4BC9DF441D044FCA00F44158 /* ROMImages */; };
 		4BC9DF4F1D04691600F44158 /* 6560.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4BC9DF4D1D04691600F44158 /* 6560.cpp */; };
+		4BC9E1EE1D23449A003FCEE4 /* 6502InterruptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BC9E1ED1D23449A003FCEE4 /* 6502InterruptTests.swift */; };
 		4BD5F1951D13528900631CD1 /* CSBestEffortUpdater.m in Sources */ = {isa = PBXBuildFile; fileRef = 4BD5F1941D13528900631CD1 /* CSBestEffortUpdater.m */; };
 /* End PBXBuildFile section */
 
@@ -397,7 +398,7 @@
 		4B73C71C1D036C030074D992 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = "Clock Signal/Base.lproj/Vic20Document.xib"; sourceTree = SOURCE_ROOT; };
 		4B886FF01D03B517004291C3 /* Vic20.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Vic20.cpp; path = "Vic-20/Vic20.cpp"; sourceTree = "<group>"; };
 		4B886FF11D03B517004291C3 /* Vic20.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = Vic20.hpp; path = "Vic-20/Vic20.hpp"; sourceTree = "<group>"; };
-		4B92EAC91B7C112B00246143 /* TimingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimingTests.swift; sourceTree = "<group>"; };
+		4B92EAC91B7C112B00246143 /* 6502TimingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = 6502TimingTests.swift; sourceTree = "<group>"; };
 		4BB297DF1B587D8200A49093 /* Clock SignalTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Clock SignalTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		4BB297E01B587D8300A49093 /* 6502_functional_test.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; path = 6502_functional_test.bin; sourceTree = "<group>"; };
 		4BB297E11B587D8300A49093 /* AllSuiteA.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; path = AllSuiteA.bin; sourceTree = "<group>"; };
@@ -708,6 +709,7 @@
 		4BC9DF441D044FCA00F44158 /* ROMImages */ = {isa = PBXFileReference; lastKnownFileType = folder; name = ROMImages; path = ../../../../ROMImages; sourceTree = "<group>"; };
 		4BC9DF4D1D04691600F44158 /* 6560.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = 6560.cpp; sourceTree = "<group>"; };
 		4BC9DF4E1D04691600F44158 /* 6560.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = 6560.hpp; sourceTree = "<group>"; };
+		4BC9E1ED1D23449A003FCEE4 /* 6502InterruptTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = 6502InterruptTests.swift; sourceTree = "<group>"; };
 		4BCA98C21D065CA20062F44C /* 6522.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = 6522.hpp; sourceTree = "<group>"; };
 		4BD5F1931D13528900631CD1 /* CSBestEffortUpdater.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CSBestEffortUpdater.h; path = Updater/CSBestEffortUpdater.h; sourceTree = "<group>"; };
 		4BD5F1941D13528900631CD1 /* CSBestEffortUpdater.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CSBestEffortUpdater.m; path = Updater/CSBestEffortUpdater.m; sourceTree = "<group>"; };
@@ -1253,9 +1255,10 @@
 				4B1E85801D176468001EF87D /* 6532Tests.swift */,
 				4BB73EB61B587A5100552FC2 /* AllSuiteATests.swift */,
 				4B1414611B58888700E04248 /* KlausDormannTests.swift */,
-				4B92EAC91B7C112B00246143 /* TimingTests.swift */,
+				4B92EAC91B7C112B00246143 /* 6502TimingTests.swift */,
 				4B14145F1B58885000E04248 /* WolfgangLorenzTests.swift */,
 				4B1414631B588A1100E04248 /* Test Binaries */,
+				4BC9E1ED1D23449A003FCEE4 /* 6502InterruptTests.swift */,
 			);
 			path = "Clock SignalTests";
 			sourceTree = "<group>";
@@ -1814,7 +1817,8 @@
 				4B14145E1B5887AA00E04248 /* CPU6502AllRAM.cpp in Sources */,
 				4B14145D1B5887A600E04248 /* CPU6502.cpp in Sources */,
 				4B1E85811D176468001EF87D /* 6532Tests.swift in Sources */,
-				4B92EACA1B7C112B00246143 /* TimingTests.swift in Sources */,
+				4BC9E1EE1D23449A003FCEE4 /* 6502InterruptTests.swift in Sources */,
+				4B92EACA1B7C112B00246143 /* 6502TimingTests.swift in Sources */,
 				4BB73EB71B587A5100552FC2 /* AllSuiteATests.swift in Sources */,
 				4BC751B21D157E61006C31D9 /* 6522Tests.swift in Sources */,
 				4B1414621B58888700E04248 /* KlausDormannTests.swift in Sources */,

--- a/OSBindings/Mac/Clock SignalTests/6502InterruptTests.swift
+++ b/OSBindings/Mac/Clock SignalTests/6502InterruptTests.swift
@@ -1,0 +1,48 @@
+//
+//  6502InterruptTests.swift
+//  Clock Signal
+//
+//  Created by Thomas Harte on 28/06/2016.
+//  Copyright © 2016 Thomas Harte. All rights reserved.
+//
+
+import XCTest
+
+class MOS6502InterruptTests: XCTestCase {
+
+	var machine: CSTestMachine! = nil
+	override func setUp() {
+		super.setUp()
+
+		// create a machine full of NOPs
+		machine = CSTestMachine()
+		for c in 0...65535 {
+			machine.setValue(0xea, forAddress: UInt16(c))
+		}
+
+		// set the IRQ vector to be 0x1234
+		machine.setValue(0x34, forAddress: 0xfffe)
+		machine.setValue(0x12, forAddress: 0xffff)
+
+		// add a CLI
+		machine.setValue(0x58, forAddress: 0x4000)
+
+		// pick things off at 0x4000
+		machine.setValue(0x4000, forRegister: CSTestMachineRegister.ProgramCounter)
+	}
+
+    func testIRQLine() {
+		// run for four cycles; check that no interrupt has occurred
+		machine.runForNumberOfCycles(6)
+		XCTAssert(machine.valueForRegister(.ProgramCounter) == 0x4003, "No interrupt should have occurred with line low")
+
+		// enable the interrupt line, check that it was too late
+		machine.irqLine = true
+		machine.runForNumberOfCycles(2)
+		XCTAssert(machine.valueForRegister(.ProgramCounter) == 0x4004, "No interrupt should have occurred from interrupt raised between instructions")
+
+		// run for a further 7 cycles, confirm that the IRQ vector was jumped to
+		machine.runForNumberOfCycles(7)
+		XCTAssert(machine.valueForRegister(.ProgramCounter) == 0x1234, "Interrupt routine should just have begun")
+    }
+}

--- a/OSBindings/Mac/Clock SignalTests/6502TimingTests.swift
+++ b/OSBindings/Mac/Clock SignalTests/6502TimingTests.swift
@@ -9,7 +9,7 @@
 import Foundation
 import XCTest
 
-class TimingTests: XCTestCase, CSTestMachineJamHandler {
+class MOS6502TimingTests: XCTestCase, CSTestMachineJamHandler {
 
 	private var endTime: UInt32 = 0
 

--- a/OSBindings/Mac/Clock SignalTests/KlausDormannTests.swift
+++ b/OSBindings/Mac/Clock SignalTests/KlausDormannTests.swift
@@ -47,6 +47,7 @@ class KlausDormannTests: XCTestCase {
 					if newPC == oldPC {
 						let error = errorForTrapAddress(oldPC)
 						XCTAssert(error == nil, "Failed with error \(error)")
+						return
 					}
 				}
 			}

--- a/OSBindings/Mac/Clock SignalTests/KlausDormannTests.swift
+++ b/OSBindings/Mac/Clock SignalTests/KlausDormannTests.swift
@@ -46,12 +46,7 @@ class KlausDormannTests: XCTestCase {
 
 					if newPC == oldPC {
 						let error = errorForTrapAddress(oldPC)
-
-						if let error = error {
-							NSException(name: "Failed test", reason: error, userInfo: nil).raise()
-						} else {
-							return
-						}
+						XCTAssert(error == nil, "Failed with error \(error)")
 					}
 				}
 			}

--- a/OSBindings/Mac/Clock SignalTests/TestMachine.h
+++ b/OSBindings/Mac/Clock SignalTests/TestMachine.h
@@ -41,5 +41,7 @@ extern const uint8_t CSTestMachineJamOpcode;
 @property (nonatomic, readonly) BOOL isJammed;
 @property (nonatomic, readonly) uint32_t timestamp;
 @property (nonatomic, weak) id <CSTestMachineJamHandler> jamHandler;
+@property (nonatomic, assign) BOOL irqLine;
+@property (nonatomic, assign) BOOL nmiLine;
 
 @end

--- a/OSBindings/Mac/Clock SignalTests/TestMachine.mm
+++ b/OSBindings/Mac/Clock SignalTests/TestMachine.mm
@@ -99,4 +99,14 @@ class MachineJamHandler: public CPU6502::AllRAMProcessor::JamHandler {
 	return _processor.get_timestamp();
 }
 
+- (void)setIrqLine:(BOOL)irqLine {
+	_irqLine = irqLine;
+	_processor.set_irq_line(irqLine);
+}
+
+- (void)setNmiLine:(BOOL)nmiLine {
+	_nmiLine = nmiLine;
+	_processor.set_nmi_line(nmiLine);
+}
+
 @end

--- a/Processors/6502/CPU6502.hpp
+++ b/Processors/6502/CPU6502.hpp
@@ -493,6 +493,8 @@ template <class T> class Processor {
 		*/
 		inline const MicroOp *get_irq_program() {
 			static const MicroOp reset[] = {
+				CycleFetchOperand,
+				CycleFetchOperand,
 				CyclePushPCH,
 				CyclePushPCL,
 				OperationSetOperandFromFlags,
@@ -511,6 +513,8 @@ template <class T> class Processor {
 		*/
 		inline const MicroOp *get_nmi_program() {
 			static const MicroOp reset[] = {
+				CycleFetchOperand,
+				CycleFetchOperand,
 				CyclePushPCH,
 				CyclePushPCL,
 				OperationSetOperandFromFlags,

--- a/Processors/6502/CPU6502.hpp
+++ b/Processors/6502/CPU6502.hpp
@@ -95,6 +95,7 @@ template <class T> class Processor {
 			CycleSetIReadBRKLow,						CycleReadBRKHigh,
 			CycleReadFromS,								CycleReadFromPC,
 			CyclePullOperand,							CyclePullPCL,						CyclePullPCH,							CyclePullA,
+			CycleNoWritePush,
 			CycleReadAndIncrementPC,					CycleIncrementPCAndReadStack,		CycleIncrementPCReadPCHLoadPCL,			CycleReadPCHLoadPCL,
 			CycleReadAddressHLoadAddressL,				CycleReadPCLFromAddress,			CycleReadPCHFromAddress,				CycleLoadAddressAbsolute,
 			OperationLoadAddressZeroPage,				CycleLoadAddessZeroX,				CycleLoadAddessZeroY,					CycleAddXToAddressLow,
@@ -478,9 +479,9 @@ template <class T> class Processor {
 			static const MicroOp reset[] = {
 				CycleFetchOperand,
 				CycleFetchOperand,
-				CyclePullOperand,
-				CyclePullOperand,
-				CyclePullOperand,
+				CycleNoWritePush,
+				CycleNoWritePush,
+				CycleNoWritePush,
 				CycleReadRSTLow,
 				CycleReadRSTHigh,
 				OperationMoveToNextProgram
@@ -680,6 +681,12 @@ template <class T> class Processor {
 						case CyclePushPCL:					push(_pc.bytes.low);											break;
 						case CyclePushOperand:				push(_operand);													break;
 						case CyclePushA:					push(_a);														break;
+						case CycleNoWritePush:
+						{
+							uint16_t targetAddress = _s | 0x100; _s--;
+							read_mem(_operand, targetAddress);
+						}
+						break;
 
 #undef push
 

--- a/Processors/6502/CPU6502AllRAM.cpp
+++ b/Processors/6502/CPU6502AllRAM.cpp
@@ -12,11 +12,13 @@
 
 using namespace CPU6502;
 
-AllRAMProcessor::AllRAMProcessor() : _timestamp(0) {}
+AllRAMProcessor::AllRAMProcessor() : _timestamp(0)
+{
+	set_power_on(false);
+}
 
 int AllRAMProcessor::perform_bus_operation(CPU6502::BusOperation operation, uint16_t address, uint8_t *value)
 {
-	set_power_on(false);
 	_timestamp++;
 
 	if(isReadOperation(operation)) {

--- a/Processors/6502/CPU6502AllRAM.cpp
+++ b/Processors/6502/CPU6502AllRAM.cpp
@@ -16,6 +16,7 @@ AllRAMProcessor::AllRAMProcessor() : _timestamp(0) {}
 
 int AllRAMProcessor::perform_bus_operation(CPU6502::BusOperation operation, uint16_t address, uint8_t *value)
 {
+	set_power_on(false);
 	_timestamp++;
 
 	if(isReadOperation(operation)) {


### PR DESCRIPTION
Simultaneously:
* makes per-operation decision slightly cheaper;
* extends IRQ and NMI to their proper lengths;
* adds a more convenient way for machines to cause a power-on reset, fixing a break-button bug in the Electron;
* slightly improves 6560 timing; and
* makes some attempt at allowing NMIs to usurp IRQs and BRKs.