### PR TITLE
Adjusts the timing of the Z80's wait line sampling to be on a half clock and better regularises 'action' partial bus cycles

### DIFF
--- a/OSBindings/Mac/Clock SignalTests/6502TimingTests.swift
+++ b/OSBindings/Mac/Clock SignalTests/6502TimingTests.swift
@@ -34,6 +34,7 @@ class MOS6502TimingTests: XCTestCase, CSTestMachineTrapHandler {
 			0xbd, 0x00, 0x00,	// [4] LDA $0000, x (no wrap)
 			0xbd, 0x02, 0x00,	// [5] LDA $0002, x (wrap)
 			0xb9, 0x00, 0x00,	// [4] LDA $0000, y (no wrap)
+
 			0xb9, 0x10, 0x00,	// [5] LDA $0010, y (wrap)
 			0xa1, 0x44,			// [6] LDA ($44, x)
 			0xb1, 0x00,			// [5] LDA ($00), y (no wrap)
@@ -222,7 +223,7 @@ class MOS6502TimingTests: XCTestCase, CSTestMachineTrapHandler {
 
 	func testMachine(_ testMachine: CSTestMachine, didTrapAtAddress address: UInt16) {
 		if self.endTime == 0 {
-			self.endTime = machine.timestamp - 1
+			self.endTime = (machine.timestamp / 2) - 1
 		}
 	}
 }

--- a/OSBindings/Mac/Clock SignalTests/Bridges/TestMachine6502.mm
+++ b/OSBindings/Mac/Clock SignalTests/Bridges/TestMachine6502.mm
@@ -78,7 +78,7 @@ static CPU::MOS6502::Register registerForRegister(CSTestMachine6502Register reg)
 }
 
 - (uint32_t)timestamp {
-	return _processor->get_timestamp();
+	return _processor->get_timestamp().as_int();
 }
 
 - (void)setIrqLine:(BOOL)irqLine {

--- a/OSBindings/Mac/Clock SignalTests/Bridges/TestMachineZ80.h
+++ b/OSBindings/Mac/Clock SignalTests/Bridges/TestMachineZ80.h
@@ -61,7 +61,7 @@ typedef NS_ENUM(NSInteger, CSTestMachineZ80Register) {
 @property(nonatomic, readonly, nonnull) NSArray<CSTestMachineZ80BusOperationCapture *> *busOperationCaptures;
 
 @property(nonatomic, readonly) BOOL isHalted;
-@property(nonatomic, readonly) int completedCycles;
+@property(nonatomic, readonly) int completedHalfCycles;
 
 @property(nonatomic) BOOL nmiLine;
 @property(nonatomic) BOOL irqLine;

--- a/OSBindings/Mac/Clock SignalTests/Bridges/TestMachineZ80.mm
+++ b/OSBindings/Mac/Clock SignalTests/Bridges/TestMachineZ80.mm
@@ -14,7 +14,7 @@
 - (void)testMachineDidPerformBusOperation:(CPU::Z80::PartialMachineCycle::Operation)operation
 	address:(uint16_t)address
 	value:(uint8_t)value
-	timeStamp:(int)time_stamp;
+	timeStamp:(HalfCycles)time_stamp;
 @end
 
 #pragma mark - C++ delegate handlers
@@ -23,7 +23,7 @@ class BusOperationHandler: public CPU::Z80::AllRAMProcessor::MemoryAccessDelegat
 	public:
 		BusOperationHandler(CSTestMachineZ80 *targetMachine) : target_(targetMachine) {}
 
-		void z80_all_ram_processor_did_perform_bus_operation(CPU::Z80::AllRAMProcessor &processor, CPU::Z80::PartialMachineCycle::Operation operation, uint16_t address, uint8_t value, int time_stamp) {
+		void z80_all_ram_processor_did_perform_bus_operation(CPU::Z80::AllRAMProcessor &processor, CPU::Z80::PartialMachineCycle::Operation operation, uint16_t address, uint8_t value, HalfCycles time_stamp) {
 			[target_ testMachineDidPerformBusOperation:operation address:address value:value timeStamp:time_stamp];
 		}
 
@@ -154,8 +154,8 @@ static CPU::Z80::Register registerForRegister(CSTestMachineZ80Register reg) {
 	return _processor->get_halt_line() ? YES : NO;
 }
 
-- (int)completedCycles {
-	return _processor->get_timestamp();
+- (int)completedHalfCycles {
+	return _processor->get_timestamp().as_int();
 }
 
 - (void)setNmiLine:(BOOL)nmiLine {
@@ -184,7 +184,7 @@ static CPU::Z80::Register registerForRegister(CSTestMachineZ80Register reg) {
 	_processor->set_memory_access_delegate(captureBusActivity ? _busOperationHandler : nullptr);
 }
 
-- (void)testMachineDidPerformBusOperation:(CPU::Z80::PartialMachineCycle::Operation)operation address:(uint16_t)address value:(uint8_t)value timeStamp:(int)timeStamp {
+- (void)testMachineDidPerformBusOperation:(CPU::Z80::PartialMachineCycle::Operation)operation address:(uint16_t)address value:(uint8_t)value timeStamp:(HalfCycles)timeStamp {
 	if(self.captureBusActivity) {
 		CSTestMachineZ80BusOperationCapture *capture = [[CSTestMachineZ80BusOperationCapture alloc] init];
 		switch(operation) {
@@ -216,7 +216,7 @@ static CPU::Z80::Register registerForRegister(CSTestMachineZ80Register reg) {
 		}
 		capture.address = address;
 		capture.value = value;
-		capture.timeStamp = timeStamp;
+		capture.timeStamp = timeStamp.as_int();
 
 		[_busOperationCaptures addObject:capture];
 	}

--- a/OSBindings/Mac/Clock SignalTests/FUSETests.swift
+++ b/OSBindings/Mac/Clock SignalTests/FUSETests.swift
@@ -195,8 +195,8 @@ class FUSETests: XCTestCase {
 			machine.runForNumber(ofCycles: Int32(targetState.tStates))
 
 			// Verify that exactly the right number of cycles was hit; this is a primitive cycle length tester.
-			let cyclesRun = machine.completedCycles
-			XCTAssert(cyclesRun == Int32(targetState.tStates), "Instruction length off; was \(machine.completedCycles) but should be \(targetState.tStates): \(name)")
+			let halfCyclesRun = machine.completedHalfCycles
+			XCTAssert(halfCyclesRun == Int32(targetState.tStates) * 2, "Instruction length off; was \(machine.completedHalfCycles) but should be \(targetState.tStates * 2): \(name)")
 
 			let finalState = RegisterState(machine: machine)
 

--- a/OSBindings/Mac/Clock SignalTests/Z80MachineCycleTests.swift
+++ b/OSBindings/Mac/Clock SignalTests/Z80MachineCycleTests.swift
@@ -61,7 +61,9 @@ class Z80MachineCycleTests: XCTestCase {
 				// array access
 				break
 			} else {
-				if length != busCycles[index].length || cycle.operation != busCycles[index].operation {
+				XCTAssert(length & Int32(1) == 0, "While performing \(machine.busOperationCaptures) Z80 ended on a half cycle")
+
+				if length != busCycles[index].length*2 || cycle.operation != busCycles[index].operation {
 					matches = false
 					break;
 				}

--- a/Processors/6502/6502AllRAM.cpp
+++ b/Processors/6502/6502AllRAM.cpp
@@ -21,7 +21,7 @@ class ConcreteAllRAMProcessor: public AllRAMProcessor, public Processor<Concrete
 		}
 
 		inline Cycles perform_bus_operation(BusOperation operation, uint16_t address, uint8_t *value) {
-			timestamp_++;
+			timestamp_ += Cycles(1);
 
 			if(operation == BusOperation::ReadOpcode) {
 				check_address_for_trap(address);

--- a/Processors/AllRAMProcessor.cpp
+++ b/Processors/AllRAMProcessor.cpp
@@ -25,7 +25,7 @@ void AllRAMProcessor::get_data_at_address(uint16_t startAddress, size_t length, 
 	memcpy(data, &memory_[startAddress], endAddress - startAddress);
 }
 
-uint32_t AllRAMProcessor::get_timestamp() {
+HalfCycles AllRAMProcessor::get_timestamp() {
 	return timestamp_;
 }
 

--- a/Processors/AllRAMProcessor.hpp
+++ b/Processors/AllRAMProcessor.hpp
@@ -13,12 +13,14 @@
 #include <set>
 #include <vector>
 
+#include "../ClockReceiver/ClockReceiver.hpp"
+
 namespace CPU {
 
 class AllRAMProcessor {
 	public:
 		AllRAMProcessor(size_t memory_size);
-		virtual uint32_t get_timestamp();
+		HalfCycles get_timestamp();
 		void set_data_at_address(uint16_t startAddress, size_t length, const uint8_t *data);
 		void get_data_at_address(uint16_t startAddress, size_t length, uint8_t *data);
 
@@ -31,7 +33,7 @@ class AllRAMProcessor {
 
 	protected:
 		std::vector<uint8_t> memory_;
-		uint32_t timestamp_;
+		HalfCycles timestamp_;
 
 		inline void check_address_for_trap(uint16_t address) {
 			if(traps_[address]) {

--- a/Processors/Z80/Z80.hpp
+++ b/Processors/Z80/Z80.hpp
@@ -104,7 +104,7 @@ struct PartialMachineCycle {
 		return operation <= Operation::BusAcknowledge;
 	}
 	inline bool is_wait() const {
-		return operation >= Operation::ReadWait && operation <= Operation::InterruptWait;
+		return operation >= Operation::ReadOpcodeWait && operation <= Operation::InterruptWait;
 	}
 };
 
@@ -1894,7 +1894,7 @@ template <class T> class Processor {
 			how many cycles before now the line changed state. The value may not be longer than the
 			current machine cycle. If called at any other time, this must be zero.
 		*/
-		void set_interrupt_line(bool value, int offset = 0) {
+		void set_interrupt_line(bool value, HalfCycles offset = 0) {
 			if(irq_line_ == value) return;
 
 			// IRQ requests are level triggered and masked.
@@ -1908,7 +1908,7 @@ template <class T> class Processor {
 			// If this change happened at least one cycle ago then: (i) we're promised that this is a machine
 			// cycle per the contract on supplying an offset; and (ii) that means it happened before the lines
 			// were sampled. So adjust the most recent sample.
-			if(offset < 0) {
+			if(offset <= HalfCycles(-2)) {
 				last_request_status_ = (last_request_status_ & ~Interrupt::IRQ) | (request_status_ & Interrupt::IRQ);
 			}
 		}

--- a/Processors/Z80/Z80AllRAM.cpp
+++ b/Processors/Z80/Z80AllRAM.cpp
@@ -17,14 +17,14 @@ class ConcreteAllRAMProcessor: public AllRAMProcessor, public Processor<Concrete
 		ConcreteAllRAMProcessor() : AllRAMProcessor() {}
 
 		inline Cycles perform_machine_cycle(const PartialMachineCycle &cycle) {
-			timestamp_ += cycle.length.as_int();
+			timestamp_ += cycle.length;
 			if(!cycle.is_terminal()) {
 				return Cycles(0);
 			}
 
 			uint16_t address = cycle.address ? *cycle.address : 0x0000;
 			switch(cycle.operation) {
-				case PartialMachineCycle::ReadOpcodeStart:
+				case PartialMachineCycle::ReadOpcode:
 					check_address_for_trap(address);
 				case PartialMachineCycle::Read:
 					*cycle.value = memory_[address];
@@ -57,7 +57,7 @@ class ConcreteAllRAMProcessor: public AllRAMProcessor, public Processor<Concrete
 			}
 
 			if(delegate_ != nullptr) {
-				delegate_->z80_all_ram_processor_did_perform_bus_operation(*this, cycle.operation, address, cycle.value ? *cycle.value : 0x00, timestamp_ >> 1);
+				delegate_->z80_all_ram_processor_did_perform_bus_operation(*this, cycle.operation, address, cycle.value ? *cycle.value : 0x00, timestamp_);
 			}
 
 			return Cycles(0);
@@ -93,10 +93,6 @@ class ConcreteAllRAMProcessor: public AllRAMProcessor, public Processor<Concrete
 
 		void set_wait_line(bool value) {
 			CPU::Z80::Processor<ConcreteAllRAMProcessor>::set_wait_line(value);
-		}
-
-		uint32_t get_timestamp() {
-			return timestamp_ >> 1;
 		}
 };
 

--- a/Processors/Z80/Z80AllRAM.hpp
+++ b/Processors/Z80/Z80AllRAM.hpp
@@ -22,7 +22,7 @@ class AllRAMProcessor:
 		static AllRAMProcessor *Processor();
 
 		struct MemoryAccessDelegate {
-			virtual void z80_all_ram_processor_did_perform_bus_operation(CPU::Z80::AllRAMProcessor &processor, CPU::Z80::PartialMachineCycle::Operation operation, uint16_t address, uint8_t value, int time_stamp) = 0;
+			virtual void z80_all_ram_processor_did_perform_bus_operation(CPU::Z80::AllRAMProcessor &processor, CPU::Z80::PartialMachineCycle::Operation operation, uint16_t address, uint8_t value, HalfCycles time_stamp) = 0;
 		};
 		inline void set_memory_access_delegate(MemoryAccessDelegate *delegate) {
 			delegate_ = delegate;
@@ -37,8 +37,6 @@ class AllRAMProcessor:
 		virtual void set_interrupt_line(bool value) = 0;
 		virtual void set_non_maskable_interrupt_line(bool value) = 0;
 		virtual void set_wait_line(bool value) = 0;
-
-		virtual uint32_t get_timestamp() = 0;
 
 	protected:
 		MemoryAccessDelegate *delegate_;


### PR DESCRIPTION
Simultaneously adjusts test machines to talk in half cycles since that's a new potential failure case to test for: for some reason the Z80 finishes a complete machine cycle on a half clock cycle.

Various affected tests are updated in response.