### PR TITLE
Switches to using the original Oric colour ROM to generate Oric composite values

### DIFF
--- a/Machines/Atari2600/Atari2600.cpp
+++ b/Machines/Atari2600/Atari2600.cpp
@@ -60,7 +60,7 @@ Machine::Machine() :
 void Machine::setup_output(float aspect_ratio)
 {
 	speaker_.reset(new Speaker);
-	crt_.reset(new Outputs::CRT::CRT(228, 1, 263, Outputs::CRT::ColourSpace::YIQ, 228, 1, 1));
+	crt_.reset(new Outputs::CRT::CRT(228, 1, 263, Outputs::CRT::ColourSpace::YIQ, 228, 1, false, 1));
 	crt_->set_output_device(Outputs::CRT::Television);
 
 	// this is the NTSC phase offset function; see below for PAL
@@ -93,7 +93,7 @@ void Machine::switch_region()
 			"return mix(float(y) / 14.0, step(4, (iPhase + 2u) & 15u) * cos(phase + phaseOffset), amplitude);"
 		"}");
 
-	crt_->set_new_timing(228, 312, Outputs::CRT::ColourSpace::YUV, 228, 1);
+	crt_->set_new_timing(228, 312, Outputs::CRT::ColourSpace::YUV, 228, 1, true);
 
 	is_pal_region_ = true;
 	speaker_->set_input_rate((float)(get_clock_rate() / 38.0));

--- a/Machines/Electron/Electron.cpp
+++ b/Machines/Electron/Electron.cpp
@@ -43,8 +43,7 @@ Machine::Machine() :
 	display_output_position_(0),
 	audio_output_position_(0),
 	current_pixel_line_(-1),
-	use_fast_tape_hack_(false),
-	phase_(0)
+	use_fast_tape_hack_(false)
 {
 	memset(key_states_, 0, sizeof(key_states_));
 	memset(palette_, 0xf, sizeof(palette_));
@@ -451,8 +450,6 @@ unsigned int Machine::perform_bus_operation(CPU6502::BusOperation operation, uin
 	}
 
 	frame_cycles_ += cycles;
-
-	if(!(frame_cycles_&127)) phase_ += 64;
 
 	// deal with frame wraparound by updating the two dependent subsystems
 	// as though the exact end of frame had been hit, then reset those
@@ -874,7 +871,7 @@ inline void Machine::update_display()
 			if(this_cycle < 24)
 			{
 				if(final_cycle < 24) return;
-				crt_->output_colour_burst((24-9) * crt_cycles_multiplier, phase_, 12);
+				crt_->output_default_colour_burst((24-9) * crt_cycles_multiplier);
 				display_output_position_ += 24-9;
 				this_cycle = 24;
 				// TODO: phase shouldn't be zero on every line

--- a/Machines/Electron/Electron.hpp
+++ b/Machines/Electron/Electron.hpp
@@ -135,7 +135,6 @@ class Machine:
 		// Counters related to simultaneous subsystems
 		unsigned int frame_cycles_, display_output_position_;
 		unsigned int audio_output_position_, audio_output_position_error_;
-		uint8_t phase_;
 
 		struct {
 			uint16_t forty1bpp[256];

--- a/Machines/Oric/Oric.cpp
+++ b/Machines/Oric/Oric.cpp
@@ -82,6 +82,10 @@ void Machine::set_rom(ROM rom, const std::vector<uint8_t> &data)
 		case BASIC11:	basic11_rom_ = std::move(data);		break;
 		case BASIC10:	basic10_rom_ = std::move(data);		break;
 		case Microdisc:	microdisc_rom_ = std::move(data);	break;
+		case Colour:
+			colour_rom_ = std::move(data);
+			if(video_output_) video_output_->set_colour_rom(colour_rom_);
+		break;
 	}
 }
 
@@ -172,9 +176,10 @@ void Machine::update_video()
 
 void Machine::setup_output(float aspect_ratio)
 {
-	video_output_.reset(new VideoOutput(ram_));
 	via_.ay8910.reset(new GI::AY38910());
 	via_.ay8910->set_clock_rate(1000000);
+	video_output_.reset(new VideoOutput(ram_));
+	if(!colour_rom_.empty()) video_output_->set_colour_rom(colour_rom_);
 }
 
 void Machine::close_output()

--- a/Machines/Oric/Oric.cpp
+++ b/Machines/Oric/Oric.cpp
@@ -218,6 +218,11 @@ void Machine::set_use_fast_tape_hack(bool activate)
 	use_fast_tape_hack_ = activate;
 }
 
