### PR TITLE
Adjusts non-ROM PRG loading to be via the tape interface

### DIFF
--- a/Machines/Commodore/Vic-20/Vic20.cpp
+++ b/Machines/Commodore/Vic-20/Vic20.cpp
@@ -238,7 +238,7 @@ void Machine::set_prg(const char *file_name, size_t length, const uint8_t *data)
 		_rom_length = (uint16_t)(length - 2);
 
 		// install in the ROM area if this looks like a ROM; otherwise put on tape and throw into that mechanism
-		if(_rom_address == 0xa000 && _rom_length == 0x1000)
+		if(_rom_address == 0xa000 && (_rom_length == 0x1000 || _rom_length == 0x2000))
 		{
 			_rom = new uint8_t[length - 2];
 			memcpy(_rom, &data[2], length - 2);

--- a/Machines/Commodore/Vic-20/Vic20.cpp
+++ b/Machines/Commodore/Vic-20/Vic20.cpp
@@ -102,7 +102,7 @@ Machine::~Machine()
 unsigned int Machine::perform_bus_operation(CPU6502::BusOperation operation, uint16_t address, uint8_t *value)
 {
 //	static int logCount = 0;
-//	if(operation == CPU6502::BusOperation::ReadOpcode && address == 0xee17) logCount = 500;
+//	if(operation == CPU6502::BusOperation::ReadOpcode && address == 0xf957) logCount = 500;
 //	if(operation == CPU6502::BusOperation::ReadOpcode && logCount) {
 //		logCount--;
 //		printf("%04x\n", address);

--- a/Machines/Commodore/Vic-20/Vic20.cpp
+++ b/Machines/Commodore/Vic-20/Vic20.cpp
@@ -108,6 +108,11 @@ unsigned int Machine::perform_bus_operation(CPU6502::BusOperation operation, uin
 //		printf("%04x\n", address);
 //	}
 
+	if(operation == CPU6502::BusOperation::Write && (address >= 0x033C && address < 0x033C + 192))
+	{
+		printf("\n[%04x] <- %02x\n", address, *value);
+	}
+
 	// run the phase-1 part of this cycle, in which the VIC accesses memory
 	_mos6560->run_for_cycles(1);
 

--- a/Machines/Commodore/Vic-20/Vic20.cpp
+++ b/Machines/Commodore/Vic-20/Vic20.cpp
@@ -9,6 +9,7 @@
 #include "Vic20.hpp"
 
 #include <algorithm>
+#include "../../../Storage/Tape/Formats/TapePRG.hpp"
 
 using namespace Commodore::Vic20;
 
@@ -218,7 +219,7 @@ void Machine::set_rom(ROMSlot slot, size_t length, const uint8_t *data)
 	}
 }
 
-void Machine::add_prg(size_t length, const uint8_t *data)
+void Machine::set_prg(const char *file_name, size_t length, const uint8_t *data)
 {
 	if(length > 2)
 	{
@@ -237,16 +238,8 @@ void Machine::add_prg(size_t length, const uint8_t *data)
 		}
 		else
 		{
-			// TODO: write to virtual media (tape, probably?), load normally.
-			data += 2;
-			while(_rom_length)
-			{
-				uint8_t *ram = _processorWriteMemoryMap[_rom_address >> 10];
-				if(ram) ram[_rom_address & 0x3ff] = *data;
-				data++;
-				_rom_length--;
-				_rom_address++;
-			}
+			// if it's not a ROM then insert it as a tape
+			set_tape(std::shared_ptr<Storage::Tape>(new Storage::TapePRG(file_name)));
 		}
 	}
 }

