### PR TITLE
Switches to storing the IRQ line in the inverse, to simplify its per-cycle logic

### DIFF
--- a/Components/6522/6522.hpp
+++ b/Components/6522/6522.hpp
@@ -285,7 +285,7 @@ template <class T> class MOS6522 {
 				number_of_cycles--;
 			}
 
-			while(number_of_cycles > 2)
+			while(number_of_cycles >= 2)
 			{
 				phase1();
 				phase2();

--- a/Processors/6502/CPU6502.hpp
+++ b/Processors/6502/CPU6502.hpp
@@ -547,7 +547,7 @@ template <class T> class Processor {
 			_ready_line_is_enabled(false),
 			_ready_is_active(false),
 			_scheduledPrograms{nullptr, nullptr, nullptr, nullptr},
-			_inverseInterruptFlag(Flag::Interrupt),
+			_inverseInterruptFlag(0),
 			_s(0),
 			_nextBusOperation(BusOperation::None),
 			_interrupt_requests(InterruptRequestFlags::PowerOn),


### PR DESCRIPTION
(and corrects a 6522 cycle-counting bug, as the other step necessary to correct unit tests)