+void Machine::set_output_device(Outputs::CRT::OutputDevice output_device)
+{
+	video_output_->set_output_device(output_device);
+}
+
 void Machine::tape_did_change_input(Storage::Tape::BinaryTapePlayer *tape_player)
 {
 	// set CB1

--- a/Machines/Oric/Oric.hpp
+++ b/Machines/Oric/Oric.hpp
@@ -53,7 +53,7 @@ enum Key: uint16_t {
 };
 
 enum ROM {
-	BASIC10, BASIC11, Microdisc
+	BASIC10, BASIC11, Microdisc, Colour
 };
 
 class Machine:
@@ -103,7 +103,7 @@ class Machine:
 
 	private:
 		// RAM and ROM
-		std::vector<uint8_t> basic11_rom_, basic10_rom_, microdisc_rom_;
+		std::vector<uint8_t> basic11_rom_, basic10_rom_, microdisc_rom_, colour_rom_;
 		uint8_t ram_[65536], rom_[16384];
 		int cycles_since_video_update_;
 		inline void update_video();

--- a/Machines/Oric/Oric.hpp
+++ b/Machines/Oric/Oric.hpp
@@ -73,6 +73,7 @@ class Machine:
 		void clear_all_keys();
 
 		void set_use_fast_tape_hack(bool activate);
+		void set_output_device(Outputs::CRT::OutputDevice output_device);
 
 		// to satisfy ConfigurationTarget::Machine
 		void configure_as_target(const StaticAnalyser::Target &target);

--- a/Machines/Oric/Video.cpp
+++ b/Machines/Oric/Video.cpp
@@ -63,6 +63,16 @@ void VideoOutput::set_colour_rom(const std::vector<uint8_t> &rom)
 		rom_value = (rom_value & 0xff00) | ((rom_value >> 4)&0x000f) | ((rom_value << 4)&0x00f0);
 		colour_forms_[c] = rom_value;
 	}
+
+	// check for big endianness and byte swap if required
+	uint16_t test_value = 0x0001;
+	if(*(uint8_t *)&test_value != 0x01)
+	{
+		for(size_t c = 0; c < 8; c++)
+		{
+			colour_forms_[c] = (uint16_t)((colour_forms_[c] >> 8) | (colour_forms_[c] << 8));
+		}
+	}
 }
 
 std::shared_ptr<Outputs::CRT::CRT> VideoOutput::get_crt()

--- a/Machines/Oric/Video.cpp
+++ b/Machines/Oric/Video.cpp
@@ -95,8 +95,8 @@ void VideoOutput::run_for_cycles(int number_of_cycles)
 			// this is a pixel line
 			if(!h_counter)
 			{
-				ink_ = 0xff;
-				paper_ = 0x00;
+				ink_ = 0xf;
+				paper_ = 0x0;
 				use_alternative_character_set_ = use_double_height_characters_ = blink_text_ = false;
 				set_character_set_base_address();
 				pixel_target_ = (uint16_t *)crt_->allocate_write_area(240);
@@ -133,7 +133,7 @@ void VideoOutput::run_for_cycles(int number_of_cycles)
 					pixels = ram_[character_set_base_address_ + (control_byte&127) * 8 + line];
 				}
 
-				uint8_t inverse_mask = (control_byte & 0x80) ? 0x77 : 0x00;
+				uint8_t inverse_mask = (control_byte & 0x80) ? 0x7 : 0x0;
 				pixels &= blink_mask;
 
 				if(control_byte & 0x60)