--- a/Machines/Commodore/Vic-20/Vic20.cpp
+++ b/Machines/Commodore/Vic-20/Vic20.cpp
@@ -108,10 +108,10 @@ unsigned int Machine::perform_bus_operation(CPU6502::BusOperation operation, uin
 //		printf("%04x\n", address);
 //	}
 
-	if(operation == CPU6502::BusOperation::Write && (address >= 0x033C && address < 0x033C + 192))
-	{
-		printf("\n[%04x] <- %02x\n", address, *value);
-	}
+//	if(operation == CPU6502::BusOperation::Write && (address >= 0x033C && address < 0x033C + 192))
+//	{
+//		printf("\n[%04x] <- %02x\n", address, *value);
+//	}
 
 	// run the phase-1 part of this cycle, in which the VIC accesses memory
 	_mos6560->run_for_cycles(1);
@@ -238,11 +238,11 @@ void Machine::set_prg(const char *file_name, size_t length, const uint8_t *data)
 		_rom_length = (uint16_t)(length - 2);
 
 		// install in the ROM area if this looks like a ROM; otherwise put on tape and throw into that mechanism
-		if(_rom_address == 0xa000 && (_rom_length == 0x1000 || _rom_length == 0x2000))
+		if(_rom_address == 0xa000)
 		{
-			_rom = new uint8_t[length - 2];
+			_rom = new uint8_t[0x2000];
 			memcpy(_rom, &data[2], length - 2);
-			write_to_map(_processorReadMemoryMap, _rom, _rom_address, _rom_length);
+			write_to_map(_processorReadMemoryMap, _rom, _rom_address, 0x2000);
 		}
 		else
 		{

--- a/Machines/Commodore/Vic-20/Vic20.hpp
+++ b/Machines/Commodore/Vic-20/Vic20.hpp
@@ -260,7 +260,7 @@ class Machine:
 		~Machine();
 
 		void set_rom(ROMSlot slot, size_t length, const uint8_t *data);
-		void add_prg(size_t length, const uint8_t *data);
+		void set_prg(const char *file_name, size_t length, const uint8_t *data);
 		void set_tape(std::shared_ptr<Storage::Tape> tape);
 		void set_disk(std::shared_ptr<Storage::Disk> disk);
 

--- a/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		4B2A53A11D117D36003C6002 /* CSAtari2600.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4B2A539A1D117D36003C6002 /* CSAtari2600.mm */; };
 		4B2A53A21D117D36003C6002 /* CSElectron.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4B2A539C1D117D36003C6002 /* CSElectron.mm */; };
 		4B2A53A31D117D36003C6002 /* CSVic20.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4B2A539E1D117D36003C6002 /* CSVic20.mm */; };
+		4B2BFC5F1D613E0200BA3AA9 /* TapePRG.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B2BFC5D1D613E0200BA3AA9 /* TapePRG.cpp */; };
 		4B2E2D951C399D1200138695 /* ElectronDocument.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4B2E2D931C399D1200138695 /* ElectronDocument.xib */; };
 		4B2E2D9A1C3A06EC00138695 /* Atari2600.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B2E2D971C3A06EC00138695 /* Atari2600.cpp */; };
 		4B2E2D9D1C3A070400138695 /* Electron.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B2E2D9B1C3A070400138695 /* Electron.cpp */; };
@@ -393,6 +394,8 @@
 		4B2A539C1D117D36003C6002 /* CSElectron.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CSElectron.mm; sourceTree = "<group>"; };
 		4B2A539D1D117D36003C6002 /* CSVic20.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CSVic20.h; sourceTree = "<group>"; };
 		4B2A539E1D117D36003C6002 /* CSVic20.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CSVic20.mm; sourceTree = "<group>"; };
+		4B2BFC5D1D613E0200BA3AA9 /* TapePRG.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TapePRG.cpp; sourceTree = "<group>"; };
+		4B2BFC5E1D613E0200BA3AA9 /* TapePRG.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = TapePRG.hpp; sourceTree = "<group>"; };
 		4B2E2D941C399D1200138695 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/ElectronDocument.xib; sourceTree = "<group>"; };
 		4B2E2D971C3A06EC00138695 /* Atari2600.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Atari2600.cpp; sourceTree = "<group>"; };
 		4B2E2D981C3A06EC00138695 /* Atari2600.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = Atari2600.hpp; sourceTree = "<group>"; };
@@ -1004,6 +1007,8 @@
 				4B69FB431C4D941400B5F0AA /* TapeUEF.hpp */,
 				4BC91B811D1F160E00884B76 /* CommodoreTAP.cpp */,
 				4BC91B821D1F160E00884B76 /* CommodoreTAP.hpp */,
