### PR TITLE
Increases port decoding on the ZX81

### DIFF
--- a/Machines/ZX8081/ZX8081.cpp
+++ b/Machines/ZX8081/ZX8081.cpp
@@ -109,9 +109,11 @@ int Machine::perform_machine_cycle(const CPU::Z80::PartialMachineCycle &cycle) {
 			}
 			if(latched_video_byte_) {
 				size_t char_address = (size_t)((address & 0xff00) | ((latched_video_byte_ & 0x3f) << 3) | line_counter_);
+				uint8_t mask = (latched_video_byte_ & 0x80) ? 0x00 : 0xff;
 				if(char_address < ram_base_) {
-					uint8_t mask = (latched_video_byte_ & 0x80) ? 0x00 : 0xff;
 					latched_video_byte_ = rom_[char_address & rom_mask_] ^ mask;
+				} else {
+					latched_video_byte_ = ram_[address & ram_mask_] ^ mask;
 				}
 
 				video_->output_byte(latched_video_byte_);

--- a/OSBindings/Mac/Clock Signal.xcodeproj/xcshareddata/xcschemes/Clock Signal.xcscheme
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/xcshareddata/xcschemes/Clock Signal.xcscheme
@@ -68,13 +68,14 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      enableAddressSanitizer = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "NO">
       <BuildableProductRunnable


### PR DESCRIPTION
Also blocks access to programmatic sync while the NMI generator is enabled. Both of these I currently believe to be accurate.

Also toggles the Xcode project to run as debug, with the address sanitiser. Which really should be the only configuration I commit.