@@ -143,13 +143,13 @@ void VideoOutput::run_for_cycles(int number_of_cycles)
 						uint16_t colours[2];
 						if(output_device_ == Outputs::CRT::Monitor)
 						{
-							colours[0] = (uint8_t)((paper_ ^ inverse_mask) & 0xf);
-							colours[1] = (uint8_t)((ink_ ^ inverse_mask) & 0xf);
+							colours[0] = (uint8_t)(paper_ ^ inverse_mask);
+							colours[1] = (uint8_t)(ink_ ^ inverse_mask);
 						}
 						else
 						{
-							colours[0] = colour_forms_[(paper_ ^ inverse_mask)&0xf];
-							colours[1] = colour_forms_[(ink_ ^ inverse_mask)&0xf];
+							colours[0] = colour_forms_[paper_ ^ inverse_mask];
+							colours[1] = colour_forms_[ink_ ^ inverse_mask];
 						}
 						pixel_target_[0] = colours[(pixels >> 5)&1];
 						pixel_target_[1] = colours[(pixels >> 4)&1];
@@ -163,14 +163,14 @@ void VideoOutput::run_for_cycles(int number_of_cycles)
 				{
 					switch(control_byte & 0x1f)
 					{
-						case 0x00:		ink_ = 0x00;	break;
-						case 0x01:		ink_ = 0x44;	break;
-						case 0x02:		ink_ = 0x22;	break;
-						case 0x03:		ink_ = 0x66;	break;
-						case 0x04:		ink_ = 0x11;	break;
-						case 0x05:		ink_ = 0x55;	break;
-						case 0x06:		ink_ = 0x33;	break;
-						case 0x07:		ink_ = 0x77;	break;
+						case 0x00:		ink_ = 0x0;	break;
+						case 0x01:		ink_ = 0x4;	break;
+						case 0x02:		ink_ = 0x2;	break;
+						case 0x03:		ink_ = 0x6;	break;
+						case 0x04:		ink_ = 0x1;	break;
+						case 0x05:		ink_ = 0x5;	break;
+						case 0x06:		ink_ = 0x3;	break;
+						case 0x07:		ink_ = 0x7;	break;
 
 						case 0x08:	case 0x09:	case 0x0a: case 0x0b:
 						case 0x0c:	case 0x0d:	case 0x0e: case 0x0f:
@@ -180,14 +180,14 @@ void VideoOutput::run_for_cycles(int number_of_cycles)
 							set_character_set_base_address();
 						break;
 
-						case 0x10:		paper_ = 0x00;	break;
-						case 0x11:		paper_ = 0x44;	break;
-						case 0x12:		paper_ = 0x22;	break;
-						case 0x13:		paper_ = 0x66;	break;
-						case 0x14:		paper_ = 0x11;	break;
-						case 0x15:		paper_ = 0x55;	break;
-						case 0x16:		paper_ = 0x33;	break;
-						case 0x17:		paper_ = 0x77;	break;
+						case 0x10:		paper_ = 0x0;	break;
+						case 0x11:		paper_ = 0x4;	break;
+						case 0x12:		paper_ = 0x2;	break;
+						case 0x13:		paper_ = 0x6;	break;
+						case 0x14:		paper_ = 0x1;	break;
+						case 0x15:		paper_ = 0x5;	break;
+						case 0x16:		paper_ = 0x3;	break;
+						case 0x17:		paper_ = 0x7;	break;
 
 						case 0x18: case 0x19: case 0x1a: case 0x1b:
 						case 0x1c: case 0x1d: case 0x1e: case 0x1f:
@@ -202,7 +202,7 @@ void VideoOutput::run_for_cycles(int number_of_cycles)
 						pixel_target_[0] = pixel_target_[1] =
 						pixel_target_[2] = pixel_target_[3] =
 						pixel_target_[4] = pixel_target_[5] =
-							(output_device_ == Outputs::CRT::Monitor) ? (paper_ ^ inverse_mask)&0xf : colour_forms_[(paper_ ^ inverse_mask)&0xf];
+							(output_device_ == Outputs::CRT::Monitor) ? paper_ ^ inverse_mask : colour_forms_[paper_ ^ inverse_mask];
 					}
 				}
 				if(pixel_target_) pixel_target_ += 6;