+				4B2BFC5D1D613E0200BA3AA9 /* TapePRG.cpp */,
+				4B2BFC5E1D613E0200BA3AA9 /* TapePRG.hpp */,
 			);
 			path = Formats;
 			sourceTree = "<group>";
@@ -1908,6 +1913,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4B2BFC5F1D613E0200BA3AA9 /* TapePRG.cpp in Sources */,
 				4BAB62AD1D3272D200DF5BA0 /* Disk.cpp in Sources */,
 				4BC9DF4F1D04691600F44158 /* 6560.cpp in Sources */,
 				4BB697CE1D4BA44400248BDF /* CommodoreGCR.cpp in Sources */,

--- a/OSBindings/Mac/Clock Signal/Documents/Vic20Document.swift
+++ b/OSBindings/Mac/Clock Signal/Documents/Vic20Document.swift
@@ -47,6 +47,7 @@ class Vic20Document: MachineDocument {
 				case "tap":	vic20.openTAPAtURL(url)
 				case "g64":	vic20.openG64AtURL(url)
 				case "d64":	vic20.openD64AtURL(url)
+				case "prg": vic20.openPRGAtURL(url)
 				default:
 					let fileWrapper = try NSFileWrapper(URL: url, options: NSFileWrapperReadingOptions(rawValue: 0))
 					try self.readFromFileWrapper(fileWrapper, ofType: typeName)
@@ -57,10 +58,6 @@ class Vic20Document: MachineDocument {
 	// MARK: machine setup
 	private func rom(name: String) -> NSData? {
 		return dataForResource(name, ofType: "bin", inDirectory: "ROMImages/Vic20")
-	}
-
-	override func readFromData(data: NSData, ofType typeName: String) throws {
-		vic20.setPRG(data)
 	}
 
 	// MARK: automatic loading tick box

--- a/OSBindings/Mac/Clock Signal/Machine/Wrappers/CSVic20.h
+++ b/OSBindings/Mac/Clock Signal/Machine/Wrappers/CSVic20.h
@@ -30,7 +30,7 @@ typedef NS_ENUM(NSInteger, CSVic20MemorySize)
 - (void)setCharactersROM:(nonnull NSData *)rom;
 - (void)setDriveROM:(nonnull NSData *)rom;
 
-- (void)setPRG:(nonnull NSData *)prg;
+- (BOOL)openPRGAtURL:(nonnull NSURL *)URL;
 - (BOOL)openTAPAtURL:(nonnull NSURL *)URL;
 - (BOOL)openG64AtURL:(nonnull NSURL *)URL;
 - (BOOL)openD64AtURL:(nonnull NSURL *)URL;

--- a/OSBindings/Mac/Clock Signal/Machine/Wrappers/CSVic20.mm
+++ b/OSBindings/Mac/Clock Signal/Machine/Wrappers/CSVic20.mm
@@ -82,9 +82,15 @@ using namespace Commodore::Vic20;
 	}
 }
 
-- (void)setPRG:(nonnull NSData *)prg {
+- (BOOL)openPRGAtURL:(NSURL *)URL {
+	NSData *prg = [NSData dataWithContentsOfURL:URL];
 	@synchronized(self) {
-		_vic20.add_prg(prg.length, (const uint8_t *)prg.bytes);
+		try {
+			_vic20.set_prg(URL.fileSystemRepresentation, prg.length, (const uint8_t *)prg.bytes);
+			return YES;
+		} catch(...) {
+			return NO;
+		}
 	}
 }
 

--- a/Storage/Tape/Formats/CommodoreTAP.cpp
+++ b/Storage/Tape/Formats/CommodoreTAP.cpp
@@ -64,7 +64,7 @@ void CommodoreTAP::reset()
 	_current_pulse.type = Pulse::High;
 }
 
