### PR TITLE
Corrects infinite loop when performing GCR analysis

### DIFF
--- a/StaticAnalyser/Commodore/Disk.cpp
+++ b/StaticAnalyser/Commodore/Disk.cpp
@@ -24,6 +24,7 @@ class CommodoreGCRParser: public Storage::Disk::Controller {
 		CommodoreGCRParser() : Storage::Disk::Controller(4000000, 1, 300), shift_register_(0), track_(1) {
 			drive.reset(new Storage::Disk::Drive);
 			set_drive(drive);
+			set_motor_on(true);
 		}
 
 		struct Sector {


### PR DESCRIPTION
Specifically resulting from disk controllers having a functioning motor control now.