--- a/Machines/Oric/Video.cpp
+++ b/Machines/Oric/Video.cpp
@@ -37,6 +37,26 @@ VideoOutput::VideoOutput(uint8_t *memory) :
 			"texValue >>= 4 - (int(icoordinate.x * 8) & 4);"
 			"return vec3( uvec3(texValue) & uvec3(4u, 2u, 1u));"
 		"}");
+	crt_->set_composite_sampling_function(
+		"float composite_sample(usampler2D sampler, vec2 coordinate, vec2 icoordinate, float phase, float amplitude)"
+		"{"
+			"float[] array = float[]("
+"0.0000, 0.0000, 0.0000, 0.0000, "
+"0.1100, 0.3250, 0.3750, 0.1600, "
+"0.4100, 0.2150, 0.3250, 0.5200, "
+"0.3750, 0.4100, 0.5700, 0.5200, "
+"0.2650, 0.2150, 0.0500, 0.1100, "
+"0.2650, 0.4100, 0.3250, 0.1600, "
+"0.5200, 0.3250, 0.2650, 0.4600, "
+"0.5200, 0.5200, 0.5200, 0.5200"
+			");"
+			"uint texValue = texture(sampler, coordinate).r;"
+			"texValue >>= 4 - (int(icoordinate.x * 8) & 4);"
+			"uint iPhase = uint((phase + 3.141592654 + 0.39269908175) * 2.0 / 3.141592654) & 3u;"
+			"return array[((texValue & 7u) << 2) + iPhase];"	// (texValue << 2)
+//			"return (mod(phase, 2.0 * 3.141592654) > 3.141592654) ? 0.7273 : 0.3636;"	// (texValue << 2)
+		"}"
+	);
 
 	crt_->set_output_device(Outputs::CRT::Television);
 	crt_->set_visible_area(crt_->get_rect_for_area(50, 224, 16 * 6, 40 * 6, 4.0f / 3.0f));

--- a/Machines/Oric/Video.cpp
+++ b/Machines/Oric/Video.cpp
@@ -24,7 +24,6 @@ VideoOutput::VideoOutput(uint8_t *memory) :
 	frame_counter_(0), counter_(0),
 	is_graphics_mode_(false),
 	character_set_base_address_(0xb400),
-	phase_(0),
 	v_sync_start_position_(PAL50VSyncStartPosition), v_sync_end_position_(PAL50VSyncEndPosition),
 	counter_period_(PAL50Period), next_frame_is_sixty_hertz_(false),
 	crt_(new Outputs::CRT::CRT(64*6, 6, Outputs::CRT::DisplayType::PAL50, 2))
@@ -95,12 +94,10 @@ void VideoOutput::run_for_cycles(int number_of_cycles)
 				paper_ = 0x00;
 				use_alternative_character_set_ = use_double_height_characters_ = blink_text_ = false;
 				set_character_set_base_address();