-CommodoreTAP::Pulse CommodoreTAP::get_next_pulse()
+Tape::Pulse CommodoreTAP::get_next_pulse()
 {
 	if(_current_pulse.type == Pulse::High)
 	{

--- a/Storage/Tape/Formats/CommodoreTAP.hpp
+++ b/Storage/Tape/Formats/CommodoreTAP.hpp
@@ -15,7 +15,7 @@
 namespace Storage {
 
 /*!
-	Provides a @c Tape containing a Commodore-format tape image, which is simply a timed list of zero crossings.
+	Provides a @c Tape containing a Commodore-format tape image, which is simply a timed list of downward-going zero crossings.
 */
 class CommodoreTAP: public Tape {
 	public:

--- a/Storage/Tape/Formats/TapePRG.cpp
+++ b/Storage/Tape/Formats/TapePRG.cpp
@@ -1,0 +1,49 @@
+//
+//  TapePRG.cpp
+//  Clock Signal
+//
+//  Created by Thomas Harte on 14/08/2016.
+//  Copyright © 2016 Thomas Harte. All rights reserved.
+//
+
+#include "TapePRG.hpp"
+
+#include <sys/stat.h>
+
+using namespace Storage;
+
+TapePRG::TapePRG(const char *file_name) : _file(nullptr)
+{
+	struct stat file_stats;
+	stat(file_name, &file_stats);
+
+	// There's really no way to validate other than that if this file is larger than 64kb,
+	// of if load address + length > 65536 then it's broken.
+	if(file_stats.st_size >= 65538 || file_stats.st_size < 3)
+		throw ErrorBadFormat;
+
+	_file = fopen(file_name, "rb");
+	if(!_file) throw ErrorBadFormat;
+
+	_load_address = (uint16_t)fgetc(_file);
+	_load_address |= (uint16_t)fgetc(_file) << 8;
+
+	if (_load_address + file_stats.st_size >= 65536)
+		throw ErrorBadFormat;
+}
+
+TapePRG::~TapePRG()
+{
+	if(_file) fclose(_file);
+}
+
+Tape::Pulse TapePRG::get_next_pulse()
+{
+	Tape::Pulse pulse;
+	return pulse;
+}
+
+void TapePRG::reset()
+{
+	// TODO
+}

--- a/Storage/Tape/Formats/TapePRG.cpp
+++ b/Storage/Tape/Formats/TapePRG.cpp
@@ -106,7 +106,6 @@ void TapePRG::get_next_output_token()
 		if(byte_offset < 9)
 		{
 			_output_byte = (uint8_t)(9 - byte_offset) | 0x80;
-			_check_digit = 0;
 		}
 		else if(byte_offset == 199)
 		{
@@ -114,6 +113,7 @@ void TapePRG::get_next_output_token()
 		}
 		else
 		{
+			if(byte_offset == 9) _check_digit = 0;
 			if(_filePhase == FilePhaseHeader)
 			{
 				switch(byte_offset - 9)
@@ -137,10 +137,11 @@ void TapePRG::get_next_output_token()
 				_output_byte = (uint8_t)fgetc(_file);
 				if(feof(_file)) _output_byte = 0x20;
 			}
+
+			_check_digit ^= _output_byte;
 		}
 
 		printf("%02x ", _output_byte);
-		_check_digit ^= _output_byte;
 	}
 
 	switch(bit_offset)

--- a/Storage/Tape/Formats/TapePRG.cpp
+++ b/Storage/Tape/Formats/TapePRG.cpp
@@ -57,8 +57,8 @@ Tape::Pulse TapePRG::get_next_pulse()
 		case WordMarker:	pulse.length.length = (_bitPhase&2) ? one_length : marker_length;	break;
 		case EndOfBlock:	pulse.length.length = (_bitPhase&2) ? zero_length : marker_length;	break;
 	}
-	pulse.length.clock_rate = 1000000;
-	pulse.type = (_bitPhase&1) ? Pulse::Low : Pulse::High;
+	pulse.length.clock_rate = 2000000;
+	pulse.type = (_bitPhase&1) ? Pulse::High : Pulse::Low;
 	return pulse;
 }
 
@@ -125,8 +125,8 @@ void TapePRG::get_next_output_token()
 					case 4: _output_byte = ((_load_address + _length) >> 8) & 0xff;		break;
 
 					case 5: _output_byte = 0x50;	break; // P
-					case 6: _output_byte = 0x72;	break; // R
-					case 7: _output_byte = 0x67;	break; // G
+					case 6: _output_byte = 0x52;	break; // R
+					case 7: _output_byte = 0x47;	break; // G
 					default:
 						_output_byte = 0x20;
 					break;

--- a/Storage/Tape/Formats/TapePRG.cpp
+++ b/Storage/Tape/Formats/TapePRG.cpp
@@ -146,7 +146,7 @@ void TapePRG::get_next_output_token()
 			_check_digit ^= _output_byte;
 		}
 
