### PR TITLE
Standardises on `const [Half]Cycles`

### DIFF
--- a/ClockReceiver/ClockReceiver.hpp
+++ b/ClockReceiver/ClockReceiver.hpp
@@ -153,7 +153,7 @@ class HalfCycles: public WrappedInt<HalfCycles> {
 		inline HalfCycles(int l) : WrappedInt<HalfCycles>(l) {}
 		inline HalfCycles() : WrappedInt<HalfCycles>() {}
 
-		inline HalfCycles(const Cycles &cycles) : WrappedInt<HalfCycles>(cycles.as_int() << 1) {}
+		inline HalfCycles(const Cycles cycles) : WrappedInt<HalfCycles>(cycles.as_int() << 1) {}
 		inline HalfCycles(const HalfCycles &half_cycles) : WrappedInt<HalfCycles>(half_cycles.length_) {}
 
 		/// @returns The number of whole cycles completely covered by this span of half cycles.
@@ -178,7 +178,7 @@ template <class T> class HalfClockReceiver: public T {
 		using T::T;
 
 		using T::run_for;
-		inline void run_for(const HalfCycles &half_cycles) {
+		inline void run_for(const HalfCycles half_cycles) {
 			half_cycles_ += half_cycles;
 			T::run_for(half_cycles_.flush_cycles());
 		}

--- a/Components/1770/1770.cpp
+++ b/Components/1770/1770.cpp
@@ -124,7 +124,7 @@ uint8_t WD1770::get_register(int address) {
 	}
 }
 
-void WD1770::run_for(const Cycles &cycles) {
+void WD1770::run_for(const Cycles cycles) {
 	Storage::Disk::Controller::run_for(cycles);
 
 	if(delay_time_) {

--- a/Components/1770/1770.hpp
+++ b/Components/1770/1770.hpp
@@ -43,7 +43,7 @@ class WD1770: public Storage::Disk::Controller {
 		uint8_t get_register(int address);
 
 		/// Runs the controller for @c number_of_cycles cycles.
-		void run_for(const Cycles &cycles);
+		void run_for(const Cycles cycles);
 		using Storage::Disk::Controller::run_for;
 
 		enum Flag: uint8_t {

--- a/Components/6522/6522.hpp
+++ b/Components/6522/6522.hpp
@@ -253,7 +253,7 @@ template <class T> class MOS6522 {
 	}
 
 		/*! Runs for a specified number of half cycles. */
-		inline void run_for(const HalfCycles &half_cycles) {
+		inline void run_for(const HalfCycles half_cycles) {
 			int number_of_half_cycles = half_cycles.as_int();
 
 			if(is_phase2_) {
@@ -276,7 +276,7 @@ template <class T> class MOS6522 {
 		}
 
 		/*! Runs for a specified number of cycles. */
-		inline void run_for(const Cycles &cycles) {
+		inline void run_for(const Cycles cycles) {
 			int number_of_cycles = cycles.as_int();
 			while(number_of_cycles--) {
 				phase1();

--- a/Components/6532/6532.hpp
+++ b/Components/6532/6532.hpp
@@ -106,7 +106,7 @@ template <class T> class MOS6532 {
 			return 0xff;
 		}
 
-		inline void run_for(const Cycles &cycles) {
+		inline void run_for(const Cycles cycles) {
 			unsigned int number_of_cycles = (unsigned int)cycles.as_int();
 
 			// permit counting _to_ zero; counting _through_ zero initiates the other behaviour

--- a/Components/6560/6560.hpp
+++ b/Components/6560/6560.hpp
@@ -150,7 +150,7 @@ template <class T> class MOS6560 {
 		/*!
 			Runs for cycles. Derr.
 		*/
-		inline void run_for(const Cycles &cycles) {
+		inline void run_for(const Cycles cycles) {
 			// keep track of the amount of time since the speaker was updated; lazy updates are applied
 			cycles_since_speaker_update_ += cycles;
 

--- a/Machines/Atari2600/Atari2600.hpp
+++ b/Machines/Atari2600/Atari2600.hpp
@@ -44,7 +44,7 @@ class Machine:
 		virtual void close_output();
 		virtual std::shared_ptr<Outputs::CRT::CRT> get_crt() { return bus_->tia_->get_crt(); }
 		virtual std::shared_ptr<Outputs::Speaker> get_speaker() { return bus_->speaker_; }
-		virtual void run_for(const Cycles &cycles) { bus_->run_for(cycles); }
+		virtual void run_for(const Cycles cycles) { bus_->run_for(cycles); }
 
 		// to satisfy Outputs::CRT::Delegate
 		virtual void crt_did_end_batch_of_frames(Outputs::CRT::CRT *crt, unsigned int number_of_frames, unsigned int number_of_unexpected_vertical_syncs);

--- a/Machines/Atari2600/Bus.hpp
+++ b/Machines/Atari2600/Bus.hpp
@@ -24,7 +24,7 @@ class Bus {
 			tia_input_value_{0xff, 0xff},
 			cycles_since_speaker_update_(0) {}
 
-		virtual void run_for(const Cycles &cycles) = 0;
+		virtual void run_for(const Cycles cycles) = 0;
 		virtual void set_reset_line(bool state) = 0;
 
 		// the RIOT, TIA and speaker

--- a/Machines/Atari2600/Cartridges/Cartridge.hpp
+++ b/Machines/Atari2600/Cartridges/Cartridge.hpp
@@ -22,7 +22,7 @@ template<class T> class Cartridge:
 		Cartridge(const std::vector<uint8_t> &rom) :
 			rom_(rom) {}
 
-		void run_for(const Cycles &cycles) { CPU::MOS6502::Processor<Cartridge<T>>::run_for(cycles); }
+		void run_for(const Cycles cycles) { CPU::MOS6502::Processor<Cartridge<T>>::run_for(cycles); }
 		void set_reset_line(bool state) { CPU::MOS6502::Processor<Cartridge<T>>::set_reset_line(state); }
 		void advance_cycles(int cycles) {}
 

--- a/Machines/Atari2600/TIA.cpp
+++ b/Machines/Atari2600/TIA.cpp
@@ -165,7 +165,7 @@ void TIA::set_output_mode(Atari2600::TIA::OutputMode output_mode) {
 /*	speaker_->set_input_rate((float)(get_clock_rate() / 38.0));*/
 }
 
-void TIA::run_for(const Cycles &cycles) {
+void TIA::run_for(const Cycles cycles) {
 	int number_of_cycles = cycles.as_int();
 
 	// if part way through a line, definitely perform a partial, at most up to the end of the line
@@ -198,7 +198,7 @@ void TIA::set_blank(bool blank) {
 void TIA::reset_horizontal_counter() {
 }
 
-int TIA::get_cycles_until_horizontal_blank(const Cycles &from_offset) {
+int TIA::get_cycles_until_horizontal_blank(const Cycles from_offset) {
 	return (cycles_per_line - (horizontal_counter_ + from_offset.as_int()) % cycles_per_line) % cycles_per_line;
 }
 

--- a/Machines/Atari2600/TIA.hpp
+++ b/Machines/Atari2600/TIA.hpp
@@ -30,7 +30,7 @@ class TIA {
 		/*!
 			Advances the TIA by @c cycles. Any queued setters take effect in the first cycle performed.
 		*/
-		void run_for(const Cycles &cycles);
+		void run_for(const Cycles cycles);
 		void set_output_mode(OutputMode output_mode);
 
 		void set_sync(bool sync);
@@ -41,7 +41,7 @@ class TIA {
 			@returns the number of cycles between (current TIA time) + from_offset to the current or
 			next horizontal blanking period. Returns numbers in the range [0, 227].
 		*/
-		int get_cycles_until_horizontal_blank(const Cycles &from_offset);
+		int get_cycles_until_horizontal_blank(const Cycles from_offset);
 
 		void set_background_colour(uint8_t colour);
 

--- a/Machines/CRTMachine.hpp
+++ b/Machines/CRTMachine.hpp
@@ -43,7 +43,7 @@ class Machine {
 		virtual std::shared_ptr<Outputs::Speaker> get_speaker() = 0;
 
 		/// Runs the machine for @c cycles.
-		virtual void run_for(const Cycles &cycles) = 0;
+		virtual void run_for(const Cycles cycles) = 0;
 
 		// TODO: sever the clock-rate stuff.
 		double get_clock_rate() {

--- a/Machines/Commodore/1540/C1540.cpp
+++ b/Machines/Commodore/1540/C1540.cpp
@@ -79,7 +79,7 @@ void Machine::set_disk(std::shared_ptr<Storage::Disk::Disk> disk) {
 	set_drive(drive);
 }
 
-void Machine::run_for(const Cycles &cycles) {
+void Machine::run_for(const Cycles cycles) {
 	CPU::MOS6502::Processor<Machine>::run_for(cycles);
 	set_motor_on(drive_VIA_.get_motor_enabled());
 	if(drive_VIA_.get_motor_enabled()) // TODO: motor speed up/down

--- a/Machines/Commodore/1540/C1540.hpp
+++ b/Machines/Commodore/1540/C1540.hpp
@@ -138,7 +138,7 @@ class Machine:
 		*/
 		void set_serial_bus(std::shared_ptr<::Commodore::Serial::Bus> serial_bus);
 
-		void run_for(const Cycles &cycles);
+		void run_for(const Cycles cycles);
 		void set_disk(std::shared_ptr<Storage::Disk::Disk> disk);
 
 		// to satisfy CPU::MOS6502::Processor

--- a/Machines/Commodore/Vic-20/Vic20.hpp
+++ b/Machines/Commodore/Vic-20/Vic20.hpp
@@ -174,7 +174,7 @@ class Machine:
 		virtual void close_output();
 		virtual std::shared_ptr<Outputs::CRT::CRT> get_crt() { return mos6560_->get_crt(); }
 		virtual std::shared_ptr<Outputs::Speaker> get_speaker() { return mos6560_->get_speaker(); }
-		virtual void run_for(const Cycles &cycles) { CPU::MOS6502::Processor<Machine>::run_for(cycles); }
+		virtual void run_for(const Cycles cycles) { CPU::MOS6502::Processor<Machine>::run_for(cycles); }
 
 		// to satisfy MOS::MOS6522::Delegate
 		virtual void mos6522_did_change_interrupt_status(void *mos6522);

--- a/Machines/Electron/Electron.hpp
+++ b/Machines/Electron/Electron.hpp
@@ -95,7 +95,7 @@ class Machine:
 		virtual void close_output();
 		virtual std::shared_ptr<Outputs::CRT::CRT> get_crt();
 		virtual std::shared_ptr<Outputs::Speaker> get_speaker();
-		virtual void run_for(const Cycles &cycles) { CPU::MOS6502::Processor<Machine>::run_for(cycles); }
+		virtual void run_for(const Cycles cycles) { CPU::MOS6502::Processor<Machine>::run_for(cycles); }
 
 		// to satisfy Tape::Delegate
 		virtual void tape_did_change_interrupt_status(Tape *tape);

--- a/Machines/Electron/Tape.cpp
+++ b/Machines/Electron/Tape.cpp
@@ -80,7 +80,7 @@ void Tape::acorn_shifter_output_bit(int value) {
 	push_tape_bit((uint16_t)value);
 }
 
-void Tape::run_for(const Cycles &cycles) {
+void Tape::run_for(const Cycles cycles) {
 	if(is_enabled_) {
 		if(is_in_input_mode_) {
 			if(is_running_) {

--- a/Machines/Electron/Tape.hpp
+++ b/Machines/Electron/Tape.hpp
@@ -24,7 +24,7 @@ class Tape:
 	public:
 		Tape();
 
-		void run_for(const Cycles &cycles);
+		void run_for(const Cycles cycles);
 		using Storage::Tape::TapePlayer::run_for;
 
 		uint8_t get_data_register();

--- a/Machines/Electron/Video.cpp
+++ b/Machines/Electron/Video.cpp
@@ -223,7 +223,7 @@ void VideoOutput::output_pixels(unsigned int number_of_cycles) {
 	}
 }
 
-void VideoOutput::run_for(const Cycles &cycles) {
+void VideoOutput::run_for(const Cycles cycles) {
 	int number_of_cycles = cycles.as_int();
 	output_position_ = (output_position_ + number_of_cycles) % cycles_per_frame;
 	while(number_of_cycles) {

--- a/Machines/Electron/Video.hpp
+++ b/Machines/Electron/Video.hpp
@@ -34,7 +34,7 @@ class VideoOutput {
 		std::shared_ptr<Outputs::CRT::CRT> get_crt();
 
 		/// Produces the next @c cycles of video output.
-		void run_for(const Cycles &cycles);
+		void run_for(const Cycles cycles);
 
 		/*!
 			Writes @c value to the register at @c address. May mutate the results of @c get_next_interrupt,

--- a/Machines/Oric/Microdisc.cpp
+++ b/Machines/Oric/Microdisc.cpp
@@ -104,7 +104,7 @@ void Microdisc::set_head_load_request(bool head_load) {
 	}
 }
 
-void Microdisc::run_for(const Cycles &cycles) {
+void Microdisc::run_for(const Cycles cycles) {
 	if(head_load_request_counter_ < head_load_request_counter_target) {
 		head_load_request_counter_ += cycles.as_int();
 		if(head_load_request_counter_ >= head_load_request_counter_target) set_head_loaded(true);

--- a/Machines/Oric/Microdisc.hpp
+++ b/Machines/Oric/Microdisc.hpp
@@ -24,7 +24,7 @@ class Microdisc: public WD::WD1770 {
 
 		bool get_interrupt_request_line();
 
-		void run_for(const Cycles &cycles);
+		void run_for(const Cycles cycles);
 		using WD::WD1770::run_for;
 
 		enum PagingFlags {

--- a/Machines/Oric/Oric.cpp
+++ b/Machines/Oric/Oric.cpp
@@ -196,7 +196,7 @@ std::shared_ptr<Outputs::Speaker> Machine::get_speaker() {
 	return via_.ay8910;
 }
 
-void Machine::run_for(const Cycles &cycles) {
+void Machine::run_for(const Cycles cycles) {
 	CPU::MOS6502::Processor<Machine>::run_for(cycles);
 }
 
@@ -236,7 +236,7 @@ void Machine::VIA::flush() {
 	ay8910->flush();
 }
 
-void Machine::VIA::run_for(const Cycles &cycles) {
+void Machine::VIA::run_for(const Cycles cycles) {
 	cycles_since_ay_update_ += cycles;
 	MOS::MOS6522<VIA>::run_for(cycles);
 	tape->run_for(cycles);

--- a/Machines/Oric/Oric.hpp
+++ b/Machines/Oric/Oric.hpp
@@ -85,7 +85,7 @@ class Machine:
 		virtual void close_output();
 		virtual std::shared_ptr<Outputs::CRT::CRT> get_crt();
 		virtual std::shared_ptr<Outputs::Speaker> get_speaker();
-		virtual void run_for(const Cycles &cyclesß);
+		virtual void run_for(const Cycles cycles);
 
 		// to satisfy MOS::MOS6522IRQDelegate::Delegate
 		void mos6522_did_change_interrupt_status(void *mos6522);
@@ -143,7 +143,7 @@ class Machine:
 				void set_control_line_output(Port port, Line line, bool value);
 				void set_port_output(Port port, uint8_t value, uint8_t direction_mask);
 				uint8_t get_port_input(Port port);
-				inline void run_for(const Cycles &cycles);
+				inline void run_for(const Cycles cycles);
 
 				std::shared_ptr<GI::AY38910> ay8910;
 				std::unique_ptr<TapePlayer> tape;

--- a/Machines/Oric/Video.cpp
+++ b/Machines/Oric/Video.cpp
@@ -74,7 +74,7 @@ std::shared_ptr<Outputs::CRT::CRT> VideoOutput::get_crt() {
 	return crt_;
 }
 
-void VideoOutput::run_for(const Cycles &cycles) {
+void VideoOutput::run_for(const Cycles cycles) {
 	// Vertical: 0–39: pixels; otherwise blank; 48–53 sync, 54–56 colour burst
 	// Horizontal: 0–223: pixels; otherwise blank; 256–259 sync
 

--- a/Machines/Oric/Video.hpp
+++ b/Machines/Oric/Video.hpp
@@ -18,7 +18,7 @@ class VideoOutput {
 	public:
 		VideoOutput(uint8_t *memory);
 		std::shared_ptr<Outputs::CRT::CRT> get_crt();
-		void run_for(const Cycles &cycles);
+		void run_for(const Cycles cycles);
 		void set_colour_rom(const std::vector<uint8_t> &rom);
 		void set_output_device(Outputs::CRT::OutputDevice output_device);
 

--- a/Machines/Typer.cpp
+++ b/Machines/Typer.cpp
@@ -18,7 +18,7 @@ Typer::Typer(const char *string, HalfCycles delay, HalfCycles frequency, Delegat
 	snprintf(string_, string_size, "%c%s%c", Typer::BeginString, string, Typer::EndString);
 }
 
-void Typer::run_for(HalfCycles duration) {
+void Typer::run_for(const HalfCycles duration) {
 	if(string_) {
 		if(counter_ < 0 && counter_ + duration >= 0) {
 			if(!type_next_character()) {

--- a/Machines/Typer.hpp
+++ b/Machines/Typer.hpp
@@ -33,7 +33,7 @@ class Typer {
 
 		Typer(const char *string, HalfCycles delay, HalfCycles frequency, Delegate *delegate);
 		~Typer();
-		void run_for(HalfCycles duration);
+		void run_for(const HalfCycles duration);
 		bool type_next_character();
 
 		const char BeginString = 0x02;	// i.e. ASCII start of text

--- a/Machines/ZX8081/Video.cpp
+++ b/Machines/ZX8081/Video.cpp
@@ -29,7 +29,7 @@ Video::Video() :
 	crt_->set_visible_area(Outputs::CRT::Rect(0.1f, 0.1f, 0.8f, 0.8f));
 }
 
-void Video::run_for(const HalfCycles &half_cycles) {
+void Video::run_for(const HalfCycles half_cycles) {
 	// Just keep a running total of the amount of time that remains owed to the CRT.
 	cycles_since_update_ += (unsigned int)half_cycles.as_int();
 }

--- a/Machines/ZX8081/Video.hpp
+++ b/Machines/ZX8081/Video.hpp
@@ -32,7 +32,7 @@ class Video {
 		std::shared_ptr<Outputs::CRT::CRT> get_crt();
 
 		/// Advances time by @c cycles.
-		void run_for(const HalfCycles &);
+		void run_for(const HalfCycles);
 		/// Forces output to catch up to the current output position.
 		void flush();
 

--- a/Machines/ZX8081/ZX8081.cpp
+++ b/Machines/ZX8081/ZX8081.cpp
@@ -208,7 +208,7 @@ std::shared_ptr<Outputs::Speaker> Machine::get_speaker() {
 	return nullptr;
 }
 
-void Machine::run_for(const Cycles &cycles) {
+void Machine::run_for(const Cycles cycles) {
 	CPU::Z80::Processor<Machine>::run_for(cycles);
 }
 

--- a/Machines/ZX8081/ZX8081.hpp
+++ b/Machines/ZX8081/ZX8081.hpp
@@ -56,7 +56,7 @@ class Machine:
 		std::shared_ptr<Outputs::CRT::CRT> get_crt();
 		std::shared_ptr<Outputs::Speaker> get_speaker();
 
-		void run_for(const Cycles &cycles);
+		void run_for(const Cycles cycles);
 
 		void configure_as_target(const StaticAnalyser::Target &target);
 

--- a/Outputs/Speaker.hpp
+++ b/Outputs/Speaker.hpp
@@ -141,7 +141,7 @@ template <class T> class Filter: public Speaker {
 			_queue->flush();
 		}
 
-		void run_for(const Cycles &cycles) {
+		void run_for(const Cycles cycles) {
 			enqueue([=]() {
 				unsigned int cycles_remaining = (unsigned int)cycles.as_int();
 				if(coefficients_are_dirty_) update_filter_coefficients();

--- a/Processors/6502/6502.hpp
+++ b/Processors/6502/6502.hpp
@@ -292,7 +292,7 @@ template <class T> class Processor: public ProcessorBase {
 
 			@param cycles The number of cycles to run the 6502 for.
 		*/
-		void run_for(const Cycles &cycles) {
+		void run_for(const Cycles cycles) {
 			static const MicroOp doBranch[] = {
 				CycleReadFromPC,
 				CycleAddSignedOperandToPC,

--- a/Processors/6502/6502AllRAM.cpp
+++ b/Processors/6502/6502AllRAM.cpp
@@ -36,7 +36,7 @@ class ConcreteAllRAMProcessor: public AllRAMProcessor, public Processor<Concrete
 			return Cycles(1);
 		}
 
-		void run_for(const Cycles &cycles) {
+		void run_for(const Cycles cycles) {
 			Processor<ConcreteAllRAMProcessor>::run_for(cycles);
 		}
 

--- a/Processors/6502/6502AllRAM.hpp
+++ b/Processors/6502/6502AllRAM.hpp
@@ -22,7 +22,7 @@ class AllRAMProcessor:
 		static AllRAMProcessor *Processor();
 		virtual ~AllRAMProcessor() {}
 
-		virtual void run_for(const Cycles &cycles) = 0;
+		virtual void run_for(const Cycles cycles) = 0;
 		virtual bool is_jammed() = 0;
 		virtual void set_irq_line(bool value) = 0;
 		virtual void set_nmi_line(bool value) = 0;

--- a/Processors/Z80/Z80.hpp
+++ b/Processors/Z80/Z80.hpp
@@ -872,7 +872,7 @@ template <class T> class Processor {
 
 			@param cycles The number of cycles to run for.
 		*/
-		void run_for(const HalfCycles &cycles) {
+		void run_for(const HalfCycles cycles) {
 
 #define advance_operation() \
 	pc_increment_ = 1;	\

--- a/Processors/Z80/Z80AllRAM.cpp
+++ b/Processors/Z80/Z80AllRAM.cpp
@@ -63,7 +63,7 @@ class ConcreteAllRAMProcessor: public AllRAMProcessor, public Processor<Concrete
 			return HalfCycles(0);
 		}
 
-		void run_for(const Cycles &cycles) {
+		void run_for(const Cycles cycles) {
 			CPU::Z80::Processor<ConcreteAllRAMProcessor>::run_for(cycles);
 		}
 

--- a/Processors/Z80/Z80AllRAM.hpp
+++ b/Processors/Z80/Z80AllRAM.hpp
@@ -28,7 +28,7 @@ class AllRAMProcessor:
 			delegate_ = delegate;
 		}
 
-		virtual void run_for(const Cycles &cycles) = 0;
+		virtual void run_for(const Cycles cycles) = 0;
 		virtual uint16_t get_value_of_register(Register r) = 0;
 		virtual void set_value_of_register(Register r, uint16_t value) = 0;
 		virtual bool get_halt_line() = 0;

--- a/Storage/Disk/DigitalPhaseLockedLoop.cpp
+++ b/Storage/Disk/DigitalPhaseLockedLoop.cpp
@@ -20,7 +20,7 @@ DigitalPhaseLockedLoop::DigitalPhaseLockedLoop(int clocks_per_bit, size_t length
 		offset_history_(length_of_history, 0),
 		offset_(0) {}
 
-void DigitalPhaseLockedLoop::run_for(const Cycles &cycles) {
+void DigitalPhaseLockedLoop::run_for(const Cycles cycles) {
 	offset_ += cycles.as_int();
 	phase_ += cycles.as_int();
 	if(phase_ >= window_length_) {

--- a/Storage/Disk/DigitalPhaseLockedLoop.hpp
+++ b/Storage/Disk/DigitalPhaseLockedLoop.hpp
@@ -31,7 +31,7 @@ class DigitalPhaseLockedLoop {
 
 			@c number_of_cycles The time to run the loop for.
 		*/
-		void run_for(const Cycles &cycles);
+		void run_for(const Cycles cycles);
 
 		/*!
 			Announces a pulse at the current time.

--- a/Storage/Disk/DiskController.cpp
+++ b/Storage/Disk/DiskController.cpp
@@ -40,7 +40,7 @@ void Controller::setup_track() {
 	get_next_event(offset);
 }
 
-void Controller::run_for(const Cycles &cycles) {
+void Controller::run_for(const Cycles cycles) {
 	Time zero(0);
 
 	if(drive_ && drive_->has_disk() && motor_is_on_) {

--- a/Storage/Disk/DiskController.hpp
+++ b/Storage/Disk/DiskController.hpp
@@ -43,7 +43,7 @@ class Controller: public DigitalPhaseLockedLoop::Delegate, public TimedEventLoop
 		/*!
 			Advances the drive by @c number_of_cycles cycles.
 		*/
-		void run_for(const Cycles &cycles);
+		void run_for(const Cycles cycles);
 		using TimedEventLoop::run_for;
 
 		/*!

--- a/Storage/Tape/Tape.cpp
+++ b/Storage/Tape/Tape.cpp
@@ -92,7 +92,7 @@ void TapePlayer::get_next_pulse() {
 	set_next_event_time_interval(current_pulse_.length);
 }
 
-void TapePlayer::run_for(const Cycles &cycles) {
+void TapePlayer::run_for(const Cycles cycles) {
 	if(has_tape()) {
 		TimedEventLoop::run_for(cycles);
 	}
@@ -125,7 +125,7 @@ bool BinaryTapePlayer::get_input() {
 	return motor_is_running_ && input_level_;
 }
 
-void BinaryTapePlayer::run_for(const Cycles &cycles) {
+void BinaryTapePlayer::run_for(const Cycles cycles) {
 	if(motor_is_running_) TapePlayer::run_for(cycles);
 }
 

--- a/Storage/Tape/Tape.hpp
+++ b/Storage/Tape/Tape.hpp
@@ -101,7 +101,7 @@ class TapePlayer: public TimedEventLoop {
 		bool has_tape();
 		std::shared_ptr<Storage::Tape::Tape> get_tape();
 
-		void run_for(const Cycles &cycles);
+		void run_for(const Cycles cycles);
 
 		void run_for_input_pulse();
 
@@ -131,7 +131,7 @@ class BinaryTapePlayer: public TapePlayer {
 		void set_tape_output(bool set);
 		bool get_input();
 
-		void run_for(const Cycles &cycles);
+		void run_for(const Cycles cycles);
 
 		class Delegate {
 			public:

--- a/Storage/TimedEventLoop.cpp
+++ b/Storage/TimedEventLoop.cpp
@@ -15,7 +15,7 @@ using namespace Storage;
 TimedEventLoop::TimedEventLoop(unsigned int input_clock_rate) :
 	input_clock_rate_(input_clock_rate) {}
 
-void TimedEventLoop::run_for(const Cycles &cycles) {
+void TimedEventLoop::run_for(const Cycles cycles) {
 	cycles_until_event_ -= cycles.as_int();
 	while(cycles_until_event_ <= 0) {
 		process_next_event();

--- a/Storage/TimedEventLoop.hpp
+++ b/Storage/TimedEventLoop.hpp
@@ -47,7 +47,7 @@ namespace Storage {
 			/*!
 				Advances the event loop by @c number_of_cycles cycles.
 			*/
-			void run_for(const Cycles &cycles);
+			void run_for(const Cycles cycles);
 
 			/*!
 				@returns the number of whole cycles remaining until the next event is triggered.


### PR DESCRIPTION
… rather than `const [Half]Cycles &` as it's explicitly defined to be only one `int` in size, so using a reference is overly weighty.