### PR TITLE
Corrects a source of potential desynchronisation between the texture and geometry builders

### DIFF
--- a/Components/6560/6560.hpp
+++ b/Components/6560/6560.hpp
@@ -259,7 +259,7 @@ template <class T> class MOS6560 {
 				if(this_state_ != output_state_) {
 					switch(output_state_) {
 						case State::Sync:			crt_->output_sync(cycles_in_state_ * 4);														break;
-						case State::ColourBurst:	crt_->output_colour_burst(cycles_in_state_ * 4, (is_odd_frame_ || is_odd_line_) ? 128 : 0, 0);	break;
+						case State::ColourBurst:	crt_->output_colour_burst(cycles_in_state_ * 4, (is_odd_frame_ || is_odd_line_) ? 128 : 0);		break;
 						case State::Border:			output_border(cycles_in_state_ * 4);															break;
 						case State::Pixels:			crt_->output_data(cycles_in_state_ * 4, 1);														break;
 					}

--- a/Outputs/CRT/CRT.cpp
+++ b/Outputs/CRT/CRT.cpp
@@ -140,12 +140,12 @@ void CRT::advance_cycles(unsigned int number_of_cycles, bool hsync_requested, bo
 		bool is_output_segment = ((is_output_run && next_run_length) && !horizontal_flywheel_->is_in_retrace() && !vertical_flywheel_->is_in_retrace());
 		uint8_t *next_run = nullptr;
 		if(is_output_segment && !openGL_output_builder_.composite_output_buffer_is_full()) {
-			openGL_output_builder_.texture_builder.retain_latest();
 			next_run = openGL_output_builder_.array_builder.get_input_storage(SourceVertexSize);
 		}
 
 		if(next_run) {
 			// output_y and texture locations will be written later; we won't necessarily know what it is outside of the locked region
+			openGL_output_builder_.texture_builder.retain_latest();
 			source_output_position_x1() = (uint16_t)horizontal_flywheel_->get_current_output_position();
 			source_phase() = colour_burst_phase_;
 			source_amplitude() = colour_burst_amplitude_;

--- a/Outputs/CRT/CRT.cpp
+++ b/Outputs/CRT/CRT.cpp
@@ -8,9 +8,10 @@
 
 #include "CRT.hpp"
 #include "CRTOpenGL.hpp"
-#include <stdarg.h>
-#include <math.h>
+#include <cstdarg>
+#include <cmath>
 #include <algorithm>
+#include <cassert>
 
 using namespace Outputs::CRT;
 
@@ -194,7 +195,8 @@ void CRT::advance_cycles(unsigned int number_of_cycles, bool hsync_requested, bo
 					openGL_output_builder_.array_builder.flush(
 						[output_y, this] (uint8_t *input_buffer, size_t input_size, uint8_t *output_buffer, size_t output_size) {
 							openGL_output_builder_.texture_builder.flush(
-								[output_y, input_buffer] (const std::vector<TextureBuilder::WriteArea> &write_areas, size_t number_of_write_areas) {
+								[=] (const std::vector<TextureBuilder::WriteArea> &write_areas, size_t number_of_write_areas) {
+									assert(number_of_write_areas == input_size * SourceVertexSize);
 									for(size_t run = 0; run < number_of_write_areas; run++) {
 										*(uint16_t *)&input_buffer[run * SourceVertexSize + SourceVertexOffsetOfInputStart + 0] = write_areas[run].x;
 										*(uint16_t *)&input_buffer[run * SourceVertexSize + SourceVertexOffsetOfInputStart + 2] = write_areas[run].y;

--- a/Outputs/CRT/CRT.cpp
+++ b/Outputs/CRT/CRT.cpp
@@ -194,7 +194,7 @@ void CRT::advance_cycles(unsigned int number_of_cycles, bool hsync_requested, bo
 						output_x2() = (uint16_t)horizontal_flywheel_->get_current_output_position();
 					}
 					openGL_output_builder_.array_builder.flush(
-						[output_y, this] (uint8_t *input_buffer, size_t input_size, uint8_t *output_buffer, size_t output_size) {
+						[=] (uint8_t *input_buffer, size_t input_size, uint8_t *output_buffer, size_t output_size) {
 							openGL_output_builder_.texture_builder.flush(
 								[=] (const std::vector<TextureBuilder::WriteArea> &write_areas, size_t number_of_write_areas) {
 									assert(number_of_write_areas * SourceVertexSize == input_size);
@@ -333,13 +333,7 @@ void CRT::output_colour_burst(unsigned int number_of_cycles, uint8_t phase, uint
 }
 
 void CRT::output_default_colour_burst(unsigned int number_of_cycles) {
-	Scan scan {
-		.type = Scan::Type::ColourBurst,
-		.number_of_cycles = number_of_cycles,
-		.phase = (uint8_t)((phase_numerator_ * 256) / phase_denominator_ + (is_alernate_line_ ? 128 : 0)),
-		.amplitude = 32
-	};
-	output_scan(&scan);
+	output_colour_burst(number_of_cycles, (uint8_t)((phase_numerator_ * 256) / phase_denominator_ + (is_alernate_line_ ? 128 : 0)));
 }
 
 void CRT::output_data(unsigned int number_of_cycles, unsigned int source_divider) {

--- a/Outputs/CRT/CRT.hpp
+++ b/Outputs/CRT/CRT.hpp
@@ -187,7 +187,7 @@ class CRT {
 			@param amplitude The amplitude of the colour burst in 1/256ths of the amplitude of the
 			positive portion of the wave.
 		*/
-		void output_colour_burst(unsigned int number_of_cycles, uint8_t phase, uint8_t amplitude);
+		void output_colour_burst(unsigned int number_of_cycles, uint8_t phase, uint8_t amplitude = 102);
 
 		/*! Outputs a colour burst exactly in phase with CRT expectations using the idiomatic amplitude.
 

--- a/Outputs/CRT/Internals/TextureBuilder.cpp
+++ b/Outputs/CRT/Internals/TextureBuilder.cpp
@@ -39,7 +39,6 @@ TextureBuilder::TextureBuilder(size_t bytes_per_pixel, GLenum texture_unit) :
 		write_areas_start_y_(0),
 		is_full_(false),
 		did_submit_(false),
-		has_write_area_(false),
 		number_of_write_areas_(0) {
 	image_.resize(bytes_per_pixel * InputBufferBuilderWidth * InputBufferBuilderHeight);
 	glGenTextures(1, &texture_name_);
@@ -87,7 +86,6 @@ uint8_t *TextureBuilder::allocate_write_area(size_t required_length) {
 	write_area_.x = starting_x + 1;
 	write_area_.y = starting_y;
 	write_area_.length = (uint16_t)required_length;
-	has_write_area_ = true;
 
 	return pointer_to_location(write_area_.x, write_area_.y);
 }
@@ -97,17 +95,16 @@ bool TextureBuilder::is_full() {
 }
 
 void TextureBuilder::retain_latest() {
-	if(is_full_ || !has_write_area_) return;
+	if(is_full_) return;
 	if(number_of_write_areas_ < write_areas_.size())
 		write_areas_[number_of_write_areas_] = write_area_;
 	else
 		write_areas_.push_back(write_area_);
 	number_of_write_areas_++;
-	has_write_area_ = false;
 }
 
 void TextureBuilder::reduce_previous_allocation_to(size_t actual_length) {
-	if(is_full_ || !has_write_area_) return;
+	if(is_full_) return;
 
 	write_area_.length = (uint16_t)actual_length;
 
@@ -174,6 +171,5 @@ void TextureBuilder::flush(const std::function<void(const std::vector<WriteArea>
 	}
 
 	did_submit_ = false;
-	has_write_area_ = false;
 	number_of_write_areas_ = 0;
 }

--- a/Outputs/CRT/Internals/TextureBuilder.hpp
+++ b/Outputs/CRT/Internals/TextureBuilder.hpp
@@ -101,7 +101,6 @@ class TextureBuilder {
 		size_t number_of_write_areas_;
 		bool is_full_;
 		bool did_submit_;
-		bool has_write_area_;
 		inline uint8_t *pointer_to_location(uint16_t x, uint16_t y);
 
 		// Usually: the start position for the current batch of write areas.


### PR DESCRIPTION
That desynchronisation potentially leading to out-of-bounds buffer accesses. Adds an assert on synchronisation to catch potential future errors.

Also codifies a standard definition of colour subcarrier amplitude, at 40 IRE.