### PR TITLE
Fixes NTSC colour cycle count

### DIFF
--- a/Machines/Atari2600/TIA.cpp
+++ b/Machines/Atari2600/TIA.cpp
@@ -32,7 +32,7 @@ TIA::TIA(bool create_crt) :
 {
 	if(create_crt)
 	{
-		crt_.reset(new Outputs::CRT::CRT(cycles_per_line * 2 + 1, 1, Outputs::CRT::DisplayType::NTSC60, 1));
+		crt_.reset(new Outputs::CRT::CRT(cycles_per_line * 2 - 1, 1, Outputs::CRT::DisplayType::NTSC60, 1));
 		crt_->set_output_device(Outputs::CRT::Television);
 		set_output_mode(OutputMode::NTSC);
 	}
@@ -150,7 +150,7 @@ void TIA::set_output_mode(Atari2600::TIA::OutputMode output_mode)
 				"uint y = c & 14u;"
 				"uint iPhase = (c >> 4);"
 
-				"float phaseOffset = 6.283185308 * float(iPhase) / 13.0  + 5.074880441076923;"
+				"float phaseOffset = 6.283185308 * (float(iPhase) + 3.0) / 13.0  + 5.074880441076923;"
 				"return mix(float(y) / 14.0, step(1, iPhase) * cos(phase + phaseOffset), amplitude);"
 			"}");
 		display_type = Outputs::CRT::DisplayType::NTSC60;

--- a/Outputs/CRT/CRT.cpp
+++ b/Outputs/CRT/CRT.cpp
@@ -59,7 +59,7 @@ void CRT::set_new_display_type(unsigned int cycles_per_line, DisplayType display
 		break;
 
 		case DisplayType::NTSC60:
-			set_new_timing(cycles_per_line, 262, ColourSpace::YIQ, 545, 2, false);
+			set_new_timing(cycles_per_line, 262, ColourSpace::YIQ, 455, 2, false);	// i.e. 227.5
 		break;
 	}
 }


### PR DESCRIPTION
A typing error transposed a digit; it was running at 272.5 cycles per line, rather than 227.5.

Corrected the 2600's expectation of phase appropriately.