### PR TITLE
Introduces an NMI/wait interrupt timing test

### DIFF
--- a/OSBindings/Mac/Clock SignalTests/Bridges/TestMachineZ80.h
+++ b/OSBindings/Mac/Clock SignalTests/Bridges/TestMachineZ80.h
@@ -64,5 +64,6 @@ typedef NS_ENUM(NSInteger, CSTestMachineZ80Register) {
 
 @property(nonatomic) BOOL nmiLine;
 @property(nonatomic) BOOL irqLine;
+@property(nonatomic) BOOL waitLine;
 
 @end

--- a/OSBindings/Mac/Clock SignalTests/Bridges/TestMachineZ80.mm
+++ b/OSBindings/Mac/Clock SignalTests/Bridges/TestMachineZ80.mm
@@ -167,6 +167,11 @@ static CPU::Z80::Register registerForRegister(CSTestMachineZ80Register reg) {
 	_processor->set_interrupt_line(irqLine ? true : false);
 }
 
+- (void)setWaitLine:(BOOL)waitLine {
+	_waitLine = waitLine;
+	_processor->set_wait_line(waitLine ? true : false);
+}
+
 - (CPU::AllRAMProcessor *)processor {
 	return _processor;
 }

--- a/Processors/Z80/Z80.hpp
+++ b/Processors/Z80/Z80.hpp
@@ -803,12 +803,15 @@ template <class T> class Processor {
 			assemble_fetch_decode_execute(ddcb_page_, 3);
 
 			MicroOp reset_program[] = Sequence(InternalOperation(3), {MicroOp::Reset});
+
+			// Justification for NMI timing: per Wilf Rigter on the ZX81 (http://www.user.dccnet.com/wrigter/index_files/ZX81WAIT.htm),
+			// wait cycles occur between T2 and T3 during NMI; extending the refresh cycle is also consistent with my guess
+			// for the action of other non-four-cycle opcode fetches
 			MicroOp nmi_program[] = {
 				{ MicroOp::BeginNMI },
 				BusOp(ReadOpcodeStart()),
-				BusOp(ReadOpcodeWait(1, false)),
 				BusOp(ReadOpcodeWait(1, true)),
-				BusOp(Refresh(2)),
+				BusOp(Refresh(3)),
 				Push(pc_),
 				{ MicroOp::JumpTo66, nullptr, nullptr},
 				{ MicroOp::MoveToNextProgram }

--- a/Processors/Z80/Z80AllRAM.cpp
+++ b/Processors/Z80/Z80AllRAM.cpp
@@ -90,6 +90,10 @@ class ConcreteAllRAMProcessor: public AllRAMProcessor, public Processor<Concrete
 		void set_non_maskable_interrupt_line(bool value) {
 			CPU::Z80::Processor<ConcreteAllRAMProcessor>::set_non_maskable_interrupt_line(value);
 		}
+
+		void set_wait_line(bool value) {
+			CPU::Z80::Processor<ConcreteAllRAMProcessor>::set_wait_line(value);
+		}
 };
 
 }

--- a/Processors/Z80/Z80AllRAM.hpp
+++ b/Processors/Z80/Z80AllRAM.hpp
@@ -33,8 +33,10 @@ class AllRAMProcessor:
 		virtual void set_value_of_register(Register r, uint16_t value) = 0;
 		virtual bool get_halt_line() = 0;
 		virtual void reset_power_on() = 0;
+
 		virtual void set_interrupt_line(bool value) = 0;
 		virtual void set_non_maskable_interrupt_line(bool value) = 0;
+		virtual void set_wait_line(bool value) = 0;
 
 	protected:
 		MemoryAccessDelegate *delegate_;


### PR DESCRIPTION
… and adjusts the Z80 to pass it.

Proper wait cycle location is cribbed from information posted by Wilf Rigter; as per comment it's also potentially helpful in making me more confident about those long opcode fetches.

Effect on the ZX81 is to eliminate the remaining timing misstep: there's no more maladjusted hsync now.