### PR TITLE
Corrects a potential invalid memory dereference in the default typer implementation

### DIFF
--- a/Machines/Typer.cpp
+++ b/Machines/Typer.cpp
@@ -15,7 +15,7 @@ Typer::Typer(const char *string, int delay, int frequency, Delegate *delegate) :
 		counter_(-delay), frequency_(frequency), string_pointer_(0), delegate_(delegate), phase_(0) {
 	size_t string_size = strlen(string) + 3;
 	string_ = (char *)malloc(string_size);
-	snprintf(string_, strlen(string) + 3, "%c%s%c", Typer::BeginString, string, Typer::EndString);
+	snprintf(string_, string_size, "%c%s%c", Typer::BeginString, string, Typer::EndString);
 }
 
 void Typer::update(int duration) {

--- a/Machines/Typer.hpp
+++ b/Machines/Typer.hpp
@@ -51,7 +51,6 @@ class TypeRecipient: public Typer::Delegate {
 
 		void typer_reset(Typer *typer) {
 			clear_all_keys();
-			typer_.reset();
 		}
 
 	protected:


### PR DESCRIPTION
Specifically resulting from a delegate freeing its caller.