-		printf("%02x ", _output_byte);
+		printf(" %02x", _output_byte);
 	}
 
 	switch(bit_offset)
@@ -159,11 +159,12 @@ void TapePRG::get_next_output_token()
 		break;
 		case 9:
 		{
-			uint8_t parity = _outputToken;
+			uint8_t parity = _output_byte;
 			parity ^= (parity >> 4);
 			parity ^= (parity >> 2);
 			parity ^= (parity >> 1);
-			_outputToken = (parity&1) ? One : Zero;
+			_outputToken = (parity&1) ? Zero : One;
+			printf("[%d]", parity&1);
 		}
 		break;
 	}

--- a/Storage/Tape/Formats/TapePRG.cpp
+++ b/Storage/Tape/Formats/TapePRG.cpp
@@ -8,6 +8,42 @@
 
 #include "TapePRG.hpp"
 
+/*
+	My interpretation of Commodore's tape format is such that a PRG is encoded as:
+
+	[long block of lead-in tone]
+	[short block of lead-in tone]
+	[count down][header; 192 bytes fixed length]
+	[short block of lead-in tone]
+	[count down][copy of header; 192 bytes fixed length]
+	[gap]
+	[short block of lead-in tone]
+	[count down][data; length as in file]
+	[short block of lead-in tone]
+	[count down][copy of data]
+	... and repeat ...
+
+	Individual bytes are composed of:
+
+		word marker
+		least significant bit
+		...
+		most significant bit
+		parity bit
+
+	Both the header and data blocks additionally end with an end-of-block marker.
+
+	Encoding is via square-wave cycles of four lengths, in ascending order: lead-in, zero, one, marker.
+
+	Lead-in tone is always just repetitions of the lead-in wave.
+	A word marker is a marker wave followed by a one wave.
+	An end-of-block marker is a marker wave followed by a zero wave.
+	A zero bit is a zero wave followed by a one wave.
+	A one bit is a one wave followed by a zero wave.
+
+	Parity is 1 if there are an even number of bits in the byte; 0 otherwise.
+*/
+
 #include <sys/stat.h>
 
 using namespace Storage;

--- a/Storage/Tape/Formats/TapePRG.hpp
+++ b/Storage/Tape/Formats/TapePRG.hpp
@@ -59,6 +59,8 @@ class TapePRG: public Tape {
 		void get_next_output_token();
 		uint8_t _output_byte;
 		uint8_t _check_digit;
+//		uint8_t _copy_mask;
+		uint8_t _file_type;
 };
 
 }

--- a/Storage/Tape/Formats/TapePRG.hpp
+++ b/Storage/Tape/Formats/TapePRG.hpp
@@ -45,12 +45,14 @@ class TapePRG: public Tape {
 			FilePhaseHeader
 		} _filePhase;
 
-		enum BitPhase {
-			BitPhase0,
-			BitPhase1,
-			BitPhase2,
-			BitPhase3
-		} _bitPhase;
+		int _bitPhase;
+		enum OutputToken {
+			Leader,
+			Zero,
+			One,
+			WordMarker
+		} _outputToken;
+		void get_next_output_token();
 };
 
 }

