### PR TITLE
Reduces 6522 emulation costs

### DIFF
--- a/Machines/Commodore/1540/C1540.cpp
+++ b/Machines/Commodore/1540/C1540.cpp
@@ -91,8 +91,8 @@ unsigned int Machine::perform_bus_operation(CPU6502::BusOperation operation, uin
 			_driveVIA.set_register(address, *value);
 	}
 
-	_serialPortVIA->run_for_half_cycles(2);
-	_driveVIA.run_for_half_cycles(2);
+	_serialPortVIA->run_for_cycles(1);
+	_driveVIA.run_for_cycles(1);
 
 	return 1;
 }

--- a/Machines/Commodore/Vic-20/Vic20.cpp
+++ b/Machines/Commodore/Vic-20/Vic20.cpp
@@ -139,8 +139,8 @@ unsigned int Machine::perform_bus_operation(CPU6502::BusOperation operation, uin
 		{
 			while(!_userPortVIA->get_interrupt_line() && !_keyboardVIA->get_interrupt_line() && !_tape.get_tape()->is_at_end())
 			{
-				_userPortVIA->run_for_half_cycles(2);
-				_keyboardVIA->run_for_half_cycles(2);
+				_userPortVIA->run_for_cycles(1);
+				_keyboardVIA->run_for_cycles(1);
 				_tape.run_for_cycles(1);
 			}
 		}
@@ -157,8 +157,8 @@ unsigned int Machine::perform_bus_operation(CPU6502::BusOperation operation, uin
 		}
 	}
 
-	_userPortVIA->run_for_half_cycles(2);
-	_keyboardVIA->run_for_half_cycles(2);
+	_userPortVIA->run_for_cycles(1);
+	_keyboardVIA->run_for_cycles(1);
 	if(_typer && operation == CPU6502::BusOperation::ReadOpcode && address == 0xEB1E)
 	{
 		if(!_typer->type_next_character())

--- a/Machines/Oric/Oric.cpp
+++ b/Machines/Oric/Oric.cpp
@@ -61,7 +61,7 @@ unsigned int Machine::perform_bus_operation(CPU6502::BusOperation operation, uin
 		}
 	}
 
-	_via.run_for_half_cycles(2);
+	_via.run_for_cycles(1);
 	_via.tape->run_for_cycles(1);
 	_cycles_since_video_update++;
 	return 1;

--- a/Machines/Oric/Video.cpp
+++ b/Machines/Oric/Video.cpp
@@ -51,7 +51,7 @@ std::shared_ptr<Outputs::CRT::CRT> VideoOutput::get_crt()
 
 void VideoOutput::run_for_cycles(int number_of_cycles)
 {
-	// Vertical: 0–39: pixels; otherwise blank; 48–53 sync
+	// Vertical: 0–39: pixels; otherwise blank; 48–53 sync, 54–56 colour burst
 	// Horizontal: 0–223: pixels; otherwise blank; 256–259 sync
 
 	while(number_of_cycles--)
@@ -77,6 +77,7 @@ void VideoOutput::run_for_cycles(int number_of_cycles)
 				_counter_period = _next_frame_is_sixty_hertz ? PAL60Period : PAL50Period;
 			}
 		}
+
 
 		State new_state = Blank;
 		if(


### PR DESCRIPTION
Partly by introducing a full-cycle execution mode, partly by taking the phase 1/2 test outside the loop when running in half cycles, making it more amenable to branch prediction.