### PR TITLE
Publicly declares the ZX80/81 and Amstrad CPC as keyboard machines

### DIFF
--- a/Machines/AmstradCPC/AmstradCPC.hpp
+++ b/Machines/AmstradCPC/AmstradCPC.hpp
@@ -11,6 +11,7 @@
 
 #include "../ConfigurationTarget.hpp"
 #include "../CRTMachine.hpp"
+#include "../KeyboardMachine.hpp"
 
 namespace AmstradCPC {
 
@@ -50,19 +51,14 @@ enum Key: uint16_t {
 */
 class Machine:
 	public CRTMachine::Machine,
-	public ConfigurationTarget::Machine {
+	public ConfigurationTarget::Machine,
+	public KeyboardMachine::Machine {
 	public:
 		/// Creates an returns an Amstrad CPC on the heap.
 		static Machine *AmstradCPC();
 
 		/// Sets the contents of rom @c type to @c data. Assumed to be a setup step; has no effect once a machine is running.
 		virtual void set_rom(ROMType type, std::vector<uint8_t> data) = 0;
-
-		/// Indicates that @c key is either pressed or released, according to @c is_pressed.
-		virtual void set_key_state(uint16_t key, bool is_pressed) = 0;
-
-		/// Indicates that all keys are now released.
-		virtual void clear_all_keys() = 0;
 };
 
 }

--- a/Machines/ZX8081/ZX8081.hpp
+++ b/Machines/ZX8081/ZX8081.hpp
@@ -11,6 +11,7 @@
 
 #include "../ConfigurationTarget.hpp"
 #include "../CRTMachine.hpp"
+#include "../KeyboardMachine.hpp"
 
 #include <cstdint>
 #include <vector>
@@ -34,13 +35,12 @@ enum Key: uint16_t {
 
 class Machine:
 	public CRTMachine::Machine,
-	public ConfigurationTarget::Machine {
+	public ConfigurationTarget::Machine,
+	public KeyboardMachine::Machine {
 	public:
 		static Machine *ZX8081();
 
 		virtual void set_rom(ROMType type, std::vector<uint8_t> data) = 0;
-		virtual void set_key_state(uint16_t key, bool isPressed) = 0;
-		virtual void clear_all_keys() = 0;
 
 		virtual void set_use_fast_tape_hack(bool activate) = 0;
 		virtual void set_tape_is_playing(bool is_playing) = 0;


### PR DESCRIPTION
Which means not having to repeat the meaning of set_key_state and clear_all_keys. So: a minor DRY improvement.