-				phase_ += 64;
 				pixel_target_ = (uint16_t *)crt_->allocate_write_area(240);
 
 				if(!counter_)
 				{
-					phase_ += 3; // TODO: incorporate all the lines that were missed
 					frame_counter_++;
 
 					v_sync_start_position_ = next_frame_is_sixty_hertz_ ? PAL60VSyncStartPosition : PAL50VSyncStartPosition;
@@ -228,7 +225,7 @@ void VideoOutput::run_for_cycles(int number_of_cycles)
 			else if(h_counter < 56)
 			{
 				cycles_run_for = 56 - h_counter;
-				clamp(crt_->output_colour_burst(2 * 6, phase_, 128));
+				clamp(crt_->output_default_colour_burst(2 * 6));
 			}
 			else
 			{

--- a/Machines/Oric/Video.cpp
+++ b/Machines/Oric/Video.cpp
@@ -28,7 +28,6 @@ VideoOutput::VideoOutput(uint8_t *memory) :
 	counter_period_(PAL50Period), next_frame_is_sixty_hertz_(false),
 	crt_(new Outputs::CRT::CRT(64*6, 6, Outputs::CRT::DisplayType::PAL50, 2))
 {
-	// TODO: this is a copy and paste from the Electron; factor out.
 	crt_->set_rgb_sampling_function(
 		"vec3 rgb_sample(usampler2D sampler, vec2 coordinate, vec2 icoordinate)"
 		"{"
@@ -95,7 +94,7 @@ void VideoOutput::run_for_cycles(int number_of_cycles)
 			// this is a pixel line
 			if(!h_counter)
 			{
-				ink_ = 0xf;
+				ink_ = 0x7;
 				paper_ = 0x0;
 				use_alternative_character_set_ = use_double_height_characters_ = blink_text_ = false;
 				set_character_set_base_address();

--- a/Machines/Oric/Video.hpp
+++ b/Machines/Oric/Video.hpp
@@ -18,6 +18,7 @@ class VideoOutput {
 		VideoOutput(uint8_t *memory);
 		std::shared_ptr<Outputs::CRT::CRT> get_crt();
 		void run_for_cycles(int number_of_cycles);
+		void set_colour_rom(const std::vector<uint8_t> &rom);
 
 	private:
 		uint8_t *ram_;
@@ -28,7 +29,8 @@ class VideoOutput {
 		int v_sync_start_position_, v_sync_end_position_, counter_period_;
 
 		// Output target
-		uint8_t *pixel_target_;
+		uint16_t *pixel_target_;
+		uint16_t colour_forms_[8];
 
 		// Registers
 		uint8_t ink_, paper_;

--- a/Machines/Oric/Video.hpp
+++ b/Machines/Oric/Video.hpp
@@ -43,8 +43,6 @@ class VideoOutput {
 		bool use_alternative_character_set_;
 		bool use_double_height_characters_;
 		bool blink_text_;
-
-		uint8_t phase_;
 };
 
 }

--- a/Machines/Oric/Video.hpp
+++ b/Machines/Oric/Video.hpp
@@ -19,6 +19,7 @@ class VideoOutput {
 		std::shared_ptr<Outputs::CRT::CRT> get_crt();
 		void run_for_cycles(int number_of_cycles);
 		void set_colour_rom(const std::vector<uint8_t> &rom);
+		void set_output_device(Outputs::CRT::OutputDevice output_device);
 
 	private:
 		uint8_t *ram_;
@@ -28,9 +29,10 @@ class VideoOutput {
 		int counter_, frame_counter_;
 		int v_sync_start_position_, v_sync_end_position_, counter_period_;
 
-		// Output target
+		// Output target and device
 		uint16_t *pixel_target_;
 		uint16_t colour_forms_[8];
+		Outputs::CRT::OutputDevice output_device_;
 
 		// Registers
 		uint8_t ink_, paper_;

--- a/OSBindings/Mac/Clock Signal/Machine/Wrappers/CSOric.mm
+++ b/OSBindings/Mac/Clock Signal/Machine/Wrappers/CSOric.mm
@@ -152,7 +152,7 @@
 - (void)setUseCompositeOutput:(BOOL)useCompositeOutput {
 	@synchronized(self) {
 		_useCompositeOutput = useCompositeOutput;
-		_oric.get_crt()->set_output_device(useCompositeOutput ? Outputs::CRT::Television : Outputs::CRT::Monitor);
+		_oric.set_output_device(useCompositeOutput ? Outputs::CRT::Television : Outputs::CRT::Monitor);
 	}
 }
 

--- a/OSBindings/Mac/Clock Signal/Machine/Wrappers/CSOric.mm
+++ b/OSBindings/Mac/Clock Signal/Machine/Wrappers/CSOric.mm
@@ -27,10 +27,12 @@
 	{
 		NSData *basic10 = [self rom:@"basic10"];
 		NSData *basic11 = [self rom:@"basic11"];
+		NSData *colour = [self rom:@"colour"];
 		NSData *microdisc = [self rom:@"microdisc"];
 
 		if(basic10)		_oric.set_rom(Oric::BASIC10, basic10.stdVector8);
 		if(basic11)		_oric.set_rom(Oric::BASIC11, basic11.stdVector8);
+		if(colour)		_oric.set_rom(Oric::Colour, colour.stdVector8);
 		if(microdisc)	_oric.set_rom(Oric::Microdisc, microdisc.stdVector8);
 	}
 	return self;

--- a/Outputs/CRT/Internals/ArrayBuilder.cpp
+++ b/Outputs/CRT/Internals/ArrayBuilder.cpp
@@ -78,7 +78,7 @@ ArrayBuilder::Submission ArrayBuilder::submit()
 }
 
 ArrayBuilder::Buffer::Buffer(size_t size, std::function<void(bool is_input, uint8_t *, size_t)> submission_function) :
-	is_full(false), was_reset(false),
+	is_full(false),
 	submission_function_(submission_function),
 	allocated_data(0), flushed_data(0), submitted_data(0)
 {
@@ -137,14 +137,6 @@ void ArrayBuilder::Buffer::flush()
 	}
 
 	flushed_data = allocated_data;
-
-	if(was_reset)
-	{
-		allocated_data = 0;
-		flushed_data = 0;
-		submitted_data = 0;
-		was_reset = false;
-	}
 }
 
 size_t ArrayBuilder::Buffer::submit(bool is_input)
@@ -171,6 +163,8 @@ void ArrayBuilder::Buffer::bind()
 
 void ArrayBuilder::Buffer::reset()
 {
-	was_reset = true;
 	is_full = false;
+	allocated_data = 0;
+	flushed_data = 0;
+	submitted_data = 0;
 }

--- a/Outputs/CRT/Internals/ArrayBuilder.hpp
+++ b/Outputs/CRT/Internals/ArrayBuilder.hpp
@@ -82,7 +82,7 @@ class ArrayBuilder {
 				void reset();
 
 			private:
-				bool is_full, was_reset;
+				bool is_full;
 				GLuint buffer;
 				std::function<void(bool is_input, uint8_t *, size_t)> submission_function_;
 				std::vector<uint8_t> data;

--- a/Outputs/CRT/Internals/CRTConstants.hpp
+++ b/Outputs/CRT/Internals/CRTConstants.hpp
@@ -36,7 +36,7 @@ const GLsizei InputBufferBuilderWidth = 2048;
 const GLsizei InputBufferBuilderHeight = 512;
 
 // This is the size of the intermediate buffers used during composite to RGB conversion
-const GLsizei IntermediateBufferWidth = 2048;
+const GLsizei IntermediateBufferWidth = 4096;
 const GLsizei IntermediateBufferHeight = 512;
 
 // Some internal buffer sizes

--- a/Outputs/CRT/Internals/CRTOpenGL.cpp
+++ b/Outputs/CRT/Internals/CRTOpenGL.cpp
@@ -385,7 +385,7 @@ void OpenGLOutputBuilder::set_timing_uniforms()
 
 	float colour_subcarrier_frequency = (float)colour_cycle_numerator_ / (float)colour_cycle_denominator_;
 	if(composite_separation_filter_program_)			composite_separation_filter_program_->set_separation_frequency(cycles_per_line_, colour_subcarrier_frequency);
-	if(composite_y_filter_shader_program_)				composite_y_filter_shader_program_->set_filter_coefficients(cycles_per_line_, colour_subcarrier_frequency * 0.66f);
+	if(composite_y_filter_shader_program_)				composite_y_filter_shader_program_->set_filter_coefficients(cycles_per_line_, colour_subcarrier_frequency * 0.25f);
 	if(composite_chrominance_filter_shader_program_)	composite_chrominance_filter_shader_program_->set_filter_coefficients(cycles_per_line_, colour_subcarrier_frequency * 0.5f);
 	if(rgb_filter_shader_program_)						rgb_filter_shader_program_->set_filter_coefficients(cycles_per_line_, (float)input_frequency_ * 0.5f);
 }

--- a/ROMImages/Oric/readme.txt
+++ b/ROMImages/Oric/readme.txt
@@ -1,0 +1,8 @@
+ROM files would ordinarily go here; the copyright status of these is uncertain so they have not been included in this repository.
+
+Expected files:
+
+basic10.rom
+basic11.rom
+colour.rom
+microdisc.rom


### PR DESCRIPTION
Simultaneously introducing a simplified default colour burst route for computers that are known to keep phase consistently, and attempting to do a bit better at composite rendering, albeit at a heavy GPU cost for the time being.