### PR TITLE
Switches the binary tape player to low = false, high = true

### DIFF
--- a/Machines/Commodore/Vic-20/Vic20.cpp
+++ b/Machines/Commodore/Vic-20/Vic20.cpp
@@ -307,7 +307,7 @@ void Machine::configure_as_target(const StaticAnalyser::Target &target) {
 }
 
 void Machine::tape_did_change_input(Storage::Tape::BinaryTapePlayer *tape) {
-	keyboard_via_->set_control_line_input(KeyboardVIA::Port::A, KeyboardVIA::Line::One, tape->get_input());
+	keyboard_via_->set_control_line_input(KeyboardVIA::Port::A, KeyboardVIA::Line::One, !tape->get_input());
 }
 
 #pragma mark - Disc

--- a/Machines/Oric/Oric.cpp
+++ b/Machines/Oric/Oric.cpp
@@ -187,7 +187,7 @@ void Machine::set_output_device(Outputs::CRT::OutputDevice output_device) {
 
 void Machine::tape_did_change_input(Storage::Tape::BinaryTapePlayer *tape_player) {
 	// set CB1
-	via_.set_control_line_input(VIA::Port::B, VIA::Line::One, tape_player->get_input());
+	via_.set_control_line_input(VIA::Port::B, VIA::Line::One, !tape_player->get_input());
 }
 
 std::shared_ptr<Outputs::CRT::CRT> Machine::get_crt() {

--- a/Machines/ZX8081/ZX8081.cpp
+++ b/Machines/ZX8081/ZX8081.cpp
@@ -54,7 +54,7 @@ int Machine::perform_machine_cycle(const CPU::Z80::PartialMachineCycle &cycle) {
 	}
 
 	if(is_zx81_) horizontal_counter_ %= 207;
-//	tape_player_.run_for_cycles(cycle.length);
+	tape_player_.run_for_cycles(cycle.length);
 
 	if(!cycle.is_terminal()) {
 		return 0;
@@ -117,7 +117,7 @@ int Machine::perform_machine_cycle(const CPU::Z80::PartialMachineCycle &cycle) {
 		case CPU::Z80::PartialMachineCycle::ReadOpcodeStart:
 		case CPU::Z80::PartialMachineCycle::ReadOpcodeWait:
 			// Check for use of the fast tape hack.
-			if(address == tape_trap_address_) { // TODO: && fast_tape_hack_enabled_
+/*			if(address == tape_trap_address_) { // TODO: && fast_tape_hack_enabled_
 				int next_byte = parser_.get_next_byte(tape_player_.get_tape());
 				if(next_byte != -1) {
 					uint16_t hl = get_value_of_register(CPU::Z80::Register::HL);
@@ -126,7 +126,7 @@ int Machine::perform_machine_cycle(const CPU::Z80::PartialMachineCycle &cycle) {
 					set_value_of_register(CPU::Z80::Register::ProgramCounter, tape_return_address_ - 1);
 					return 0;
 				}
-			}
+			}*/
 			is_opcode_read = true;
 
 		case CPU::Z80::PartialMachineCycle::Read:

--- a/Storage/Tape/Tape.cpp
+++ b/Storage/Tape/Tape.cpp
@@ -109,7 +109,7 @@ void BinaryTapePlayer::set_delegate(Delegate *delegate) {
 }
 
 void BinaryTapePlayer::process_input_pulse(Storage::Tape::Tape::Pulse pulse) {
-	bool new_input_level = pulse.type == Tape::Pulse::Low;
+	bool new_input_level = pulse.type == Tape::Pulse::High;
 	if(input_level_ != new_input_level) {
 		input_level_ = new_input_level;
 		if(delegate_) delegate_->tape_did_change_input(this);


### PR DESCRIPTION
Fixing that logical misdirection fixes normal-speed tape loading on the ZX80 and ZX81. Especially given that it still doesn't work on the '81, the fast-loading hack is dutifully disabled.