--- a/Storage/Tape/Formats/TapePRG.hpp
+++ b/Storage/Tape/Formats/TapePRG.hpp
@@ -44,6 +44,7 @@ class TapePRG: public Tape {
 		enum FilePhase {
 			FilePhaseLeadIn,
 			FilePhaseHeader,
+			FilePhaseHeaderDataGap,
 			FilePhaseData,
 		} _filePhase;
 		int _phaseOffset;
@@ -59,8 +60,7 @@ class TapePRG: public Tape {
 		void get_next_output_token();
 		uint8_t _output_byte;
 		uint8_t _check_digit;
-//		uint8_t _copy_mask;
-		uint8_t _file_type;
+		uint8_t _copy_mask;
 };
 
 }

--- a/Storage/Tape/Formats/TapePRG.hpp
+++ b/Storage/Tape/Formats/TapePRG.hpp
@@ -55,7 +55,8 @@ class TapePRG: public Tape {
 			Zero,
 			One,
 			WordMarker,
-			EndOfBlock
+			EndOfBlock,
+			Silence
 		} _outputToken;
 		void get_next_output_token();
 		uint8_t _output_byte;

--- a/Storage/Tape/Formats/TapePRG.hpp
+++ b/Storage/Tape/Formats/TapePRG.hpp
@@ -39,6 +39,7 @@ class TapePRG: public Tape {
 	private:
 		FILE *_file;
 		uint16_t _load_address;
+		uint16_t _length;
 
 		enum FilePhase {
 			FilePhaseLeadIn,
@@ -53,9 +54,11 @@ class TapePRG: public Tape {
 			Zero,
 			One,
 			WordMarker,
+			EndOfBlock
 		} _outputToken;
 		void get_next_output_token();
 		uint8_t _output_byte;
+		uint8_t _check_digit;
 };
 
 }

--- a/Storage/Tape/Formats/TapePRG.hpp
+++ b/Storage/Tape/Formats/TapePRG.hpp
@@ -1,0 +1,58 @@
+//
+//  TapePRG.hpp
+//  Clock Signal
+//
+//  Created by Thomas Harte on 14/08/2016.
+//  Copyright © 2016 Thomas Harte. All rights reserved.
+//
+
+#ifndef TapePRG_hpp
+#define TapePRG_hpp
+
+#include "../Tape.hpp"
+#include <stdint.h>
+
+namespace Storage {
+
+/*!
+	Provides a @c Tape containing a .PRG, which is a direct local file.
+*/
+class TapePRG: public Tape {
+	public:
+		/*!
+			Constructs a @c T64 containing content from the file with name @c file_name, of type @c type.
+
+			@param file_name The name of the file to load.
+			@param type The type of data the file should contain.
+			@throws ErrorBadFormat if this file could not be opened and recognised as the specified type.
+		*/
+		TapePRG(const char *file_name);
+		~TapePRG();
+
+		enum {
+			ErrorBadFormat
+		};
+
+		// implemented to satisfy @c Tape
+		Pulse get_next_pulse();
+		void reset();
+	private:
+		FILE *_file;
+		uint16_t _load_address;
+
+		enum FilePhase {
+			FilePhaseLeadIn,
+			FilePhaseHeader
+		} _filePhase;
+
+		enum BitPhase {
+			BitPhase0,
+			BitPhase1,
+			BitPhase2,
+			BitPhase3
+		} _bitPhase;
+};
+
+}
+
+#endif /* T64_hpp */

--- a/Storage/Tape/Formats/TapePRG.hpp
+++ b/Storage/Tape/Formats/TapePRG.hpp
@@ -42,17 +42,20 @@ class TapePRG: public Tape {
 
 		enum FilePhase {
 			FilePhaseLeadIn,
-			FilePhaseHeader
+			FilePhaseHeader,
+			FilePhaseData,
 		} _filePhase;
+		int _phaseOffset;
 
 		int _bitPhase;
 		enum OutputToken {
 			Leader,
 			Zero,
 			One,
-			WordMarker
+			WordMarker,
 		} _outputToken;
 		void get_next_output_token();
+		uint8_t _output_byte;
 };
 
 }


### PR DESCRIPTION
Albeit that the test for "is or is not a ROM" is terrible. The intention is that this gives another route in for PRGs and therefore shifts the ball into the court of accelerated tape loading and proper loading configuration and command issuing.