### PR TITLE
Corrects accounting errors in ZX80/81 video

### DIFF
--- a/Outputs/CRT/CRT.cpp
+++ b/Outputs/CRT/CRT.cpp
@@ -143,6 +143,9 @@ void CRT::advance_cycles(unsigned int number_of_cycles, bool hsync_requested, bo
 			bool did_retain_source_data = openGL_output_builder_.texture_builder.retain_latest();
 			if(did_retain_source_data) {
 				next_run = openGL_output_builder_.array_builder.get_input_storage(SourceVertexSize);
+				if(!next_run) {
+					openGL_output_builder_.texture_builder.discard_latest();
+				}
 			}
 		}
 

--- a/Outputs/CRT/Internals/TextureBuilder.cpp
+++ b/Outputs/CRT/Internals/TextureBuilder.cpp
@@ -128,6 +128,11 @@ bool TextureBuilder::retain_latest() {
 	return true;
 }
 
+void TextureBuilder::discard_latest() {
+	if(was_full_) return;
+	number_of_write_areas_--;
+}
+
 bool TextureBuilder::is_full() {
 	return is_full_;
 }

--- a/Outputs/CRT/Internals/TextureBuilder.hpp
+++ b/Outputs/CRT/Internals/TextureBuilder.hpp
@@ -79,6 +79,9 @@ class TextureBuilder {
 		/// @returns @c true if a retain succeeded; @c false otherwise.
 		bool retain_latest();
 
+		// Undoes the most recent retain_latest. Undefined behaviour if a submission has occurred in the interim.
+		void discard_latest();
+
 		/// @returns @c true if all future calls to @c allocate_write_area will fail on account of the input texture
 		/// being full; @c false if calls may succeed.
 		bool is_full();


### PR DESCRIPTION
Particularly those that could lead to 'negative' (i.e. very large) run timings.

Also adds a further texture/geometry tie, by ensuring that lack of available geometry acts post hoc to remove a submitted write area from the texture.