### PR TITLE
Adds partial TZX file format support

### DIFF
--- a/Machines/ZX8081/ZX8081.cpp
+++ b/Machines/ZX8081/ZX8081.cpp
@@ -24,11 +24,8 @@ Machine::Machine() :
 	tape_player_(ZX8081ClockRate),
 	use_fast_tape_hack_(false),
 	tape_advance_delay_(0),
-	tape_is_automatically_playing_(false),
-	tape_is_playing_(false),
 	has_latched_video_byte_(false) {
 	set_clock_rate(ZX8081ClockRate);
-	tape_player_.set_motor_control(true);
 	clear_all_keys();
 }
 
@@ -58,7 +55,7 @@ int Machine::perform_machine_cycle(const CPU::Z80::PartialMachineCycle &cycle) {
 
 	if(is_zx81_) horizontal_counter_ %= 207;
 	if(!tape_advance_delay_) {
-		if(tape_is_automatically_playing_ || tape_is_playing_) tape_player_.run_for_cycles(cycle.length);
+		tape_player_.run_for_cycles(cycle.length);
 	} else {
 		tape_advance_delay_ = std::max(tape_advance_delay_ - cycle.length, 0);
 	}
@@ -152,7 +149,9 @@ int Machine::perform_machine_cycle(const CPU::Z80::PartialMachineCycle &cycle) {
 			}
 
 			// Check for automatic tape control.
-			tape_is_automatically_playing_ = use_automatic_tape_motor_control_ && (address >= automatic_tape_motor_start_address_) && (address < automatic_tape_motor_end_address_);
+			if(use_automatic_tape_motor_control_) {
+				tape_player_.set_motor_control((address >= automatic_tape_motor_start_address_) && (address < automatic_tape_motor_end_address_));
+			}
 			is_opcode_read = true;
 
 		case CPU::Z80::PartialMachineCycle::Read:

--- a/Machines/ZX8081/ZX8081.cpp
+++ b/Machines/ZX8081/ZX8081.cpp
@@ -130,7 +130,7 @@ int Machine::perform_machine_cycle(const CPU::Z80::PartialMachineCycle &cycle) {
 		case CPU::Z80::PartialMachineCycle::ReadOpcodeWait:
 			// Check for use of the fast tape hack.
 			if(use_fast_tape_hack_ && address == tape_trap_address_ && tape_player_.has_tape()) {
-				Storage::Time time = tape_player_.get_tape()->get_current_time();
+				uint64_t prior_offset = tape_player_.get_tape()->get_offset();
 				int next_byte = parser_.get_next_byte(tape_player_.get_tape());
 				if(next_byte != -1) {
 					uint16_t hl = get_value_of_register(CPU::Z80::Register::HL);
@@ -144,7 +144,7 @@ int Machine::perform_machine_cycle(const CPU::Z80::PartialMachineCycle &cycle) {
 					tape_advance_delay_ = 1000;
 					return 0;
 				} else {
-					tape_player_.get_tape()->seek(time);
+					tape_player_.get_tape()->set_offset(prior_offset);
 				}
 			}
 

--- a/Machines/ZX8081/ZX8081.hpp
+++ b/Machines/ZX8081/ZX8081.hpp
@@ -69,9 +69,11 @@ class Machine:
 		inline void set_use_fast_tape_hack(bool activate) { use_fast_tape_hack_ = activate; }
 		inline void set_use_automatic_tape_motor_control(bool enabled) {
 			use_automatic_tape_motor_control_ = enabled;
-			if(!enabled) tape_is_automatically_playing_ = false;
+			if(!enabled) {
+				tape_player_.set_motor_control(false);
+			}
 		}
-		inline void set_tape_is_playing(bool is_playing) { tape_is_playing_ = is_playing; }
+		inline void set_tape_is_playing(bool is_playing) { tape_player_.set_motor_control(is_playing); }
 
 		// for Utility::TypeRecipient::Delegate
 		uint16_t *sequence_for_character(Utility::Typer *typer, char character);
@@ -113,7 +115,6 @@ class Machine:
 
 		bool use_fast_tape_hack_;
 		bool use_automatic_tape_motor_control_;
-		bool tape_is_playing_, tape_is_automatically_playing_;
 		int tape_advance_delay_;
 };
 

--- a/NumberTheory/Factors.hpp
+++ b/NumberTheory/Factors.hpp
@@ -9,15 +9,15 @@
 #ifndef Factors_hpp
 #define Factors_hpp
 
+#include <utility>
+
 namespace NumberTheory {
 	/*!
 		@returns The greatest common divisor of @c a and @c b as computed by Euclid's algorithm.
 	*/
 	template<class T> T greatest_common_divisor(T a, T b) {
 		if(a < b) {
-			T swap = b;
-			b = a;
-			a = swap;
+			std::swap(a, b);
 		}
 
 		while(1) {

--- a/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		4B3BF5B01F146265005B6C36 /* CSW.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B3BF5AE1F146264005B6C36 /* CSW.cpp */; };
 		4B3F1B461E0388D200DB26EE /* PCMPatchedTrack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B3F1B441E0388D200DB26EE /* PCMPatchedTrack.cpp */; };
 		4B448E811F1C45A00009ABD6 /* TZX.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B448E7F1F1C45A00009ABD6 /* TZX.cpp */; };
+		4B448E841F1C4C480009ABD6 /* PulseQueuedTape.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B448E821F1C4C480009ABD6 /* PulseQueuedTape.cpp */; };
 		4B44EBF51DC987AF00A7820C /* AllSuiteA.bin in Resources */ = {isa = PBXBuildFile; fileRef = 4B44EBF41DC987AE00A7820C /* AllSuiteA.bin */; };
 		4B44EBF71DC9883B00A7820C /* 6502_functional_test.bin in Resources */ = {isa = PBXBuildFile; fileRef = 4B44EBF61DC9883B00A7820C /* 6502_functional_test.bin */; };
 		4B44EBF91DC9898E00A7820C /* BCDTEST_beeb in Resources */ = {isa = PBXBuildFile; fileRef = 4B44EBF81DC9898E00A7820C /* BCDTEST_beeb */; };
@@ -547,6 +548,8 @@
 		4B3F1B451E0388D200DB26EE /* PCMPatchedTrack.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = PCMPatchedTrack.hpp; sourceTree = "<group>"; };
 		4B448E7F1F1C45A00009ABD6 /* TZX.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TZX.cpp; sourceTree = "<group>"; };
 		4B448E801F1C45A00009ABD6 /* TZX.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = TZX.hpp; sourceTree = "<group>"; };
+		4B448E821F1C4C480009ABD6 /* PulseQueuedTape.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PulseQueuedTape.cpp; sourceTree = "<group>"; };
+		4B448E831F1C4C480009ABD6 /* PulseQueuedTape.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = PulseQueuedTape.hpp; sourceTree = "<group>"; };
 		4B44EBF41DC987AE00A7820C /* AllSuiteA.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; name = AllSuiteA.bin; path = AllSuiteA/AllSuiteA.bin; sourceTree = "<group>"; };
 		4B44EBF61DC9883B00A7820C /* 6502_functional_test.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; name = 6502_functional_test.bin; path = "Klaus Dormann/6502_functional_test.bin"; sourceTree = "<group>"; };
 		4B44EBF81DC9898E00A7820C /* BCDTEST_beeb */ = {isa = PBXFileReference; lastKnownFileType = file; name = BCDTEST_beeb; path = BCDTest/BCDTEST_beeb; sourceTree = "<group>"; };
@@ -1391,6 +1394,8 @@
 			children = (
 				4B69FB411C4D941400B5F0AA /* Formats */,
 				4B8805F11DCFC9A2003085B1 /* Parsers */,
+				4B448E821F1C4C480009ABD6 /* PulseQueuedTape.cpp */,
+				4B448E831F1C4C480009ABD6 /* PulseQueuedTape.hpp */,
 				4B69FB3B1C4D908A00B5F0AA /* Tape.cpp */,
 				4B69FB3C1C4D908A00B5F0AA /* Tape.hpp */,
 			);
@@ -2580,6 +2585,7 @@
 				4BC9DF4F1D04691600F44158 /* 6560.cpp in Sources */,
 				4B59199C1DAC6C46005BB85C /* OricTAP.cpp in Sources */,
 				4BB697CE1D4BA44400248BDF /* CommodoreGCR.cpp in Sources */,
+				4B448E841F1C4C480009ABD6 /* PulseQueuedTape.cpp in Sources */,
 				4BD4A8CD1E077E8A0020D856 /* PCMSegment.cpp in Sources */,
 				4BD14B111D74627C0088EAD6 /* StaticAnalyser.cpp in Sources */,
 				4BBF99151C8FBA6F0075DAFB /* CRTOpenGL.cpp in Sources */,

--- a/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		4B3BA0D11D318B44005DD7A7 /* TestMachine6502.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4B3BA0CD1D318B44005DD7A7 /* TestMachine6502.mm */; };
 		4B3BF5B01F146265005B6C36 /* CSW.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B3BF5AE1F146264005B6C36 /* CSW.cpp */; };
 		4B3F1B461E0388D200DB26EE /* PCMPatchedTrack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B3F1B441E0388D200DB26EE /* PCMPatchedTrack.cpp */; };
