### PR TITLE
Revokes the operator bool() on WrappedInt and simplifies/generalises HalfClockReceiver

### DIFF
--- a/Machines/Electron/Electron.cpp
+++ b/Machines/Electron/Electron.cpp
@@ -351,7 +351,7 @@ void Machine::flush() {
 #pragma mark - Deferred scheduling
 
 inline void Machine::update_display() {
-	if(cycles_since_display_update_) {
+	if(cycles_since_display_update_ > 0) {
 		video_output_->run_for(cycles_since_display_update_.flush());
 	}
 }
@@ -363,7 +363,7 @@ inline void Machine::queue_next_display_interrupt() {
 }
 
 inline void Machine::update_audio() {
-	if(cycles_since_audio_update_) {
+	if(cycles_since_audio_update_ > 0) {
 		speaker_->run_for(cycles_since_audio_update_.divide(Cycles(Speaker::clock_rate_divider)));
 	}
 }

--- a/Processors/Z80/Z80AllRAM.cpp
+++ b/Processors/Z80/Z80AllRAM.cpp
@@ -16,10 +16,10 @@ class ConcreteAllRAMProcessor: public AllRAMProcessor, public Processor<Concrete
 	public:
 		ConcreteAllRAMProcessor() : AllRAMProcessor() {}
 
-		inline Cycles perform_machine_cycle(const PartialMachineCycle &cycle) {
+		inline HalfCycles perform_machine_cycle(const PartialMachineCycle &cycle) {
 			timestamp_ += cycle.length;
 			if(!cycle.is_terminal()) {
-				return Cycles(0);
+				return HalfCycles(0);
 			}
 
 			uint16_t address = cycle.address ? *cycle.address : 0x0000;
@@ -60,7 +60,7 @@ class ConcreteAllRAMProcessor: public AllRAMProcessor, public Processor<Concrete
 				delegate_->z80_all_ram_processor_did_perform_bus_operation(*this, cycle.operation, address, cycle.value ? *cycle.value : 0x00, timestamp_);
 			}
 
-			return Cycles(0);
+			return HalfCycles(0);
 		}
 
 		void run_for(const Cycles &cycles) {


### PR DESCRIPTION
Specifically to avoid accidental to-int conversions that go via the `bool` and therefore get entirely the wrong result, and so that objects counting `HalfCycle`s for communication with a `run_for(Cycles)` don't have to duplicate storage.