### PR TITLE
Corrects various ZX80/81 video deficiencies

### DIFF
--- a/Machines/ZX8081/Video.cpp
+++ b/Machines/ZX8081/Video.cpp
@@ -76,6 +76,7 @@ void Video::set_sync(bool sync) {
 
 void Video::output_byte(uint8_t byte) {
 	// Complete whatever was going on.
+	if(sync_) return;
 	flush();
 
 	// Grab a buffer if one isn't already available.

--- a/Machines/ZX8081/ZX8081.cpp
+++ b/Machines/ZX8081/ZX8081.cpp
@@ -77,11 +77,9 @@ int Machine::perform_machine_cycle(const CPU::Z80::PartialMachineCycle &cycle) {
 		case CPU::Z80::PartialMachineCycle::Output:
 			if(!(address & 2)) nmi_is_enabled_ = false;
 			if(!(address & 1)) nmi_is_enabled_ = is_zx81_;
-			if((address&3) == 3) {
-				if(!nmi_is_enabled_) {
-					set_vsync(false);
-					line_counter_ = 0;
-				}
+			if((address&3) == 3) line_counter_ = 0;
+			if(!nmi_is_enabled_) {
+				set_vsync(false);
 			}
 		break;
 

--- a/Machines/ZX8081/ZX8081.cpp
+++ b/Machines/ZX8081/ZX8081.cpp
@@ -113,7 +113,7 @@ int Machine::perform_machine_cycle(const CPU::Z80::PartialMachineCycle &cycle) {
 				set_interrupt_line(false);
 			}
 			if(latched_video_byte_) {
-				size_t char_address = (size_t)((address & 0xff00) | ((latched_video_byte_ & 0x3f) << 3) | line_counter_);
+				size_t char_address = (size_t)((address & 0xfe00) | ((latched_video_byte_ & 0x3f) << 3) | line_counter_);
 				uint8_t mask = (latched_video_byte_ & 0x80) ? 0x00 : 0xff;
 				if(char_address < ram_base_) {
 					latched_video_byte_ = rom_[char_address & rom_mask_] ^ mask;
@@ -156,7 +156,7 @@ int Machine::perform_machine_cycle(const CPU::Z80::PartialMachineCycle &cycle) {
 				uint8_t value = ram_[address & ram_mask_];
 
 				// If this is an M1 cycle reading from above the 32kb mark and HALT is not
-				// currently active, perform a video output and return a NOP. Otherwise,
+				// currently active, latch for video output and return a NOP. Otherwise,
 				// just return the value as read.
 				if(is_opcode_read && address&0x8000 && !(value & 0x40) && !get_halt_line()) {
 					latched_video_byte_ = value;

--- a/Machines/ZX8081/ZX8081.cpp
+++ b/Machines/ZX8081/ZX8081.cpp
@@ -77,8 +77,10 @@ int Machine::perform_machine_cycle(const CPU::Z80::PartialMachineCycle &cycle) {
 		case CPU::Z80::PartialMachineCycle::Output:
 			if(!(address & 2)) nmi_is_enabled_ = false;
 			if(!(address & 1)) nmi_is_enabled_ = is_zx81_;
-			if((address&3) == 3) line_counter_ = 0;
 			if(!nmi_is_enabled_) {
+				// Line counter reset is held low while vsync is active; simulate that lazily by performing
+				// an instant reset upon the transition from active to inactive.
+				if(vsync_) line_counter_ = 0;
 				set_vsync(false);
 			}
 		break;

--- a/Machines/ZX8081/ZX8081.hpp
+++ b/Machines/ZX8081/ZX8081.hpp
@@ -98,7 +98,9 @@ class Machine:
 		bool is_zx81_;
 		bool nmi_is_enabled_;
 		int vsync_start_cycle_, vsync_end_cycle_;
+
 		uint8_t latched_video_byte_;
+		bool has_latched_video_byte_;
 
 		bool use_fast_tape_hack_;
 		bool use_automatic_tape_motor_control_;


### PR DESCRIPTION
Including:
* accidental ORing of bit 8 of the refresh address with the character value;
* reliance on the latched value, rather than merely its existence, in determining whether pixels are outgoing;
* accidental queuing of pixel data during times of sync;
* an incorrect end-of-sync trigger; and
* failure properly to model line counter reset as held during programmatic sync if the running program signals end of sync multiple times.