+		4B448E811F1C45A00009ABD6 /* TZX.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B448E7F1F1C45A00009ABD6 /* TZX.cpp */; };
 		4B44EBF51DC987AF00A7820C /* AllSuiteA.bin in Resources */ = {isa = PBXBuildFile; fileRef = 4B44EBF41DC987AE00A7820C /* AllSuiteA.bin */; };
 		4B44EBF71DC9883B00A7820C /* 6502_functional_test.bin in Resources */ = {isa = PBXBuildFile; fileRef = 4B44EBF61DC9883B00A7820C /* 6502_functional_test.bin */; };
 		4B44EBF91DC9898E00A7820C /* BCDTEST_beeb in Resources */ = {isa = PBXBuildFile; fileRef = 4B44EBF81DC9898E00A7820C /* BCDTEST_beeb */; };
@@ -544,6 +545,8 @@
 		4B3BF5AF1F146264005B6C36 /* CSW.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = CSW.hpp; sourceTree = "<group>"; };
 		4B3F1B441E0388D200DB26EE /* PCMPatchedTrack.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PCMPatchedTrack.cpp; sourceTree = "<group>"; };
 		4B3F1B451E0388D200DB26EE /* PCMPatchedTrack.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = PCMPatchedTrack.hpp; sourceTree = "<group>"; };
+		4B448E7F1F1C45A00009ABD6 /* TZX.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TZX.cpp; sourceTree = "<group>"; };
+		4B448E801F1C45A00009ABD6 /* TZX.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = TZX.hpp; sourceTree = "<group>"; };
 		4B44EBF41DC987AE00A7820C /* AllSuiteA.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; name = AllSuiteA.bin; path = AllSuiteA/AllSuiteA.bin; sourceTree = "<group>"; };
 		4B44EBF61DC9883B00A7820C /* 6502_functional_test.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; name = 6502_functional_test.bin; path = "Klaus Dormann/6502_functional_test.bin"; sourceTree = "<group>"; };
 		4B44EBF81DC9898E00A7820C /* BCDTEST_beeb */ = {isa = PBXFileReference; lastKnownFileType = file; name = BCDTEST_beeb; path = BCDTest/BCDTEST_beeb; sourceTree = "<group>"; };
@@ -1402,12 +1405,14 @@
 				4B59199A1DAC6C46005BB85C /* OricTAP.cpp */,
 				4B2BFC5D1D613E0200BA3AA9 /* TapePRG.cpp */,
 				4B69FB421C4D941400B5F0AA /* TapeUEF.cpp */,
+				4B448E7F1F1C45A00009ABD6 /* TZX.cpp */,
 				4B1497861EE4A1DA00CE2596 /* ZX80O81P.cpp */,
 				4BC91B821D1F160E00884B76 /* CommodoreTAP.hpp */,
 				4B3BF5AF1F146264005B6C36 /* CSW.hpp */,
 				4B59199B1DAC6C46005BB85C /* OricTAP.hpp */,
 				4B2BFC5E1D613E0200BA3AA9 /* TapePRG.hpp */,
 				4B69FB431C4D941400B5F0AA /* TapeUEF.hpp */,
+				4B448E801F1C45A00009ABD6 /* TZX.hpp */,
 				4B1497871EE4A1DA00CE2596 /* ZX80O81P.hpp */,
 				4B69FB451C4D950F00B5F0AA /* libz.tbd */,
 			);
@@ -2605,6 +2610,7 @@
 				4B7913CC1DFCD80E00175A82 /* Video.cpp in Sources */,
 				4B2A53A11D117D36003C6002 /* CSAtari2600.mm in Sources */,
 				4BF829661D8F732B001BAE39 /* Disk.cpp in Sources */,
+				4B448E811F1C45A00009ABD6 /* TZX.cpp in Sources */,
 				4BEA52631DF339D7007E74F2 /* Speaker.cpp in Sources */,
 				4BC5E4921D7ED365008CF980 /* StaticAnalyser.cpp in Sources */,
 				4BC830D11D6E7C690000A26F /* Tape.cpp in Sources */,

--- a/OSBindings/Mac/Clock Signal/Info.plist
+++ b/OSBindings/Mac/Clock Signal/Info.plist
@@ -212,6 +212,20 @@
 			<key>NSDocumentClass</key>
 			<string>$(PRODUCT_MODULE_NAME).MachineDocument</string>
 		</dict>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>tzx</string>
+			</array>
+			<key>CFBundleTypeIconFile</key>
+			<string>cassette</string>
+			<key>CFBundleTypeName</key>
+			<string>Tape Image</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>NSDocumentClass</key>
+			<string>$(PRODUCT_MODULE_NAME).MachineDocument</string>
+		</dict>
 	</array>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>

--- a/StaticAnalyser/StaticAnalyser.cpp
+++ b/StaticAnalyser/StaticAnalyser.cpp
@@ -34,6 +34,7 @@
 #include "../Storage/Tape/Formats/OricTAP.hpp"
 #include "../Storage/Tape/Formats/TapePRG.hpp"
 #include "../Storage/Tape/Formats/TapeUEF.hpp"
+#include "../Storage/Tape/Formats/TZX.hpp"
 #include "../Storage/Tape/Formats/ZX80O81P.hpp"
 
 typedef int TargetPlatformType;
@@ -124,6 +125,7 @@ std::list<Target> StaticAnalyser::GetTargets(const char *file_name)
 		Format("ssd", disks, Disk::SSD, TargetPlatform::Acorn)						// SSD
 		Format("tap", tapes, Tape::CommodoreTAP, TargetPlatform::Commodore)			// TAP (Commodore)
 		Format("tap", tapes, Tape::OricTAP, TargetPlatform::Oric)					// TAP (Oric)
+		Format("tzx", tapes, Tape::TZX, TargetPlatform::ZX8081)						// TZX
 		Format("uef", tapes, Tape::UEF, TargetPlatform::Acorn)						// UEF (tape)
 
 #undef Format

--- a/StaticAnalyser/ZX8081/StaticAnalyser.cpp
+++ b/StaticAnalyser/ZX8081/StaticAnalyser.cpp
@@ -40,9 +40,9 @@ void StaticAnalyser::ZX8081::AddTargets(
 			StaticAnalyser::Target target;
 			target.machine = Target::ZX8081;
 			target.zx8081.isZX81 = files.front().isZX81;
-			if(files.front().data.size() > 16384) {
+			/*if(files.front().data.size() > 16384) {
 				target.zx8081.memory_model = ZX8081MemoryModel::SixtyFourKB;
-			} else if(files.front().data.size() > 1024) {
+			} else*/ if(files.front().data.size() > 1024) {
 				target.zx8081.memory_model = ZX8081MemoryModel::SixteenKB;
 			} else {
 				target.zx8081.memory_model = ZX8081MemoryModel::Unexpanded;

--- a/Storage/Data/ZX8081.cpp
+++ b/Storage/Data/ZX8081.cpp
@@ -50,8 +50,10 @@ static std::shared_ptr<File> ZX81FileFromData(const std::vector<uint8_t> &data) 
 
 	// Look for a file name.
 	size_t data_pointer = 0;
+	std::vector<uint8_t> name_data;
 	int c = 11;
 	while(c < data.size() && c--) {
+		name_data.push_back(data[data_pointer] & 0x3f);
 		if(data[data_pointer] & 0x80) break;
 		data_pointer++;
 	}
@@ -80,6 +82,7 @@ static std::shared_ptr<File> ZX81FileFromData(const std::vector<uint8_t> &data) 
 	// TODO: check that the line numbers declared above exist (?)
 
 	std::shared_ptr<File> file(new File);
+	file->name = StringFromData(name_data, true);
 	file->data = data;
 	file->isZX81 = true;
 	return file;

--- a/Storage/Data/ZX8081.hpp
+++ b/Storage/Data/ZX8081.hpp
@@ -19,7 +19,7 @@ namespace ZX8081 {
 
 struct File {
 	std::vector<uint8_t> data;
-	std::string name;
+	std::wstring name;
 	bool isZX81;
 };
 

--- a/Storage/FileHolder.hpp
+++ b/Storage/FileHolder.hpp
@@ -71,6 +71,49 @@ class FileHolder {
 		*/
 		void ensure_file_is_at_least_length(long length);
 
+		class BitStream {
+			public:
+				BitStream(FILE *f, bool lsb_first) :
+					file_(f),
+					lsb_first_(lsb_first),
+					next_value_(0),
+					bits_remaining_(0) {}
+
+				uint8_t get_bits(int q) {
+					uint8_t result = 0;
+					while(q--) {
+						result = (uint8_t)((result << 1) | get_bit());
+					}
+					return result;
+				}
+
+			private:
+				FILE *file_;
+				bool lsb_first_;
+				uint8_t next_value_;
+				int bits_remaining_;
+
+				uint8_t get_bit() {
+					if(!bits_remaining_) {
+						bits_remaining_ = 8;
+						next_value_ = (uint8_t)fgetc(file_);
+					}
+
+					uint8_t bit;
+					if(lsb_first_) {
+						bit = next_value_ & 1;
+						next_value_ >>= 1;
+					} else {
+						bit = next_value_ >> 7;
+						next_value_ <<= 1;
+					}
+
+					bits_remaining_--;
+
+					return bit;
+				}
+		};
+
 		FILE *file_;
 		struct stat file_stats_;
 		bool is_read_only_;

--- a/Storage/Tape/Formats/CSW.cpp
+++ b/Storage/Tape/Formats/CSW.cpp
@@ -18,7 +18,7 @@ CSW::CSW(const char *file_name) :
 	// Check signature.
 	char identifier[22];
 	char signature[] = "Compressed Square Wave";
-	fread(identifier, 1, 22, file_);
+	fread(identifier, 1, strlen(signature), file_);
 	if(memcmp(identifier, signature, strlen(signature))) throw ErrorNotCSW;
 
 	// Check terminating byte.

--- a/Storage/Tape/Formats/TZX.cpp
+++ b/Storage/Tape/Formats/TZX.cpp
@@ -12,9 +12,7 @@ using namespace Storage::Tape;
 
 TZX::TZX(const char *file_name) :
 	Storage::FileHolder(file_name),
-	is_high_(false),
-	is_at_end_(false),
-	pulse_pointer_(0) {
+	is_high_(false) {
 
 	// Check for signature followed by a 0x1a
 	char identifier[7];
@@ -29,21 +27,12 @@ TZX::TZX(const char *file_name) :
 
 	// Reject if an incompatible version
 	if(major_version != 1 || minor_version > 20)  throw ErrorNotTZX;
-
-	// seed initial block contents
-	parse_next_chunk();
-}
-
-bool TZX::is_at_end() {
-	return true;
-}
-
-Tape::Pulse TZX::virtual_get_next_pulse() {
-	return Tape::Pulse();
 }
 
 void TZX::virtual_reset() {
+	clear();
+	fseek(file_, SEEK_SET, 0x0a);
 }
 
-void TZX::parse_next_chunk() {
+void TZX::get_next_pulses() {
 }

--- a/Storage/Tape/Formats/TZX.cpp
+++ b/Storage/Tape/Formats/TZX.cpp
@@ -1,0 +1,49 @@
+//
+//  TZX.cpp
+//  Clock Signal
+//
+//  Created by Thomas Harte on 16/07/2017.
+//  Copyright © 2017 Thomas Harte. All rights reserved.
+//
+
+#include "TZX.hpp"
+
+using namespace Storage::Tape;
+
+TZX::TZX(const char *file_name) :
+	Storage::FileHolder(file_name),
+	is_high_(false),
+	is_at_end_(false),
+	pulse_pointer_(0) {
+
+	// Check for signature followed by a 0x1a
+	char identifier[7];
+	char signature[] = "ZXTape!";
+	fread(identifier, 1, strlen(signature), file_);
+	if(memcmp(identifier, signature, strlen(signature))) throw ErrorNotTZX;
+	if(fgetc(file_) != 0x1a) throw ErrorNotTZX;
+
+	// Get version number
+	uint8_t major_version = (uint8_t)fgetc(file_);
+	uint8_t minor_version = (uint8_t)fgetc(file_);
+
+	// Reject if an incompatible version
+	if(major_version != 1 || minor_version > 20)  throw ErrorNotTZX;
+
+	// seed initial block contents
+	parse_next_chunk();
+}
+
+bool TZX::is_at_end() {
+	return true;
+}
+
+Tape::Pulse TZX::virtual_get_next_pulse() {
+	return Tape::Pulse();
+}
+
+void TZX::virtual_reset() {
+}
+
+void TZX::parse_next_chunk() {
+}

--- a/Storage/Tape/Formats/TZX.cpp
+++ b/Storage/Tape/Formats/TZX.cpp
@@ -35,6 +35,7 @@ TZX::TZX(const char *file_name) :
 
 void TZX::virtual_reset() {
 	clear();
+	set_is_at_end(false);
 	fseek(file_, 0x0a, SEEK_SET);
 }
 

--- a/Storage/Tape/Formats/TZX.cpp
+++ b/Storage/Tape/Formats/TZX.cpp
@@ -67,6 +67,7 @@ void TZX::get_next_pulses() {
 
 void TZX::get_generalised_data_block() {
 	uint32_t block_length = fgetc32le();
+	long endpoint = ftell(file_) + (long)block_length;
 	uint16_t pause_after_block = fgetc16le();
 
 	uint32_t total_pilot_symbols = fgetc32le();
@@ -80,6 +81,9 @@ void TZX::get_generalised_data_block() {
 	get_generalised_segment(total_pilot_symbols, maximum_pulses_per_pilot_symbol, symbols_in_pilot_table, false);
 	get_generalised_segment(total_data_symbols, maximum_pulses_per_data_symbol, symbols_in_data_table, true);
 	emplace_back(Tape::Pulse::Zero, Storage::Time((unsigned int)pause_after_block, 1000u));
+
+	// This should be unnecessary, but intends to preserve sanity.
+	fseek(file_, endpoint, SEEK_SET);
 }
 
 void TZX::get_generalised_segment(uint32_t output_symbols, uint8_t max_pulses_per_symbol, uint8_t number_of_symbols, bool is_data) {

--- a/Storage/Tape/Formats/TZX.hpp
+++ b/Storage/Tape/Formats/TZX.hpp
@@ -38,7 +38,7 @@ class TZX: public PulseQueuedTape, public Storage::FileHolder {
 		bool is_high_;
 
 		void get_generalised_data_block();
-		void get_generalised_segment(uint32_t output_symbols, uint8_t max_pulses_per_symbol, uint8_t number_of_symbols);
+		void get_generalised_segment(uint32_t output_symbols, uint8_t max_pulses_per_symbol, uint8_t number_of_symbols, bool is_data);
 };
 
 }

--- a/Storage/Tape/Formats/TZX.hpp
+++ b/Storage/Tape/Formats/TZX.hpp
@@ -35,7 +35,7 @@ class TZX: public PulseQueuedTape, public Storage::FileHolder {
 		void virtual_reset();
 		void get_next_pulses();
 
-		bool next_is_high_;
+		bool current_level_;
 
 		void get_standard_speed_data_block();
 		void get_turbo_speed_data_block();
@@ -46,6 +46,9 @@ class TZX: public PulseQueuedTape, public Storage::FileHolder {
 		void get_generalised_segment(uint32_t output_symbols, uint8_t max_pulses_per_symbol, uint8_t number_of_symbols, bool is_data);
 
 		void post_pulse(unsigned int length);
+		void post_gap(unsigned int milliseconds);
+
+		void post_pulse(const Storage::Time &time);
 };
 
 }

--- a/Storage/Tape/Formats/TZX.hpp
+++ b/Storage/Tape/Formats/TZX.hpp
@@ -9,7 +9,7 @@
 #ifndef TZX_hpp
 #define TZX_hpp
 
-#include "../Tape.hpp"
+#include "../PulseQueuedTape.hpp"
 #include "../../FileHolder.hpp"
 
 namespace Storage {
@@ -18,7 +18,7 @@ namespace Tape {
 /*!
 	Provides a @c Tape containing a CSW tape image, which is a compressed 1-bit sampling.
 */
-class TZX: public Tape, public Storage::FileHolder {
+class TZX: public PulseQueuedTape, public Storage::FileHolder {
 	public:
 		/*!
 			Constructs a @c TZX containing content from the file with name @c file_name.
@@ -31,19 +31,11 @@ class TZX: public Tape, public Storage::FileHolder {
 			ErrorNotTZX
 		};
 
-		// implemented to satisfy @c Tape
-		bool is_at_end();
-
 	private:
-		Pulse virtual_get_next_pulse();
 		void virtual_reset();
-
-//		std::vector<Pulse> queued_pulses_;
-		size_t pulse_pointer_;
-		bool is_at_end_;
+		void get_next_pulses();
 
 		bool is_high_;
-		void parse_next_chunk();
 };
 
 }

--- a/Storage/Tape/Formats/TZX.hpp
+++ b/Storage/Tape/Formats/TZX.hpp
@@ -37,8 +37,15 @@ class TZX: public PulseQueuedTape, public Storage::FileHolder {
 
 		bool is_high_;
 
+		void get_standard_speed_data_block();
+		void get_turbo_speed_data_block();
+		void get_pure_tone_data_block();
+		void get_pulse_sequence();
 		void get_generalised_data_block();
+
 		void get_generalised_segment(uint32_t output_symbols, uint8_t max_pulses_per_symbol, uint8_t number_of_symbols, bool is_data);
+
+		void post_pulse(unsigned int length);
 };
 
 }

--- a/Storage/Tape/Formats/TZX.hpp
+++ b/Storage/Tape/Formats/TZX.hpp
@@ -1,0 +1,51 @@
+//
+//  TZX.hpp
+//  Clock Signal
+//
+//  Created by Thomas Harte on 16/07/2017.
+//  Copyright © 2017 Thomas Harte. All rights reserved.
+//
+
+#ifndef TZX_hpp
+#define TZX_hpp
+
+#include "../Tape.hpp"
+#include "../../FileHolder.hpp"
+
+namespace Storage {
+namespace Tape {
+
+/*!
+	Provides a @c Tape containing a CSW tape image, which is a compressed 1-bit sampling.
+*/
+class TZX: public Tape, public Storage::FileHolder {
+	public:
+		/*!
+			Constructs a @c TZX containing content from the file with name @c file_name.
+
+			@throws ErrorNotTZX if this file could not be opened and recognised as a valid TZX file.
+		*/
+		TZX(const char *file_name);
+
+		enum {
+			ErrorNotTZX
+		};
+
+		// implemented to satisfy @c Tape
+		bool is_at_end();
+
+	private:
+		Pulse virtual_get_next_pulse();
+		void virtual_reset();
+
+//		std::vector<Pulse> queued_pulses_;
+		size_t pulse_pointer_;
+		bool is_at_end_;
+
+		bool is_high_;
+		void parse_next_chunk();
+};
+
+}
+}
+#endif /* TZX_hpp */

--- a/Storage/Tape/Formats/TZX.hpp
+++ b/Storage/Tape/Formats/TZX.hpp
@@ -36,6 +36,9 @@ class TZX: public PulseQueuedTape, public Storage::FileHolder {
 		void get_next_pulses();
 
 		bool is_high_;
+
+		void get_generalised_data_block();
+		void get_generalised_segment(uint32_t output_symbols, uint8_t max_pulses_per_symbol, uint8_t number_of_symbols);
 };
 
 }

--- a/Storage/Tape/Formats/TZX.hpp
+++ b/Storage/Tape/Formats/TZX.hpp
@@ -35,7 +35,7 @@ class TZX: public PulseQueuedTape, public Storage::FileHolder {
 		void virtual_reset();
 		void get_next_pulses();
 
-		bool is_high_;
+		bool next_is_high_;
 
 		void get_standard_speed_data_block();
 		void get_turbo_speed_data_block();

--- a/Storage/Tape/Formats/TapeUEF.hpp
+++ b/Storage/Tape/Formats/TapeUEF.hpp
@@ -9,7 +9,7 @@
 #ifndef TapeUEF_hpp
 #define TapeUEF_hpp
 
-#include "../Tape.hpp"
+#include "../PulseQueuedTape.hpp"
 #include <zlib.h>
 #include <cstdint>
 #include <vector>
@@ -20,7 +20,7 @@ namespace Tape {
 /*!
 	Provides a @c Tape containing a UEF tape image, a slightly-convoluted description of pulses.
 */
-class UEF : public Tape {
+class UEF : public PulseQueuedTape {
 	public:
 		/*!
 			Constructs a @c UEF containing content from the file with name @c file_name.
@@ -34,22 +34,14 @@ class UEF : public Tape {
 			ErrorNotUEF
 		};
 
-		// implemented to satisfy @c Tape
-		bool is_at_end();
-
 	private:
 		void virtual_reset();
-		Pulse virtual_get_next_pulse();
 
 		gzFile file_;
 		unsigned int time_base_;
-		bool is_at_end_;
 		bool is_300_baud_;
 
-		std::vector<Pulse> queued_pulses_;
-		size_t pulse_pointer_;
-
-		void parse_next_tape_chunk();
+		void get_next_pulses();
 
 		void queue_implicit_bit_pattern(uint32_t length);
 		void queue_explicit_bit_pattern(uint32_t length);

--- a/Storage/Tape/Parsers/ZX8081.cpp
+++ b/Storage/Tape/Parsers/ZX8081.cpp
@@ -29,14 +29,11 @@ void Parser::post_pulse() {
 
 	if(pulse_time > expected_gap_length * 1.25f) {
 		push_wave(WaveType::LongGap);
-	}
-	else if(pulse_time > expected_pulse_length * 1.25f) {
+	} else if(pulse_time > expected_pulse_length * 1.25f) {
 		push_wave(WaveType::Gap);
-	}
-	else if(pulse_time >= expected_pulse_length * 0.75f && pulse_time <= expected_pulse_length * 1.25f) {
+	} else if(pulse_time >= expected_pulse_length * 0.75f && pulse_time <= expected_pulse_length * 1.25f) {
 		push_wave(WaveType::Pulse);
-	}
-	else {
+	} else {
 		push_wave(WaveType::Unrecognised);
 	}
 }

--- a/Storage/Tape/Parsers/ZX8081.cpp
+++ b/Storage/Tape/Parsers/ZX8081.cpp
@@ -95,11 +95,8 @@ int Parser::get_next_byte(const std::shared_ptr<Storage::Tape::Tape> &tape) {
 	while(c--) {
 		if(is_at_end(tape)) return -1;
 		SymbolType symbol = get_next_symbol(tape);
-		if(symbol == SymbolType::FileGap) {
-			return_symbol(symbol);
-			return -1;
-		}
 		if(symbol != SymbolType::One && symbol != SymbolType::Zero) {
+			return_symbol(symbol);
 			return -1;
 		}
 		result = (result << 1) | (symbol == SymbolType::One ? 1 : 0);
@@ -110,10 +107,7 @@ int Parser::get_next_byte(const std::shared_ptr<Storage::Tape::Tape> &tape) {
 std::shared_ptr<std::vector<uint8_t>> Parser::get_next_file_data(const std::shared_ptr<Storage::Tape::Tape> &tape) {
 	if(is_at_end(tape)) return nullptr;
 	SymbolType symbol = get_next_symbol(tape);
-	if(symbol != SymbolType::FileGap) {
-		return nullptr;
-	}
-	while(symbol == SymbolType::FileGap && !is_at_end(tape)) {
+	while((symbol == SymbolType::FileGap || symbol == SymbolType::Unrecognised) && !is_at_end(tape)) {
 		symbol = get_next_symbol(tape);
 	}
 	if(is_at_end(tape)) return nullptr;

--- a/Storage/Tape/Parsers/ZX8081.cpp
+++ b/Storage/Tape/Parsers/ZX8081.cpp
@@ -13,19 +13,25 @@ using namespace Storage::Tape::ZX8081;
 Parser::Parser() : pulse_was_high_(false), pulse_time_(0) {}
 
 void Parser::process_pulse(const Storage::Tape::Tape::Pulse &pulse) {
-	pulse_time_ += pulse.length;
+	// If this is anything other than a transition from low to high, just add it to the
+	// count of time.
 	bool pulse_is_high = pulse.type == Storage::Tape::Tape::Pulse::High;
-
-	if(pulse_is_high == pulse_was_high_) return;
+	bool pulse_did_change = pulse_is_high != pulse_was_high_;
 	pulse_was_high_ = pulse_is_high;
+	if(!pulse_did_change || !pulse_is_high) {
+		pulse_time_ += pulse.length;
+		return;
+	}
+
+	// Otherwise post a new pulse.
 	post_pulse();
+	pulse_time_ = pulse.length;
 }
 
 void Parser::post_pulse() {
-	const float expected_pulse_length = 150.0f / 1000000.0f;
+	const float expected_pulse_length = 300.0f / 1000000.0f;
 	const float expected_gap_length = 1300.0f / 1000000.0f;
 	float pulse_time = pulse_time_.get_float();
-	pulse_time_.set_zero();
 
 	if(pulse_time > expected_gap_length * 1.25f) {
 		push_wave(WaveType::LongGap);
@@ -52,7 +58,7 @@ void Parser::inspect_waves(const std::vector<WaveType> &waves) {
 		return;
 	}
 
-	if(waves.size() >= 9) {
+	if(waves.size() >= 4) {
 		size_t wave_offset = 0;
 		// If the very first thing is a gap, swallow it.
 		if(waves[0] == WaveType::Gap) {
@@ -67,10 +73,7 @@ void Parser::inspect_waves(const std::vector<WaveType> &waves) {
 
 		// If those pulses were followed by a gap then they might be
 		// a recognised symbol.
-		if(number_of_pulses > 17 || number_of_pulses < 7) {
-			push_symbol(SymbolType::Unrecognised, 1);
-		}
-		else if(number_of_pulses + wave_offset < waves.size() &&
+		if(number_of_pulses + wave_offset < waves.size() &&
 			(waves[number_of_pulses + wave_offset] == WaveType::LongGap || waves[number_of_pulses + wave_offset] == WaveType::Gap)) {
 			// A 1 is 18 up/down waves, a 0 is 8. But the final down will be indistinguishable from
 			// the gap that follows the bit due to the simplified "high is high, everything else is low"
@@ -78,9 +81,9 @@ void Parser::inspect_waves(const std::vector<WaveType> &waves) {
 			// 17 and/or 7 pulses.
 			size_t gaps_to_swallow = wave_offset + ((waves[number_of_pulses + wave_offset] == WaveType::Gap) ? 1 : 0);
 			switch(number_of_pulses) {
-				case 18:	case 17:	push_symbol(SymbolType::One, (int)(number_of_pulses + gaps_to_swallow));	break;
-				case 8:		case 7:		push_symbol(SymbolType::Zero, (int)(number_of_pulses + gaps_to_swallow));	break;
-				default:	push_symbol(SymbolType::Unrecognised, 1);			break;
+				case 8:		push_symbol(SymbolType::One, (int)(number_of_pulses + gaps_to_swallow));	break;
+				case 3:		push_symbol(SymbolType::Zero, (int)(number_of_pulses + gaps_to_swallow));	break;
+				default:	push_symbol(SymbolType::Unrecognised, 1);									break;
 			}
 		}
 	}
@@ -104,6 +107,9 @@ int Parser::get_next_byte(const std::shared_ptr<Storage::Tape::Tape> &tape) {
 std::shared_ptr<std::vector<uint8_t>> Parser::get_next_file_data(const std::shared_ptr<Storage::Tape::Tape> &tape) {
 	if(is_at_end(tape)) return nullptr;
 	SymbolType symbol = get_next_symbol(tape);
+	if(symbol != SymbolType::FileGap) {
+		return nullptr;
+	}
 	while((symbol == SymbolType::FileGap || symbol == SymbolType::Unrecognised) && !is_at_end(tape)) {
 		symbol = get_next_symbol(tape);
 	}
@@ -122,6 +128,8 @@ std::shared_ptr<std::vector<uint8_t>> Parser::get_next_file_data(const std::shar
 
 std::shared_ptr<Storage::Data::ZX8081::File> Parser::get_next_file(const std::shared_ptr<Storage::Tape::Tape> &tape) {
 	std::shared_ptr<std::vector<uint8_t>> file_data = get_next_file_data(tape);
-	if(!file_data) return nullptr;
+	if(!file_data) {
+		return nullptr;
+	}
 	return Storage::Data::ZX8081::FileFromData(*file_data);
 }

--- a/Storage/Tape/Parsers/ZX8081.cpp
+++ b/Storage/Tape/Parsers/ZX8081.cpp
@@ -58,6 +58,11 @@ void Parser::inspect_waves(const std::vector<WaveType> &waves) {
 		return;
 	}
 
+	if(waves[0] == WaveType::Unrecognised) {
+		push_symbol(SymbolType::Unrecognised, 1);
+		return;
+	}
+
 	if(waves.size() >= 4) {
 		size_t wave_offset = 0;
 		// If the very first thing is a gap, swallow it.
@@ -92,14 +97,18 @@ void Parser::inspect_waves(const std::vector<WaveType> &waves) {
 int Parser::get_next_byte(const std::shared_ptr<Storage::Tape::Tape> &tape) {
 	int c = 8;
 	int result = 0;
-	while(c--) {
+	while(c) {
 		if(is_at_end(tape)) return -1;
+
 		SymbolType symbol = get_next_symbol(tape);
 		if(symbol != SymbolType::One && symbol != SymbolType::Zero) {
+			if(c == 8) continue;
 			return_symbol(symbol);
 			return -1;
 		}
+
 		result = (result << 1) | (symbol == SymbolType::One ? 1 : 0);
+		c--;
 	}
 	return result;
 }

--- a/Storage/Tape/PulseQueuedTape.cpp
+++ b/Storage/Tape/PulseQueuedTape.cpp
@@ -1,0 +1,61 @@
+//
+//  PulseQueuedTape.cpp
+//  Clock Signal
+//
+//  Created by Thomas Harte on 16/07/2017.
+//  Copyright © 2017 Thomas Harte. All rights reserved.
+//
+
+#include "PulseQueuedTape.hpp"
+
+using namespace Storage::Tape;
+
+PulseQueuedTape::PulseQueuedTape() : pulse_pointer_(0) {}
+
+bool PulseQueuedTape::is_at_end() {
+	return is_at_end_;
+}
+
+void PulseQueuedTape::set_is_at_end(bool is_at_end) {
+	is_at_end_ = is_at_end;
+}
+
+void PulseQueuedTape::clear() {
+	queued_pulses_.clear();
+	pulse_pointer_ = 0;
+}
+
+bool PulseQueuedTape::empty() {
+	return queued_pulses_.empty();
+}
+
+void PulseQueuedTape::emplace_back(Tape::Pulse::Type type, Time length) {
+	queued_pulses_.emplace_back(type, length);
+}
+
+Tape::Pulse PulseQueuedTape::silence() {
+	Pulse silence;
+	silence.type = Pulse::Zero;
+	silence.length.length = 1;
+	silence.length.clock_rate = 1;
+	return silence;
+}
+
+Tape::Pulse PulseQueuedTape::virtual_get_next_pulse() {
+	if(is_at_end_) {
+		return silence();
+	}
+
+	if(pulse_pointer_ == queued_pulses_.size()) {
+		clear();
+		get_next_pulses();
+
+		if(is_at_end_ || pulse_pointer_ == queued_pulses_.size()) {
+			return silence();
+		}
+	}
+
+	size_t read_pointer = pulse_pointer_;
+	pulse_pointer_++;
+	return queued_pulses_[read_pointer];
+}

--- a/Storage/Tape/PulseQueuedTape.hpp
+++ b/Storage/Tape/PulseQueuedTape.hpp
@@ -1,0 +1,53 @@
+//
+//  PulseQueuedTape.hpp
+//  Clock Signal
+//
+//  Created by Thomas Harte on 16/07/2017.
+//  Copyright © 2017 Thomas Harte. All rights reserved.
+//
+
+#ifndef PulseQueuedTape_hpp
+#define PulseQueuedTape_hpp
+
+#include "Tape.hpp"
+#include <vector>
+
+namespace Storage {
+namespace Tape {
+
+/*!
+	Provides a @c Tape with a queue of upcoming pulses and an is-at-end flag.
+
+	If is-at-end is set then get_next_pulse() returns a second of silence and
+	is_at_end() returns true.
+	
+	Otherwise get_next_pulse() returns something from the pulse queue if there is
+	anything there, and otherwise calls get_next_pulses(). get_next_pulses() is
+	virtual, giving subclasses a chance to provide the next batch of pulses.
+*/
+class PulseQueuedTape: public Tape {
+	public:
+		PulseQueuedTape();
+		bool is_at_end();
+
+	protected:
+		void emplace_back(Tape::Pulse::Type type, Time length);
+		void clear();
+		bool empty();
+
+		void set_is_at_end(bool);
+		virtual void get_next_pulses() = 0;
+
+	private:
+		Pulse virtual_get_next_pulse();
+		Pulse silence();
+
+		std::vector<Pulse> queued_pulses_;
+		size_t pulse_pointer_;
+		bool is_at_end_;
+};
+
+}
+}
+
+#endif /* PulseQueuedTape_hpp */

--- a/Storage/Tape/Tape.cpp
+++ b/Storage/Tape/Tape.cpp
@@ -85,7 +85,7 @@ void TapePlayer::process_next_event() {
 #pragma mark - Binary Player
 
 BinaryTapePlayer::BinaryTapePlayer(unsigned int input_clock_rate) :
-	TapePlayer(input_clock_rate), motor_is_running_(false)
+	TapePlayer(input_clock_rate), motor_is_running_(false), input_level_(false)
 {}
 
 void BinaryTapePlayer::set_motor_control(bool enabled) {
@@ -97,7 +97,7 @@ void BinaryTapePlayer::set_tape_output(bool set) {
 }
 
 bool BinaryTapePlayer::get_input() {
-	return input_level_;
+	return motor_is_running_ && input_level_;
 }
 
 void BinaryTapePlayer::run_for_cycles(int number_of_cycles) {

--- a/Storage/Tape/Tape.cpp
+++ b/Storage/Tape/Tape.cpp
@@ -55,7 +55,11 @@ uint64_t Tape::get_offset() {
 }
 
 void Tape::set_offset(uint64_t offset) {
-	reset();
+	if(offset == offset_) return;
+	if(offset < offset_) {
+		reset();
+	}
+	offset -= offset_;
 	while(offset--) get_next_pulse();
 }
 

--- a/Storage/Tape/Tape.cpp
+++ b/Storage/Tape/Tape.cpp
@@ -20,22 +20,43 @@ TapePlayer::TapePlayer(unsigned int input_clock_rate) :
 #pragma mark - Seeking
 
 void Storage::Tape::Tape::seek(Time &seek_time) {
-	current_time_.set_zero();
-	next_time_.set_zero();
-	while(next_time_ <= seek_time) get_next_pulse();
+	Time next_time(0);
+	reset();
+	while(next_time <= seek_time) {
+		get_next_pulse();
+		next_time += pulse_.length;
+	}
+}
+
+Storage::Time Tape::get_current_time() {
+	Time time(0);
+	uint64_t steps = get_offset();
+	reset();
+	while(steps--) {
+		get_next_pulse();
+		time += pulse_.length;
+	}
+	return time;
 }
 
 void Storage::Tape::Tape::reset() {
-	current_time_.set_zero();
-	next_time_.set_zero();
+	offset_ = 0;
 	virtual_reset();
 }
 
 Tape::Pulse Tape::get_next_pulse() {
-	Tape::Pulse pulse = virtual_get_next_pulse();
-	current_time_ = next_time_;
-	next_time_ += pulse.length;
-	return pulse;
+	pulse_ = virtual_get_next_pulse();
+	offset_++;
+	return pulse_;
+}
+
+uint64_t Tape::get_offset() {
+	return offset_;
+}
+
+void Tape::set_offset(uint64_t offset) {
+	reset();
+	while(offset--) get_next_pulse();
 }
 
 #pragma mark - Player

--- a/Storage/Tape/Tape.hpp
+++ b/Storage/Tape/Tape.hpp
@@ -52,16 +52,33 @@ class Tape {
 		/// @returns @c true if the tape has progressed beyond all recorded content; @c false otherwise.
 		virtual bool is_at_end() = 0;
 
-		/// @returns the amount of time preceeding the most recently-returned pulse.
-		virtual Time get_current_time() { return current_time_; }
+		/*!
+			Returns a numerical representation of progression into the tape. Precision is arbitrary but
+			required to be at least to the whole pulse. Greater numbers are later than earlier numbers,
+			but not necessarily continuous.
+		*/
+		virtual uint64_t get_offset();
 
-		/// Advances or reverses the tape to the last time before or at @c time from which a pulse starts.
+		/*!
+			Moves the tape to the first time at which the specified offset would be returned by get_offset.
+		*/
+		virtual void set_offset(uint64_t);
+
+		/*!
+			Calculates and returns the amount of time that has elapsed since the time began. Potentially expensive.
+		*/
+		virtual Time get_current_time();
+
+		/*!
+			Seeks to @c time. Potentially expensive.
+		*/
 		virtual void seek(Time &time);
 
 		virtual ~Tape() {};
 
 	private:
-		Time current_time_, next_time_;
+		uint64_t offset_;
+		Tape::Pulse pulse_;
 
 		virtual Pulse virtual_get_next_pulse() = 0;
 		virtual void virtual_reset() = 0;


### PR DESCRIPTION
Really only for the ZX80 and ZX81 at present, but it'll be here if I ever decide to add ZX Spectrum support, I guess.

TZX support ends up sharing some code with UEF support so this factors out from the UEF class the very basic stuff of having a prepared queue of pulses and vending those as a tape.

As per the CSW/Electron experience, having an imperfect input stream that I didn't generate myself has also given me an opportunity to improve the ZX80 and ZX81 tape parsing.