### PR TITLE
Introduces the beginning seeds 8272 emulation, and therefore floppy emulation for the CPC

### DIFF
--- a/Components/1770/1770.cpp
+++ b/Components/1770/1770.cpp
@@ -263,7 +263,7 @@ void WD1770::process_write_completed() {
 }
 
 #define WAIT_FOR_EVENT(mask)	resume_point_ = __LINE__; interesting_event_mask_ = mask; return; case __LINE__:
-#define WAIT_FOR_TIME(ms)		resume_point_ = __LINE__; interesting_event_mask_ = Event::Timer; delay_time_ = ms * 8000; if(delay_time_) return; case __LINE__:
+#define WAIT_FOR_TIME(ms)		resume_point_ = __LINE__; interesting_event_mask_ = Event::Timer; delay_time_ = ms * 8000; case __LINE__: if(delay_time_) return;
 #define WAIT_FOR_BYTES(count)	resume_point_ = __LINE__; interesting_event_mask_ = Event::Token; distance_into_section_ = 0; return; case __LINE__: if(latest_token_.type == Token::Byte) distance_into_section_++; if(distance_into_section_ < count) { interesting_event_mask_ = Event::Token; return; }
 #define BEGIN_SECTION()	switch(resume_point_) { default:
 #define END_SECTION()	0; }

--- a/Components/8272/i8272.cpp
+++ b/Components/8272/i8272.cpp
@@ -135,7 +135,8 @@ void i8272::set_disk(std::shared_ptr<Storage::Disk::Disk> disk, int drive) {
 #define SET_DRIVE_HEAD_MFM()	\
 	if(!dma_mode_) main_status_ |= StatusNDM;	\
 	set_drive(drives_[command_[1]&3].drive);	\
-	set_is_double_density(command_[0] & 0x40);
+	set_is_double_density(command_[0] & 0x40);	\
+	invalidate_track();
 
 void i8272::posit_event(int event_type) {
 	if(!(interesting_event_mask_ & event_type)) return;

--- a/Components/8272/i8272.cpp
+++ b/Components/8272/i8272.cpp
@@ -58,7 +58,6 @@ void i8272::run_for(Cycles cycles) {
 					(drives_[c].drive->get_is_track_zero() && drives_[c].target_head_position == -1)) {
 					drives_[c].phase = Drive::CompletedSeeking;
 					if(drives_[c].target_head_position == -1) drives_[c].head_position = 0;
-					main_status_ &= ~(1 << c);
 				} else {
 					int direction = (drives_[c].target_head_position < drives_[c].head_position) ? -1 : 1;
 					drives_[c].drive->step(direction);
@@ -83,7 +82,7 @@ void i8272::set_register(int address, uint8_t value) {
 
 uint8_t i8272::get_register(int address) {
 	if(address) {
-		printf("8272 get data\n");
+//		printf("8272 get data\n");
 
 		if(result_stack_.empty()) return 0xff;
 		uint8_t result = result_stack_.back();
@@ -231,8 +230,9 @@ void i8272::posit_event(int event_type) {
 		FIND_HEADER();
 		if(!index_hole_limit_) goto read_data_not_found;
 		READ_HEADER();
-		printf("Comparing with %02x\n", header_[2]);
-		if(header_[2] != sector_) goto find_next_sector;
+//		printf("Comparing with %02x\n", header_[2]);
+		if(header_[0] != cylinder_ || header_[1] != head_ || header_[2] != sector_ || header_[3] != size_) goto find_next_sector;
+
 
 		FIND_DATA();
 		distance_into_section_ = 0;
@@ -323,12 +323,14 @@ void i8272::posit_event(int event_type) {
 		goto wait_for_command;
 
 	recalibrate:
-		printf("Recalibrate\n");
+	seek:
+		printf((command_.size() > 2) ? "Seek\n" : "Recalibrate\n");
+		status_[0] = status_[1] = status_[2] = 0;
 		drives_[command_[1]&3].phase = Drive::Seeking;
-		drives_[command_[1]&3].permitted_steps = 77;
-		drives_[command_[1]&3].target_head_position = -1;
+		drives_[command_[1]&3].steps_taken = 0;
+		drives_[command_[1]&3].target_head_position = (command_.size() > 2) ? command_[2] : -1;
 		drives_[command_[1]&3].step_rate_counter = 0;
-		main_status_ |= (1 << command_[1]&3);
+		main_status_ |= 1 << (command_[1]&3);
 		goto wait_for_command;
 
 	sense_interrupt_status:
@@ -346,6 +348,7 @@ void i8272::posit_event(int event_type) {
 			if(found_drive != -1) {
 				drives_[found_drive].phase = Drive::NotSeeking;
 				status_[0] = (uint8_t)found_drive | 0x20;
+				main_status_ &= ~(1 << found_drive);
 
 				result_stack_.push_back(drives_[found_drive].head_position);
 				result_stack_.push_back(status_[0]);
@@ -367,15 +370,6 @@ void i8272::posit_event(int event_type) {
 		printf("Sense drive status\n");
 		result_stack_.push_back(status_[3]);
 		goto post_result;
-
-	seek:
-		printf("Seek\n");
-		drives_[command_[1]&3].phase = Drive::Seeking;
-		drives_[command_[1]&3].permitted_steps = -1;
-		drives_[command_[1]&3].target_head_position = command_[2];
-		drives_[command_[1]&3].step_rate_counter = 0;
-		main_status_ |= (1 << command_[1]&3);
-		goto wait_for_command;
 
 	invalid:
 		// A no-op, causing the FDC to go back into standby mode.

--- a/Components/8272/i8272.cpp
+++ b/Components/8272/i8272.cpp
@@ -12,78 +12,41 @@
 
 using namespace Intel;
 
+namespace {
+const uint8_t StatusRQM = 0x80;	// Set indicates: ready to send or receive from processor.
+}
+
 i8272::i8272(Cycles clock_rate, int clock_rate_multiplier, int revolutions_per_minute) :
-	Storage::Disk::MFMController(clock_rate, clock_rate_multiplier, revolutions_per_minute) {
+	Storage::Disk::MFMController(clock_rate, clock_rate_multiplier, revolutions_per_minute),
+	status_(StatusRQM),
+	interesting_event_mask_((int)Event8272::CommandByte),
+	resume_point_(0),
+	delay_time_(0) {
+	posit_event((int)Event8272::CommandByte);
 }
 
 void i8272::run_for(Cycles cycles) {
 	Storage::Disk::MFMController::run_for(cycles);
+	if(delay_time_ > 0) {
+		if(cycles.as_int() >= delay_time_) {
+			delay_time_ = 0;
+			posit_event((int)Event8272::Timer);
+		} else {
+			delay_time_ -= cycles.as_int();
+		}
+	}
 }
 
 void i8272::set_register(int address, uint8_t value) {
+	// don't consider attempted sets to the status register
 	if(!address) return;
 
-	// TODO: if not accepting commands, return
+	// if not ready for commands, do nothing
+	if(!(status_ & StatusRQM)) return;
 
+	// accumulate latest byte in the command byte sequence
 	command_.push_back(value);
-	size_t necessary_length;
-	switch(command_[0] & 0x1f) {
-		case 0x06:	// read data
-			necessary_length = 9;
-		break;
-		case 0x0b:	// read deleted data
-			necessary_length = 9;
-		break;
-		case 0x05:	// write data
-			necessary_length = 9;
-		break;
-		case 0x09:	// write deleted data
-			necessary_length = 9;
-		break;
-		case 0x02:	// read track
-			necessary_length = 9;
-		break;
-		case 0x0a:	// read ID
-			necessary_length = 2;
-		break;
-		case 0x0d:	// format track
-			necessary_length = 6;
-		break;
-		case 0x11:	// scan low
-			necessary_length = 9;
-		break;
-		case 0x19:	// scan low  or equal
-			necessary_length = 9;
-		break;
-		case 0x1d:	// scan high or equal
-			necessary_length = 9;
-		break;
-		case 0x07:	// recalibrate
-			necessary_length = 2;
-		break;
-		case 0x08:	// sense interrupt status
-			necessary_length = 1;
-		break;
-		case 0x03:	// specify
-			necessary_length = 3;
-		break;
-		case 0x04:	// sense drive status
-			necessary_length = 2;
-		break;
-		case 0x0f:	// seek
-			necessary_length = 3;
-		break;
-		default:	// invalid
-			necessary_length = 1;
-		break;
-	}
-
-	printf("8272 set register %d to %02x\n", address, value);
-
-	if(command_.size() == necessary_length) {
-		printf("8272 Perform!\n");
-		command_.clear();
-	}
+	posit_event((int)Event8272::CommandByte);
 }
 
 uint8_t i8272::get_register(int address) {
@@ -92,9 +55,161 @@ uint8_t i8272::get_register(int address) {
 		return 0xff;
 	} else {
 		printf("8272 get status\n");
-		return 0x80;
+		return status_;
 	}
 }
 
-void i8272::posit_event(Event type) {
+#define BEGIN_SECTION()	switch(resume_point_) { default:
+#define END_SECTION()	}
+
+#define WAIT_FOR_EVENT(mask)	resume_point_ = __LINE__; interesting_event_mask_ = (int)mask; return; case __LINE__:
+
+void i8272::posit_event(int type) {
+	if(!(interesting_event_mask_ & type)) return;
+	interesting_event_mask_ &= ~type;
+
+	BEGIN_SECTION();
+
+	wait_for_command:
+		set_data_mode(Storage::Disk::MFMController::DataMode::Scanning);
+		command_.clear();
+
+	wait_for_complete_command_sequence:
+		status_ |= StatusRQM;
+		WAIT_FOR_EVENT(Event8272::CommandByte)
+		status_ &= ~StatusRQM;
+
+		switch(command_[0] & 0x1f) {
+			case 0x06:	// read data
+				if(command_.size() < 9) goto wait_for_complete_command_sequence;
+				goto read_data;
+
+			case 0x0b:	// read deleted data
+				if(command_.size() < 9) goto wait_for_complete_command_sequence;
+				goto read_deleted_data;
+
+			case 0x05:	// write data
+				if(command_.size() < 9) goto wait_for_complete_command_sequence;
+				goto write_data;
+
+			case 0x09:	// write deleted data
+				if(command_.size() < 9) goto wait_for_complete_command_sequence;
+				goto write_deleted_data;
+
+			case 0x02:	// read track
+				if(command_.size() < 9) goto wait_for_complete_command_sequence;
+				goto read_track;
+
+			case 0x0a:	// read ID
+				if(command_.size() < 2) goto wait_for_complete_command_sequence;
+				goto read_id;
+
+			case 0x0d:	// format track
+				if(command_.size() < 6) goto wait_for_complete_command_sequence;
+				goto format_track;
+
+			case 0x11:	// scan low
+				if(command_.size() < 9) goto wait_for_complete_command_sequence;
+				goto scan_low;
+
+			case 0x19:	// scan low or equal
+				if(command_.size() < 9) goto wait_for_complete_command_sequence;
+				goto scan_low_or_equal;
+
+			case 0x1d:	// scan high or equal
+				if(command_.size() < 9) goto wait_for_complete_command_sequence;
+				goto scan_high_or_equal;
+
+			case 0x07:	// recalibrate
+				if(command_.size() < 2) goto wait_for_complete_command_sequence;
+				goto recalibrate;
+
+			case 0x08:	// sense interrupt status
+				goto sense_interrupt_status;
+
+			case 0x03:	// specify
+				if(command_.size() < 3) goto wait_for_complete_command_sequence;
+				goto specify;
+
+			case 0x04:	// sense drive status
+				if(command_.size() < 2) goto wait_for_complete_command_sequence;
+				goto sense_drive_status;
+
+			case 0x0f:	// seek
+				if(command_.size() < 3) goto wait_for_complete_command_sequence;
+				goto seek;
+
+			default:	// invalid
+				goto invalid;
+		}
+
+	read_data:
+		printf("Read data unimplemented!!");
+		goto wait_for_command;
+
+	read_deleted_data:
+		printf("Read deleted data unimplemented!!");
+		goto wait_for_command;
+
+	write_data:
+		printf("Write data unimplemented!!");
+		goto wait_for_command;
+
+	write_deleted_data:
+		printf("Write deleted data unimplemented!!");
+		goto wait_for_command;
+
+	read_track:
+		printf("Read track unimplemented!!");
+		goto wait_for_command;
+
+	read_id:
+		printf("Read ID unimplemented!!");
+		goto wait_for_command;
+
+	format_track:
+		printf("Fromat track unimplemented!!");
+		goto wait_for_command;
+
+	scan_low:
+		printf("Scan low unimplemented!!");
+		goto wait_for_command;
+
+	scan_low_or_equal:
+		printf("Scan low or equal unimplemented!!");
+		goto wait_for_command;
+
+	scan_high_or_equal:
+		printf("Scan high or equal unimplemented!!");
+		goto wait_for_command;
+
+	recalibrate:
+		printf("Recalibrate unimplemented!!");
+		goto wait_for_command;
+
+	sense_interrupt_status:
+		printf("Sense interrupt status unimplemented!!");
+		goto wait_for_command;
+
+	specify:
+		printf("Specify");
+		step_rate_time_ = command_[1] &0xf0;		// i.e. 16 to 240m
+		head_unload_time_ = command_[1] & 0x0f;		// i.e. 1 to 16ms
+		head_load_time_ = command_[2] & ~1;			// i.e. 2 to 254 ms in increments of 2ms
+		dma_mode_ = !(command_[2] & 1);
+		goto wait_for_command;
+
+	sense_drive_status:
+		printf("Sense drive status unimplemented!!");
+		goto wait_for_command;
+
+	seek:
+		printf("Seek unimplemented!!");
+		goto wait_for_command;
+
+	invalid:
+		// A no-op, causing the FDC to go back into standby mode.
+		goto wait_for_command;
+
+	END_SECTION()
 }

--- a/Components/8272/i8272.cpp
+++ b/Components/8272/i8272.cpp
@@ -244,6 +244,7 @@ void i8272::posit_event(int event_type) {
 		distance_into_section_++;
 		main_status_ |= StatusRQM | StatusDIO;
 		WAIT_FOR_EVENT(Event8272::ResultEmpty);
+		main_status_ &= ~StatusRQM;
 		if(distance_into_section_ < (128 << size_)) goto get_byte;
 
 		set_data_mode(Scanning);

--- a/Components/8272/i8272.cpp
+++ b/Components/8272/i8272.cpp
@@ -1,0 +1,18 @@
+//
+//  i8272.cpp
+//  Clock Signal
+//
+//  Created by Thomas Harte on 05/08/2017.
+//  Copyright © 2017 Thomas Harte. All rights reserved.
+//
+
+#include "i8272.hpp"
+
+using namespace Intel;
+
+void i8272::set_register(int address, uint8_t value) {
+}
+
+uint8_t i8272::get_register(int address) {
+	return 0xff;
+}

--- a/Components/8272/i8272.cpp
+++ b/Components/8272/i8272.cpp
@@ -69,6 +69,9 @@ uint8_t i8272::get_register(int address) {
 	}
 }
 
+void i8272::set_disk(std::shared_ptr<Storage::Disk::Disk> disk, int drive) {
+}
+
 #define BEGIN_SECTION()	switch(resume_point_) { default:
 #define END_SECTION()	}
 

--- a/Components/8272/i8272.cpp
+++ b/Components/8272/i8272.cpp
@@ -214,14 +214,18 @@ void i8272::posit_event(int event_type) {
 		if(!dma_mode_) main_status_ |= StatusNDM;
 		set_drive(drives_[command_[1]&3].drive);
 		set_is_double_density(command_[0] & 0x40);
+		cylinder_ = command_[2];
+		head_ = command_[3];
+		sector_ = command_[4];
+		size_ = command_[5];
 
 		index_hole_limit_ = 2;
 	find_next_sector:
 		FIND_HEADER();
 		if(!index_hole_limit_) goto read_data_not_found;
 		READ_HEADER();
-		printf("Comparing with %02x\n", header_[2]);
-		if(header_[2] != command_[4]) goto find_next_sector;
+		printf("Comparing with %02x\n", sector_);
+		if(header_[2] != sector_) goto find_next_sector;
 
 		printf("Unimplemented!!\n");
 		goto wait_for_command;
@@ -233,10 +237,14 @@ void i8272::posit_event(int event_type) {
 		status_[0] = (status_[0] & ~0xc0) | 0x40;
 
 	read_data_end:
-		result_.push_back(header_[3]);
-		result_.push_back(header_[2]);
-		result_.push_back(header_[1]);
-		result_.push_back(header_[0]);
+//		result_.push_back(header_[3]);
+//		result_.push_back(header_[2]);
+//		result_.push_back(header_[1]);
+//		result_.push_back(header_[0]);
+		result_.push_back(size_);
+		result_.push_back(sector_);
+		result_.push_back(head_);
+		result_.push_back(cylinder_);
 
 		result_.push_back(status_[2]);
 		result_.push_back(status_[1]);

--- a/Components/8272/i8272.cpp
+++ b/Components/8272/i8272.cpp
@@ -12,6 +12,14 @@
 
 using namespace Intel;
 
+i8272::i8272(Cycles clock_rate, int clock_rate_multiplier, int revolutions_per_minute) :
+	Storage::Disk::MFMController(clock_rate, clock_rate_multiplier, revolutions_per_minute) {
+}
+
+void i8272::run_for(Cycles cycles) {
+	Storage::Disk::MFMController::run_for(cycles);
+}
+
 void i8272::set_register(int address, uint8_t value) {
 	if(!address) return;
 
@@ -86,4 +94,7 @@ uint8_t i8272::get_register(int address) {
 		printf("8272 get status\n");
 		return 0x80;
 	}
+}
+
+void i8272::posit_event(Event type) {
 }

--- a/Components/8272/i8272.cpp
+++ b/Components/8272/i8272.cpp
@@ -406,8 +406,9 @@ void i8272::posit_event(int event_type) {
 
 	// Performs any invalid command.
 	invalid:
-			// A no-op, causing the FDC to go back into standby mode.
-			goto wait_for_command;
+			// A no-op, but posts ST0.
+			result_stack_.push_back(status_[0]);
+			goto post_result;
 
 	// Posts ST0, ST1, ST2, C, H, R and N as a result phase.
 	post_st012chrn:

--- a/Components/8272/i8272.cpp
+++ b/Components/8272/i8272.cpp
@@ -236,8 +236,7 @@ void i8272::posit_event(int type) {
 	sense_interrupt_status:
 		printf("Sense interrupt status\n");
 		// Find the first drive that is in the CompletedSeeking state and return for that;
-		// if none has done so then return 0xff for the sake of returning something.
-		// TODO: verify that fallback.
+		// if none has done so then return a single 0x80.
 		{
 			int found_drive = -1;
 			for(int c = 0; c < 4; c++) {
@@ -249,9 +248,11 @@ void i8272::posit_event(int type) {
 			if(found_drive != -1) {
 				drives_[found_drive].phase = Drive::NotSeeking;
 				result_.push_back(drives_[found_drive].head_position);
+				result_.push_back(status_[0]);
+			} else {
+				result_.push_back(0x80);
 			}
 		}
-		result_.push_back(status_[0]);
 		goto post_result;
 
 	specify:

--- a/Components/8272/i8272.cpp
+++ b/Components/8272/i8272.cpp
@@ -131,7 +131,7 @@ void i8272::set_disk(std::shared_ptr<Storage::Disk::Disk> disk, int drive) {
 	CONCAT(read_header, __LINE__): WAIT_FOR_EVENT(Event::Token); \
 	header_[distance_into_section_] = get_latest_token().byte_value;	\
 	distance_into_section_++; \
-	if(distance_into_section_ != 7) goto CONCAT(read_header, __LINE__);	\
+	if(distance_into_section_ < 6) goto CONCAT(read_header, __LINE__);	\
 	set_data_mode(Scanning);
 
 #define SET_DRIVE_HEAD_MFM()	\
@@ -281,6 +281,10 @@ void i8272::posit_event(int event_type) {
 			WAIT_FOR_EVENT(Event8272::ResultEmpty);
 			main_status_ &= ~StatusRQM;
 			if(distance_into_section_ < (128 << size_)) goto get_byte;
+
+		// read CRC, without transferring it
+			WAIT_FOR_EVENT(Event::Token);
+			WAIT_FOR_EVENT(Event::Token);
 
 		// For a final result phase, post the standard ST0, ST1, ST2, C, H, R, N
 			goto post_st012chrn;

--- a/Components/8272/i8272.cpp
+++ b/Components/8272/i8272.cpp
@@ -13,12 +13,18 @@
 using namespace Intel;
 
 namespace {
-const uint8_t StatusRQM = 0x80;	// Set indicates: ready to send or receive from processor.
+const uint8_t StatusRQM = 0x80;	// Set: ready to send or receive from processor.
+const uint8_t StatusDIO = 0x40;	// Set: data is expected to be taken from the 8272 by the processor.
+const uint8_t StatusNDM = 0x20;	// Set: the execution phase of a data transfer command is ongoing and DMA mode is disabled.
+const uint8_t StatusD3B = 0x08;	// Set: drive 3 is seeking.
+const uint8_t StatusD2B = 0x04;	// Set: drive 2 is seeking.
+const uint8_t StatusD1B = 0x02;	// Set: drive 1 is seeking.
+const uint8_t StatusD0B = 0x01;	// Set: drive 0 is seeking.
 }
 
 i8272::i8272(Cycles clock_rate, int clock_rate_multiplier, int revolutions_per_minute) :
 	Storage::Disk::MFMController(clock_rate, clock_rate_multiplier, revolutions_per_minute),
-	status_(StatusRQM),
+	main_status_(StatusRQM),
 	interesting_event_mask_((int)Event8272::CommandByte),
 	resume_point_(0),
 	delay_time_(0) {
@@ -42,7 +48,7 @@ void i8272::set_register(int address, uint8_t value) {
 	if(!address) return;
 
 	// if not ready for commands, do nothing
-	if(!(status_ & StatusRQM)) return;
+	if(!(main_status_ & StatusRQM)) return;
 
 	// accumulate latest byte in the command byte sequence
 	command_.push_back(value);
@@ -52,10 +58,14 @@ void i8272::set_register(int address, uint8_t value) {
 uint8_t i8272::get_register(int address) {
 	if(address) {
 		printf("8272 get data\n");
-		return 0xff;
+		if(result_.empty()) return 0xff;
+		uint8_t result = result_.back();
+		result_.pop_back();
+		if(result_.empty()) posit_event((int)Event8272::ResultEmpty);
+		return result;
 	} else {
-		printf("8272 get status\n");
-		return status_;
+		printf("8272 get main status\n");
+		return main_status_;
 	}
 }
 
@@ -75,9 +85,9 @@ void i8272::posit_event(int type) {
 		command_.clear();
 
 	wait_for_complete_command_sequence:
-		status_ |= StatusRQM;
+		main_status_ |= StatusRQM;
 		WAIT_FOR_EVENT(Event8272::CommandByte)
-		status_ &= ~StatusRQM;
+		main_status_ &= ~StatusRQM;
 
 		switch(command_[0] & 0x1f) {
 			case 0x06:	// read data
@@ -144,55 +154,57 @@ void i8272::posit_event(int type) {
 		}
 
 	read_data:
-		printf("Read data unimplemented!!");
+		printf("Read data unimplemented!!\n");
 		goto wait_for_command;
 
 	read_deleted_data:
-		printf("Read deleted data unimplemented!!");
+		printf("Read deleted data unimplemented!!\n");
 		goto wait_for_command;
 
 	write_data:
-		printf("Write data unimplemented!!");
+		printf("Write data unimplemented!!\n");
 		goto wait_for_command;
 
 	write_deleted_data:
-		printf("Write deleted data unimplemented!!");
+		printf("Write deleted data unimplemented!!\n");
 		goto wait_for_command;
 
 	read_track:
-		printf("Read track unimplemented!!");
+		printf("Read track unimplemented!!\n");
 		goto wait_for_command;
 
 	read_id:
-		printf("Read ID unimplemented!!");
+		printf("Read ID unimplemented!!\n");
 		goto wait_for_command;
 
 	format_track:
-		printf("Fromat track unimplemented!!");
+		printf("Fromat track unimplemented!!\n");
 		goto wait_for_command;
 
 	scan_low:
-		printf("Scan low unimplemented!!");
+		printf("Scan low unimplemented!!\n");
 		goto wait_for_command;
 
 	scan_low_or_equal:
-		printf("Scan low or equal unimplemented!!");
+		printf("Scan low or equal unimplemented!!\n");
 		goto wait_for_command;
 
 	scan_high_or_equal:
-		printf("Scan high or equal unimplemented!!");
+		printf("Scan high or equal unimplemented!!\n");
 		goto wait_for_command;
 
 	recalibrate:
-		printf("Recalibrate unimplemented!!");
+		printf("Recalibrate unimplemented!!\n");
 		goto wait_for_command;
 
 	sense_interrupt_status:
-		printf("Sense interrupt status unimplemented!!");
-		goto wait_for_command;
+		printf("Sense interrupt status\n");
+		result_.push_back(head_position_);
+		result_.push_back(status_[0]);
+		goto post_result;
 
 	specify:
-		printf("Specify");
+		printf("Specify\n");
 		step_rate_time_ = command_[1] &0xf0;		// i.e. 16 to 240m
 		head_unload_time_ = command_[1] & 0x0f;		// i.e. 1 to 16ms
 		head_load_time_ = command_[2] & ~1;			// i.e. 2 to 254 ms in increments of 2ms
@@ -200,15 +212,22 @@ void i8272::posit_event(int type) {
 		goto wait_for_command;
 
 	sense_drive_status:
-		printf("Sense drive status unimplemented!!");
-		goto wait_for_command;
+		printf("Sense drive status\n");
+		result_.push_back(status_[3]);
+		goto post_result;
 
 	seek:
-		printf("Seek unimplemented!!");
+		printf("Seek unimplemented!!\n");
 		goto wait_for_command;
 
 	invalid:
 		// A no-op, causing the FDC to go back into standby mode.
+		goto wait_for_command;
+
+	post_result:
+		main_status_ |= StatusRQM | StatusDIO;
+		WAIT_FOR_EVENT(Event8272::ResultEmpty);
+		main_status_ &= ~StatusDIO;
 		goto wait_for_command;
 
 	END_SECTION()

--- a/Components/8272/i8272.cpp
+++ b/Components/8272/i8272.cpp
@@ -142,89 +142,116 @@ void i8272::posit_event(int event_type) {
 
 	BEGIN_SECTION();
 
+	// Resets busy and non-DMA execution, clears the command buffer, sets the data mode to scanning and flows
+	// into wait_for_complete_command_sequence.
 	wait_for_command:
 			set_data_mode(Storage::Disk::MFMController::DataMode::Scanning);
 			main_status_ &= ~(StatusCB | StatusNDM);
 			command_.clear();
 
+	// Sets the data request bit, and waits for a byte. Then sets the busy bit. Continues accepting bytes
+	// until it has a quantity that make up an entire command, then resets the data request bit and
+	// branches to that command.
 	wait_for_complete_command_sequence:
 			main_status_ |= StatusRQM;
 			WAIT_FOR_EVENT(Event8272::CommandByte)
 			main_status_ |= StatusCB;
-			main_status_ &= ~StatusRQM;
 
 			switch(command_[0] & 0x1f) {
 				case 0x06:	// read data
 					if(command_.size() < 9) goto wait_for_complete_command_sequence;
+					main_status_ &= ~StatusRQM;
 					goto read_data;
 
 				case 0x0b:	// read deleted data
 					if(command_.size() < 9) goto wait_for_complete_command_sequence;
+					main_status_ &= ~StatusRQM;
 					goto read_deleted_data;
 
 				case 0x05:	// write data
 					if(command_.size() < 9) goto wait_for_complete_command_sequence;
+					main_status_ &= ~StatusRQM;
 					goto write_data;
 
 				case 0x09:	// write deleted data
 					if(command_.size() < 9) goto wait_for_complete_command_sequence;
+					main_status_ &= ~StatusRQM;
 					goto write_deleted_data;
 
 				case 0x02:	// read track
 					if(command_.size() < 9) goto wait_for_complete_command_sequence;
+					main_status_ &= ~StatusRQM;
 					goto read_track;
 
 				case 0x0a:	// read ID
 					if(command_.size() < 2) goto wait_for_complete_command_sequence;
+					main_status_ &= ~StatusRQM;
 					goto read_id;
 
 				case 0x0d:	// format track
 					if(command_.size() < 6) goto wait_for_complete_command_sequence;
+					main_status_ &= ~StatusRQM;
 					goto format_track;
 
 				case 0x11:	// scan low
 					if(command_.size() < 9) goto wait_for_complete_command_sequence;
+					main_status_ &= ~StatusRQM;
 					goto scan_low;
 
 				case 0x19:	// scan low or equal
 					if(command_.size() < 9) goto wait_for_complete_command_sequence;
+					main_status_ &= ~StatusRQM;
 					goto scan_low_or_equal;
 
 				case 0x1d:	// scan high or equal
 					if(command_.size() < 9) goto wait_for_complete_command_sequence;
+					main_status_ &= ~StatusRQM;
 					goto scan_high_or_equal;
 
 				case 0x07:	// recalibrate
 					if(command_.size() < 2) goto wait_for_complete_command_sequence;
+					main_status_ &= ~StatusRQM;
 					goto recalibrate;
 
 				case 0x08:	// sense interrupt status
+					main_status_ &= ~StatusRQM;
 					goto sense_interrupt_status;
 
 				case 0x03:	// specify
 					if(command_.size() < 3) goto wait_for_complete_command_sequence;
+					main_status_ &= ~StatusRQM;
 					goto specify;
 
 				case 0x04:	// sense drive status
 					if(command_.size() < 2) goto wait_for_complete_command_sequence;
+					main_status_ &= ~StatusRQM;
 					goto sense_drive_status;
 
 				case 0x0f:	// seek
 					if(command_.size() < 3) goto wait_for_complete_command_sequence;
+					main_status_ &= ~StatusRQM;
 					goto seek;
 
 				default:	// invalid
+					main_status_ &= ~StatusRQM;
 					goto invalid;
 			}
 
+	// Performs the read data command.
 	read_data:
 			printf("Read data, sector %02x %02x %02x %02x\n", command_[2], command_[3], command_[4], command_[5]);
+
+		// Establishes the drive and head being addressed, and whether in double density mode; populates the internal
+		// cylinder, head, sector and size registers from the command stream.
 			SET_DRIVE_HEAD_MFM();
 			cylinder_ = command_[2];
 			head_ = command_[3];
 			sector_ = command_[4];
 			size_ = command_[5];
 
+		// Sets a maximum index hole limit of 2 then performs a find header/read header loop, continuing either until
+		// the index hole limit is breached or a sector is found with a cylinder, head, sector and size equal to the
+		// values in the internal registers.
 			index_hole_limit_ = 2;
 		find_next_sector:
 			FIND_HEADER();
@@ -232,10 +259,16 @@ void i8272::posit_event(int event_type) {
 			READ_HEADER();
 			if(header_[0] != cylinder_ || header_[1] != head_ || header_[2] != sector_ || header_[3] != size_) goto find_next_sector;
 
+		// Finds the next data block and sets data mode to reading.
 			FIND_DATA();
 			distance_into_section_ = 0;
 			set_data_mode(Reading);
 
+		// Waits for the next token, then supplies it to the CPU by: (i) setting data request and direction; and (ii) resetting
+		// data request once the byte has been taken. Continues until all bytes have been read.
+		//
+		// TODO: signal if the CPU is too slow and missed a byte; at the minute it'll just silently miss. Also allow for other
+		// ways that sector size might have been specified.
 		get_byte:
 			WAIT_FOR_EVENT(Event::Token);
 			result_stack_.push_back(get_latest_token().byte_value);
@@ -245,9 +278,11 @@ void i8272::posit_event(int event_type) {
 			main_status_ &= ~StatusRQM;
 			if(distance_into_section_ < (128 << size_)) goto get_byte;
 
-			set_data_mode(Scanning);
+		// For a final result phase, post the standard ST0, ST1, ST2, C, H, R, N
 			goto post_st012chrn;
 
+		// Execution reaches here if two index holes were discovered before a matching sector — i.e. the data wasn't found.
+		// In that case set appropriate error flags and post the results.
 		read_data_not_found:
 			printf("Not found\n");
 
@@ -271,26 +306,25 @@ void i8272::posit_event(int event_type) {
 		printf("Read track unimplemented!!\n");
 		goto wait_for_command;
 
+	// Performs the read ID command.
 	read_id:
+		// Establishes the drive and head being addressed, and whether in double density mode.
 			printf("Read ID\n");
 			SET_DRIVE_HEAD_MFM();
 
+		// Sets a maximum index hole limit of 2 then waits either until it finds a header mark or sees too many index holes.
+		// If a header mark is found, reads in the following bytes that produce a header. Otherwise branches to data not found.
 			index_hole_limit_ = 2;
 		read_id_find_next_sector:
 			FIND_HEADER();
-			if(!index_hole_limit_) goto read_id_not_found;
+			if(!index_hole_limit_) goto read_data_not_found;
 			READ_HEADER();
 
+		// Sets internal registers from the discovered header and posts the standard ST0, ST1, ST2, C, H, R, N.
 			cylinder_ = header_[0];
 			head_ = header_[1];
 			sector_ = header_[2];
 			size_ = header_[3];
-
-			goto post_st012chrn;
-
-		read_id_not_found:
-			status_[1] |= 0x4;
-			status_[0] = 0x40;
 
 			goto post_st012chrn;
 
@@ -310,9 +344,16 @@ void i8272::posit_event(int event_type) {
 		printf("Scan high or equal unimplemented!!\n");
 		goto wait_for_command;
 
+	// Performs both recalibrate and seek commands. These commands occur asynchronously, so the actual work
+	// occurs in ::run_for; this merely establishes that seeking should be ongoing.
 	recalibrate:
 	seek:
 			printf((command_.size() > 2) ? "Seek\n" : "Recalibrate\n");
+
+		// Declines to act if a seek is already ongoing; otherwise resets all status registers, sets the drive
+		// into seeking mode, sets the drive's main status seeking bit, and sets the target head position: for
+		// a recalibrate the target is -1 and ::run_for knows that -1 means the terminal condition is the drive
+		// returning that its at track zero, and that it should reset the drive's current position once reached.
 			if(drives_[command_[1]&3].phase != Drive::Seeking) {
 				status_[0] = status_[1] = status_[2] = 0;
 				drives_[command_[1]&3].phase = Drive::Seeking;
@@ -323,11 +364,11 @@ void i8272::posit_event(int event_type) {
 			}
 			goto wait_for_command;
 
+	// Performs sense interrupt status.
 	sense_interrupt_status:
 			printf("Sense interrupt status\n");
-			// Find the first drive that is in the CompletedSeeking state and return for that;
-			// if none has done so then return a single 0x80.
 			{
+				// Find the first drive that is in the CompletedSeeking state.
 				int found_drive = -1;
 				for(int c = 0; c < 4; c++) {
 					if(drives_[c].phase == Drive::CompletedSeeking) {
@@ -335,6 +376,8 @@ void i8272::posit_event(int event_type) {
 						break;
 					}
 				}
+
+				// If a drive was found, return its results. Otherwise return a single 0x80.
 				if(found_drive != -1) {
 					drives_[found_drive].phase = Drive::NotSeeking;
 					status_[0] = (uint8_t)found_drive | 0x20;
@@ -348,7 +391,9 @@ void i8272::posit_event(int event_type) {
 			}
 			goto post_result;
 
+	// Performs specify.
 	specify:
+		// Just store the values, and terminate the command.
 			step_rate_time_ = command_[1] &0xf0;		// i.e. 16 to 240m
 			head_unload_time_ = command_[1] & 0x0f;		// i.e. 1 to 16ms
 			head_load_time_ = command_[2] & ~1;			// i.e. 2 to 254 ms in increments of 2ms
@@ -359,10 +404,12 @@ void i8272::posit_event(int event_type) {
 		printf("Sense drive status unimplemented!!\n");
 		goto wait_for_command;
 
+	// Performs any invalid command.
 	invalid:
 			// A no-op, causing the FDC to go back into standby mode.
 			goto wait_for_command;
 
+	// Posts ST0, ST1, ST2, C, H, R and N as a result phase.
 	post_st012chrn:
 			result_stack_.push_back(size_);
 			result_stack_.push_back(sector_);
@@ -375,12 +422,18 @@ void i8272::posit_event(int event_type) {
 
 			goto post_result;
 
+	// Posts whatever is in result_stack_ as a result phase. Be aware that it is a stack — the
+	// last thing in it will be returned first.
 	post_result:
 			// Set ready to send data to the processor, no longer in non-DMA execution phase.
 			main_status_ |= StatusRQM | StatusDIO;
 			main_status_ &= ~StatusNDM;
 
+			// The actual stuff of unwinding result_stack_ is handled by ::get_register; wait
+			// until the processor has read all result bytes.
 			WAIT_FOR_EVENT(Event8272::ResultEmpty);
+
+			// Reset data direction and end the command.
 			main_status_ &= ~StatusDIO;
 			goto wait_for_command;
 

--- a/Components/8272/i8272.cpp
+++ b/Components/8272/i8272.cpp
@@ -143,120 +143,117 @@ void i8272::posit_event(int event_type) {
 	BEGIN_SECTION();
 
 	wait_for_command:
-		set_data_mode(Storage::Disk::MFMController::DataMode::Scanning);
-		main_status_ &= ~(StatusCB | StatusNDM);
-		command_.clear();
+			set_data_mode(Storage::Disk::MFMController::DataMode::Scanning);
+			main_status_ &= ~(StatusCB | StatusNDM);
+			command_.clear();
 
 	wait_for_complete_command_sequence:
-		main_status_ |= StatusRQM;
-		WAIT_FOR_EVENT(Event8272::CommandByte)
-//		printf(".");
-		main_status_ |= StatusCB;
-		main_status_ &= ~StatusRQM;
+			main_status_ |= StatusRQM;
+			WAIT_FOR_EVENT(Event8272::CommandByte)
+			main_status_ |= StatusCB;
+			main_status_ &= ~StatusRQM;
 
-		switch(command_[0] & 0x1f) {
-			case 0x06:	// read data
-				if(command_.size() < 9) goto wait_for_complete_command_sequence;
-				goto read_data;
+			switch(command_[0] & 0x1f) {
+				case 0x06:	// read data
+					if(command_.size() < 9) goto wait_for_complete_command_sequence;
+					goto read_data;
 
-			case 0x0b:	// read deleted data
-				if(command_.size() < 9) goto wait_for_complete_command_sequence;
-				goto read_deleted_data;
+				case 0x0b:	// read deleted data
+					if(command_.size() < 9) goto wait_for_complete_command_sequence;
+					goto read_deleted_data;
 
-			case 0x05:	// write data
-				if(command_.size() < 9) goto wait_for_complete_command_sequence;
-				goto write_data;
+				case 0x05:	// write data
+					if(command_.size() < 9) goto wait_for_complete_command_sequence;
+					goto write_data;
 
-			case 0x09:	// write deleted data
-				if(command_.size() < 9) goto wait_for_complete_command_sequence;
-				goto write_deleted_data;
+				case 0x09:	// write deleted data
+					if(command_.size() < 9) goto wait_for_complete_command_sequence;
+					goto write_deleted_data;
 
-			case 0x02:	// read track
-				if(command_.size() < 9) goto wait_for_complete_command_sequence;
-				goto read_track;
+				case 0x02:	// read track
+					if(command_.size() < 9) goto wait_for_complete_command_sequence;
+					goto read_track;
 
-			case 0x0a:	// read ID
-				if(command_.size() < 2) goto wait_for_complete_command_sequence;
-				goto read_id;
+				case 0x0a:	// read ID
+					if(command_.size() < 2) goto wait_for_complete_command_sequence;
+					goto read_id;
 
-			case 0x0d:	// format track
-				if(command_.size() < 6) goto wait_for_complete_command_sequence;
-				goto format_track;
+				case 0x0d:	// format track
+					if(command_.size() < 6) goto wait_for_complete_command_sequence;
+					goto format_track;
 
-			case 0x11:	// scan low
-				if(command_.size() < 9) goto wait_for_complete_command_sequence;
-				goto scan_low;
+				case 0x11:	// scan low
+					if(command_.size() < 9) goto wait_for_complete_command_sequence;
+					goto scan_low;
 
-			case 0x19:	// scan low or equal
-				if(command_.size() < 9) goto wait_for_complete_command_sequence;
-				goto scan_low_or_equal;
+				case 0x19:	// scan low or equal
+					if(command_.size() < 9) goto wait_for_complete_command_sequence;
+					goto scan_low_or_equal;
 
-			case 0x1d:	// scan high or equal
-				if(command_.size() < 9) goto wait_for_complete_command_sequence;
-				goto scan_high_or_equal;
+				case 0x1d:	// scan high or equal
+					if(command_.size() < 9) goto wait_for_complete_command_sequence;
+					goto scan_high_or_equal;
 
-			case 0x07:	// recalibrate
-				if(command_.size() < 2) goto wait_for_complete_command_sequence;
-				goto recalibrate;
+				case 0x07:	// recalibrate
+					if(command_.size() < 2) goto wait_for_complete_command_sequence;
+					goto recalibrate;
 
-			case 0x08:	// sense interrupt status
-				goto sense_interrupt_status;
+				case 0x08:	// sense interrupt status
+					goto sense_interrupt_status;
 
-			case 0x03:	// specify
-				if(command_.size() < 3) goto wait_for_complete_command_sequence;
-				goto specify;
+				case 0x03:	// specify
+					if(command_.size() < 3) goto wait_for_complete_command_sequence;
+					goto specify;
 
-			case 0x04:	// sense drive status
-				if(command_.size() < 2) goto wait_for_complete_command_sequence;
-				goto sense_drive_status;
+				case 0x04:	// sense drive status
+					if(command_.size() < 2) goto wait_for_complete_command_sequence;
+					goto sense_drive_status;
 
-			case 0x0f:	// seek
-				if(command_.size() < 3) goto wait_for_complete_command_sequence;
-				goto seek;
+				case 0x0f:	// seek
+					if(command_.size() < 3) goto wait_for_complete_command_sequence;
+					goto seek;
 
-			default:	// invalid
-				goto invalid;
-		}
+				default:	// invalid
+					goto invalid;
+			}
 
 	read_data:
-		printf("Read data, sector %02x %02x %02x %02x\n", command_[2], command_[3], command_[4], command_[5]);
-		SET_DRIVE_HEAD_MFM();
-		cylinder_ = command_[2];
-		head_ = command_[3];
-		sector_ = command_[4];
-		size_ = command_[5];
+			printf("Read data, sector %02x %02x %02x %02x\n", command_[2], command_[3], command_[4], command_[5]);
+			SET_DRIVE_HEAD_MFM();
+			cylinder_ = command_[2];
+			head_ = command_[3];
+			sector_ = command_[4];
+			size_ = command_[5];
 
-		index_hole_limit_ = 2;
-	find_next_sector:
-		FIND_HEADER();
-		if(!index_hole_limit_) goto read_data_not_found;
-		READ_HEADER();
-//		printf("Comparing with %02x\n", header_[2]);
-		if(header_[0] != cylinder_ || header_[1] != head_ || header_[2] != sector_ || header_[3] != size_) goto find_next_sector;
+			index_hole_limit_ = 2;
+		find_next_sector:
+			FIND_HEADER();
+			if(!index_hole_limit_) goto read_data_not_found;
+			READ_HEADER();
+			if(header_[0] != cylinder_ || header_[1] != head_ || header_[2] != sector_ || header_[3] != size_) goto find_next_sector;
 
+			FIND_DATA();
+			distance_into_section_ = 0;
+			set_data_mode(Reading);
 
-		FIND_DATA();
-		distance_into_section_ = 0;
-		set_data_mode(Reading);
+		get_byte:
+			WAIT_FOR_EVENT(Event::Token);
+			result_stack_.push_back(get_latest_token().byte_value);
+			distance_into_section_++;
+			main_status_ |= StatusRQM | StatusDIO;
+			WAIT_FOR_EVENT(Event8272::ResultEmpty);
+			main_status_ &= ~StatusRQM;
+			if(distance_into_section_ < (128 << size_)) goto get_byte;
 
-	get_byte:
-		WAIT_FOR_EVENT(Event::Token);
-		result_stack_.push_back(get_latest_token().byte_value);
-		distance_into_section_++;
-		main_status_ |= StatusRQM | StatusDIO;
-		WAIT_FOR_EVENT(Event8272::ResultEmpty);
-		main_status_ &= ~StatusRQM;
-		if(distance_into_section_ < (128 << size_)) goto get_byte;
+			set_data_mode(Scanning);
+			goto post_st012chrn;
 
-		set_data_mode(Scanning);
-		goto return_st012chrn;
+		read_data_not_found:
+			printf("Not found\n");
 
-	read_data_not_found:
-		printf("Not found\n");
-
-		status_[1] |= 0x4;
-		status_[0] = 0x40;	// (status_[0] & ~0xc0) |
-		goto return_st012chrn;
+			status_[1] |= 0x4;
+			status_[0] = 0x40;	// (status_[0] & ~0xc0) |
+			goto post_st012chrn;
 
 	read_deleted_data:
 		printf("Read deleted data unimplemented!!\n");
@@ -275,37 +272,27 @@ void i8272::posit_event(int event_type) {
 		goto wait_for_command;
 
 	read_id:
-		printf("Read ID\n");
-		SET_DRIVE_HEAD_MFM();
+			printf("Read ID\n");
+			SET_DRIVE_HEAD_MFM();
 
-		index_hole_limit_ = 2;
-	read_id_find_next_sector:
-		FIND_HEADER();
-		if(!index_hole_limit_) goto read_id_not_found;
-		READ_HEADER();
+			index_hole_limit_ = 2;
+		read_id_find_next_sector:
+			FIND_HEADER();
+			if(!index_hole_limit_) goto read_id_not_found;
+			READ_HEADER();
 
-		cylinder_ = header_[0];
-		head_ = header_[1];
-		sector_ = header_[2];
-		size_ = header_[3];
+			cylinder_ = header_[0];
+			head_ = header_[1];
+			sector_ = header_[2];
+			size_ = header_[3];
 
-		goto return_st012chrn;
+			goto post_st012chrn;
 
-	read_id_not_found:
-		status_[1] |= 0x4;
-		status_[0] = 0x40;	// (status_[0] & ~0xc0) |
+		read_id_not_found:
+			status_[1] |= 0x4;
+			status_[0] = 0x40;
 
-	return_st012chrn:
-		result_stack_.push_back(size_);
-		result_stack_.push_back(sector_);
-		result_stack_.push_back(head_);
-		result_stack_.push_back(cylinder_);
-
-		result_stack_.push_back(status_[2]);
-		result_stack_.push_back(status_[1]);
-		result_stack_.push_back(status_[0]);
-
-		goto post_result;
+			goto post_st012chrn;
 
 	format_track:
 		printf("Fromat track unimplemented!!\n");
@@ -325,67 +312,77 @@ void i8272::posit_event(int event_type) {
 
 	recalibrate:
 	seek:
-		printf((command_.size() > 2) ? "Seek\n" : "Recalibrate\n");
-		if(drives_[command_[1]&3].phase != Drive::Seeking) {
-			status_[0] = status_[1] = status_[2] = 0;
-			drives_[command_[1]&3].phase = Drive::Seeking;
-			drives_[command_[1]&3].steps_taken = 0;
-			drives_[command_[1]&3].target_head_position = (command_.size() > 2) ? command_[2] : -1;
-			drives_[command_[1]&3].step_rate_counter = 0;
-			main_status_ |= 1 << (command_[1]&3);
-		}
-		goto wait_for_command;
+			printf((command_.size() > 2) ? "Seek\n" : "Recalibrate\n");
+			if(drives_[command_[1]&3].phase != Drive::Seeking) {
+				status_[0] = status_[1] = status_[2] = 0;
+				drives_[command_[1]&3].phase = Drive::Seeking;
+				drives_[command_[1]&3].steps_taken = 0;
+				drives_[command_[1]&3].target_head_position = (command_.size() > 2) ? command_[2] : -1;
+				drives_[command_[1]&3].step_rate_counter = 0;
+				main_status_ |= 1 << (command_[1]&3);
+			}
+			goto wait_for_command;
 
 	sense_interrupt_status:
-		printf("Sense interrupt status\n");
-		// Find the first drive that is in the CompletedSeeking state and return for that;
-		// if none has done so then return a single 0x80.
-		{
-			int found_drive = -1;
-			for(int c = 0; c < 4; c++) {
-				if(drives_[c].phase == Drive::CompletedSeeking) {
-					found_drive = c;
-					break;
+			printf("Sense interrupt status\n");
+			// Find the first drive that is in the CompletedSeeking state and return for that;
+			// if none has done so then return a single 0x80.
+			{
+				int found_drive = -1;
+				for(int c = 0; c < 4; c++) {
+					if(drives_[c].phase == Drive::CompletedSeeking) {
+						found_drive = c;
+						break;
+					}
+				}
+				if(found_drive != -1) {
+					drives_[found_drive].phase = Drive::NotSeeking;
+					status_[0] = (uint8_t)found_drive | 0x20;
+					main_status_ &= ~(1 << found_drive);
+
+					result_stack_.push_back(drives_[found_drive].head_position);
+					result_stack_.push_back(status_[0]);
+				} else {
+					result_stack_.push_back(0x80);
 				}
 			}
-			if(found_drive != -1) {
-				drives_[found_drive].phase = Drive::NotSeeking;
-				status_[0] = (uint8_t)found_drive | 0x20;
-				main_status_ &= ~(1 << found_drive);
-
-				result_stack_.push_back(drives_[found_drive].head_position);
-				result_stack_.push_back(status_[0]);
-			} else {
-				result_stack_.push_back(0x80);
-			}
-		}
-		goto post_result;
+			goto post_result;
 
 	specify:
-		printf("Specify\n");
-		step_rate_time_ = command_[1] &0xf0;		// i.e. 16 to 240m
-		head_unload_time_ = command_[1] & 0x0f;		// i.e. 1 to 16ms
-		head_load_time_ = command_[2] & ~1;			// i.e. 2 to 254 ms in increments of 2ms
-		dma_mode_ = !(command_[2] & 1);
-		goto wait_for_command;
+			step_rate_time_ = command_[1] &0xf0;		// i.e. 16 to 240m
+			head_unload_time_ = command_[1] & 0x0f;		// i.e. 1 to 16ms
+			head_load_time_ = command_[2] & ~1;			// i.e. 2 to 254 ms in increments of 2ms
+			dma_mode_ = !(command_[2] & 1);
+			goto wait_for_command;
 
 	sense_drive_status:
 		printf("Sense drive status unimplemented!!\n");
-//		result_stack_.push_back(status_[3]);
-		goto post_result;
+		goto wait_for_command;
 
 	invalid:
-		// A no-op, causing the FDC to go back into standby mode.
-		goto wait_for_command;
+			// A no-op, causing the FDC to go back into standby mode.
+			goto wait_for_command;
+
+	post_st012chrn:
+			result_stack_.push_back(size_);
+			result_stack_.push_back(sector_);
+			result_stack_.push_back(head_);
+			result_stack_.push_back(cylinder_);
+
+			result_stack_.push_back(status_[2]);
+			result_stack_.push_back(status_[1]);
+			result_stack_.push_back(status_[0]);
+
+			goto post_result;
 
 	post_result:
-		// Set ready to send data to the processor, no longer in non-DMA execution phase.
-		main_status_ |= StatusRQM | StatusDIO;
-		main_status_ &= ~StatusNDM;
+			// Set ready to send data to the processor, no longer in non-DMA execution phase.
+			main_status_ |= StatusRQM | StatusDIO;
+			main_status_ &= ~StatusNDM;
 
-		WAIT_FOR_EVENT(Event8272::ResultEmpty);
-		main_status_ &= ~StatusDIO;
-		goto wait_for_command;
+			WAIT_FOR_EVENT(Event8272::ResultEmpty);
+			main_status_ &= ~StatusDIO;
+			goto wait_for_command;
 
 	END_SECTION()
 }

--- a/Components/8272/i8272.cpp
+++ b/Components/8272/i8272.cpp
@@ -47,22 +47,24 @@ void i8272::run_for(Cycles cycles) {
 	}
 
 	// update seek status of any drives presently seeking
-	for(int c = 0; c < 4; c++) {
-		if(drives_[c].phase == Drive::Seeking) {
-			drives_[c].step_rate_counter += cycles.as_int();
-			int steps = drives_[c].step_rate_counter / (8000 * step_rate_time_);
-			drives_[c].step_rate_counter %= (8000 * step_rate_time_);
-			while(steps--) {
-				// Perform a step.
-				int direction = (drives_[c].target_head_position < drives_[c].head_position) ? -1 : 1;
-				drives_[c].drive->step(direction);
-				drives_[c].head_position += direction;
+	if(main_status_ & 0xf) {
+		for(int c = 0; c < 4; c++) {
+			if(drives_[c].phase == Drive::Seeking) {
+				drives_[c].step_rate_counter += cycles.as_int();
+				int steps = drives_[c].step_rate_counter / (8000 * step_rate_time_);
+				drives_[c].step_rate_counter %= (8000 * step_rate_time_);
+				while(steps--) {
+					// Perform a step.
+					int direction = (drives_[c].target_head_position < drives_[c].head_position) ? -1 : 1;
+					drives_[c].drive->step(direction);
+					drives_[c].head_position += direction;
 
-				// Check for completion.
-				if(seek_is_satisfied(c)) {
-					drives_[c].phase = Drive::CompletedSeeking;
-					if(drives_[c].target_head_position == -1) drives_[c].head_position = 0;
-					break;
+					// Check for completion.
+					if(seek_is_satisfied(c)) {
+						drives_[c].phase = Drive::CompletedSeeking;
+						if(drives_[c].target_head_position == -1) drives_[c].head_position = 0;
+						break;
+					}
 				}
 			}
 		}

--- a/Components/8272/i8272.cpp
+++ b/Components/8272/i8272.cpp
@@ -8,11 +8,82 @@
 
 #include "i8272.hpp"
 
+#include <cstdio>
+
 using namespace Intel;
 
 void i8272::set_register(int address, uint8_t value) {
+	if(!address) return;
+
+	// TODO: if not accepting commands, return
+
+	command_.push_back(value);
+	size_t necessary_length;
+	switch(command_[0] & 0x1f) {
+		case 0x06:	// read data
+			necessary_length = 9;
+		break;
+		case 0x0b:	// read deleted data
+			necessary_length = 9;
+		break;
+		case 0x05:	// write data
+			necessary_length = 9;
+		break;
+		case 0x09:	// write deleted data
+			necessary_length = 9;
+		break;
+		case 0x02:	// read track
+			necessary_length = 9;
+		break;
+		case 0x0a:	// read ID
+			necessary_length = 2;
+		break;
+		case 0x0d:	// format track
+			necessary_length = 6;
+		break;
+		case 0x11:	// scan low
+			necessary_length = 9;
+		break;
+		case 0x19:	// scan low  or equal
+			necessary_length = 9;
+		break;
+		case 0x1d:	// scan high or equal
+			necessary_length = 9;
+		break;
+		case 0x07:	// recalibrate
+			necessary_length = 2;
+		break;
+		case 0x08:	// sense interrupt status
+			necessary_length = 1;
+		break;
+		case 0x03:	// specify
+			necessary_length = 3;
+		break;
+		case 0x04:	// sense drive status
+			necessary_length = 2;
+		break;
+		case 0x0f:	// seek
+			necessary_length = 3;
+		break;
+		default:	// invalid
+			necessary_length = 1;
+		break;
+	}
+
+	printf("8272 set register %d to %02x\n", address, value);
+
+	if(command_.size() == necessary_length) {
+		printf("8272 Perform!\n");
+		command_.clear();
+	}
 }
 
 uint8_t i8272::get_register(int address) {
-	return 0xff;
+	if(address) {
+		printf("8272 get data\n");
+		return 0xff;
+	} else {
+		printf("8272 get status\n");
+		return 0x80;
+	}
 }

--- a/Components/8272/i8272.hpp
+++ b/Components/8272/i8272.hpp
@@ -25,6 +25,8 @@ class i8272: public Storage::Disk::MFMController {
 		void set_register(int address, uint8_t value);
 		uint8_t get_register(int address);
 
+		void set_disk(std::shared_ptr<Storage::Disk::Disk> disk, int drive);
+
 	private:
 		void posit_event(int type);
 		uint8_t main_status_;

--- a/Components/8272/i8272.hpp
+++ b/Components/8272/i8272.hpp
@@ -31,7 +31,7 @@ class i8272: public Storage::Disk::MFMController {
 	private:
 		void posit_event(int type);
 		uint8_t main_status_;
-		uint8_t status_[4];
+		uint8_t status_[3];
 
 		std::vector<uint8_t> command_;
 		std::vector<uint8_t> result_stack_;

--- a/Components/8272/i8272.hpp
+++ b/Components/8272/i8272.hpp
@@ -34,7 +34,7 @@ class i8272: public Storage::Disk::MFMController {
 		uint8_t status_[4];
 
 		std::vector<uint8_t> command_;
-		std::vector<uint8_t> result_;
+		std::vector<uint8_t> result_stack_;
 
 		enum class Event8272: int {
 			CommandByte	= (1 << 3),

--- a/Components/8272/i8272.hpp
+++ b/Components/8272/i8272.hpp
@@ -73,6 +73,8 @@ class i8272: public Storage::Disk::MFMController {
 		int index_hole_limit_;
 
 		uint8_t cylinder_, head_, sector_, size_;
+
+		bool seek_is_satisfied(int drive);
 };
 
 }

--- a/Components/8272/i8272.hpp
+++ b/Components/8272/i8272.hpp
@@ -71,6 +71,8 @@ class i8272: public Storage::Disk::MFMController {
 		uint8_t header_[6];
 		int distance_into_header_;
 		int index_hole_limit_;
+
+		uint8_t cylinder_, head_, sector_, size_;
 };
 
 }

--- a/Components/8272/i8272.hpp
+++ b/Components/8272/i8272.hpp
@@ -9,17 +9,24 @@
 #ifndef i8272_hpp
 #define i8272_hpp
 
+#include "../../Storage/Disk/MFMDiskController.hpp"
+
 #include <cstdint>
 #include <vector>
 
 namespace Intel {
 
-class i8272 {
+class i8272: public Storage::Disk::MFMController {
 	public:
+		i8272(Cycles clock_rate, int clock_rate_multiplier, int revolutions_per_minute);
+
+		void run_for(Cycles);
+
 		void set_register(int address, uint8_t value);
 		uint8_t get_register(int address);
 
 	private:
+		void posit_event(Event type);
 		uint8_t status_;
 		std::vector<uint8_t> command_;
 };

--- a/Components/8272/i8272.hpp
+++ b/Components/8272/i8272.hpp
@@ -27,13 +27,16 @@ class i8272: public Storage::Disk::MFMController {
 
 	private:
 		void posit_event(int type);
-		uint8_t status_;
+		uint8_t main_status_;
+		uint8_t status_[4];
+
 		std::vector<uint8_t> command_;
+		std::vector<uint8_t> result_;
 
 		enum class Event8272: int {
 			CommandByte	= (1 << 3),
 			Timer = (1 << 4),
-
+			ResultEmpty = (1 << 5),
 		};
 
 		int interesting_event_mask_;
@@ -44,6 +47,8 @@ class i8272: public Storage::Disk::MFMController {
 		int head_unload_time_;
 		int head_load_time_;
 		bool dma_mode_;
+
+		uint8_t head_position_;
 };
 
 }

--- a/Components/8272/i8272.hpp
+++ b/Components/8272/i8272.hpp
@@ -69,7 +69,7 @@ class i8272: public Storage::Disk::MFMController {
 		} drives_[4];
 
 		uint8_t header_[6];
-		int distance_into_header_;
+		int distance_into_section_;
 		int index_hole_limit_;
 
 		uint8_t cylinder_, head_, sector_, size_;

--- a/Components/8272/i8272.hpp
+++ b/Components/8272/i8272.hpp
@@ -26,9 +26,24 @@ class i8272: public Storage::Disk::MFMController {
 		uint8_t get_register(int address);
 
 	private:
-		void posit_event(Event type);
+		void posit_event(int type);
 		uint8_t status_;
 		std::vector<uint8_t> command_;
+
+		enum class Event8272: int {
+			CommandByte	= (1 << 3),
+			Timer = (1 << 4),
+
+		};
+
+		int interesting_event_mask_;
+		int resume_point_;
+		int delay_time_;
+
+		int step_rate_time_;
+		int head_unload_time_;
+		int head_load_time_;
+		bool dma_mode_;
 };
 
 }

--- a/Components/8272/i8272.hpp
+++ b/Components/8272/i8272.hpp
@@ -67,6 +67,9 @@ class i8272: public Storage::Disk::MFMController {
 
 			Drive() : head_position(0), phase(NotSeeking) {};
 		} drives_[4];
+
+		uint8_t header_[6];
+		int distance_into_header_;
 };
 
 }

--- a/Components/8272/i8272.hpp
+++ b/Components/8272/i8272.hpp
@@ -60,7 +60,7 @@ class i8272: public Storage::Disk::MFMController {
 				CompletedSeeking
 			} phase;
 			int step_rate_counter;
-			int permitted_steps;
+			int steps_taken;
 			int target_head_position;	// either an actual number, or -1 to indicate to step until track zero
 
 			std::shared_ptr<Storage::Disk::Drive> drive;

--- a/Components/8272/i8272.hpp
+++ b/Components/8272/i8272.hpp
@@ -10,14 +10,18 @@
 #define i8272_hpp
 
 #include <cstdint>
+#include <vector>
 
 namespace Intel {
 
 class i8272 {
 	public:
-
 		void set_register(int address, uint8_t value);
 		uint8_t get_register(int address);
+
+	private:
+		uint8_t status_;
+		std::vector<uint8_t> command_;
 };
 
 }

--- a/Components/8272/i8272.hpp
+++ b/Components/8272/i8272.hpp
@@ -63,13 +63,14 @@ class i8272: public Storage::Disk::MFMController {
 			int permitted_steps;
 			int target_head_position;	// either an actual number, or -1 to indicate to step until track zero
 
-			Storage::Disk::Drive drive;
+			std::shared_ptr<Storage::Disk::Drive> drive;
 
-			Drive() : head_position(0), phase(NotSeeking) {};
+			Drive() : head_position(0), phase(NotSeeking), drive(new Storage::Disk::Drive) {};
 		} drives_[4];
 
 		uint8_t header_[6];
 		int distance_into_header_;
+		int index_hole_limit_;
 };
 
 }

--- a/Components/8272/i8272.hpp
+++ b/Components/8272/i8272.hpp
@@ -10,6 +10,7 @@
 #define i8272_hpp
 
 #include "../../Storage/Disk/MFMDiskController.hpp"
+#include "../../Storage/Disk/Drive.hpp"
 
 #include <cstdint>
 #include <vector>
@@ -50,7 +51,22 @@ class i8272: public Storage::Disk::MFMController {
 		int head_load_time_;
 		bool dma_mode_;
 
-		uint8_t head_position_;
+		struct Drive {
+			uint8_t head_position;
+
+			enum Phase {
+				NotSeeking,
+				Seeking,
+				CompletedSeeking
+			} phase;
+			int step_rate_counter;
+			int permitted_steps;
+			int target_head_position;	// either an actual number, or -1 to indicate to step until track zero
+
+			Storage::Disk::Drive drive;
+
+			Drive() : head_position(0), phase(NotSeeking) {};
+		} drives_[4];
 };
 
 }

--- a/Components/8272/i8272.hpp
+++ b/Components/8272/i8272.hpp
@@ -1,0 +1,26 @@
+//
+//  i8272.hpp
+//  Clock Signal
+//
+//  Created by Thomas Harte on 05/08/2017.
+//  Copyright © 2017 Thomas Harte. All rights reserved.
+//
+
+#ifndef i8272_hpp
+#define i8272_hpp
+
+#include <cstdint>
+
+namespace Intel {
+
+class i8272 {
+	public:
+
+		void set_register(int address, uint8_t value);
+		uint8_t get_register(int address);
+};
+
+}
+
+
+#endif /* i8272_hpp */

--- a/Machines/AmstradCPC/AmstradCPC.cpp
+++ b/Machines/AmstradCPC/AmstradCPC.cpp
@@ -739,7 +739,13 @@ class ConcreteMachine:
 				tape_player_.set_tape(target.tapes.front());
 			}
 
-			// TODO: disks.
+			// Insert up to four disks.
+			int c = 0;
+			for(auto &disk : target.disks) {
+				fdc_.set_disk(disk, c);
+				c++;
+				if(c == 4) break;
+			}
 		}
 
 		// See header; provides the system ROMs.

--- a/Machines/AmstradCPC/AmstradCPC.cpp
+++ b/Machines/AmstradCPC/AmstradCPC.cpp
@@ -10,9 +10,10 @@
 
 #include "../../Processors/Z80/Z80.hpp"
 
-#include "../../Components/8255/i8255.hpp"
-#include "../../Components/AY38910/AY38910.hpp"
 #include "../../Components/6845/CRTC6845.hpp"
+#include "../../Components/8255/i8255.hpp"
+#include "../../Components/8272/i8272.hpp"
+#include "../../Components/AY38910/AY38910.hpp"
 
 #include "../../Storage/Tape/Tape.hpp"
 
@@ -601,6 +602,11 @@ class ConcreteMachine:
 					if(!(address & 0x800)) {
 						i8255_.set_register((address >> 8) & 3, *cycle.value);
 					}
+
+					// Check for an FDC access
+					if(has_fdc_ && (address & 0x580) == 0x100) {
+						i8272_.set_register(address & 1, *cycle.value);
+					}
 				break;
 				case CPU::Z80::PartialMachineCycle::Input:
 					// Default to nothing answering
@@ -618,6 +624,11 @@ class ConcreteMachine:
 					// Check for a PIO access
 					if(!(address & 0x800)) {
 						*cycle.value = i8255_.get_register((address >> 8) & 3);
+					}
+
+					// Check for an FDC access
+					if(has_fdc_ && (address & 0x580) == 0x100) {
+						*cycle.value = i8272_.get_register(address & 1);
 					}
 				break;
 
@@ -736,6 +747,8 @@ class ConcreteMachine:
 		AYDeferrer ay_;
 		i8255PortHandler i8255_port_handler_;
 		Intel::i8255::i8255<i8255PortHandler> i8255_;
+
+		Intel::i8272 i8272_;
 
 		InterruptTimer interrupt_timer_;
 		Storage::Tape::BinaryTapePlayer tape_player_;

--- a/Machines/AmstradCPC/AmstradCPC.cpp
+++ b/Machines/AmstradCPC/AmstradCPC.cpp
@@ -583,7 +583,7 @@ class ConcreteMachine:
 					}
 
 					// Check for an upper ROM selection
-					if(has_fdc_ && address == 0xdf00) {
+					if(has_fdc_ && !(address&0x2000)) {
 						upper_rom_ = (*cycle.value == 7) ? ROMType::AMSDOS : rom_model_ + 1;
 						if(upper_rom_is_paged_) read_pointers_[3] = roms_[upper_rom_].data();
 					}

--- a/Machines/AmstradCPC/AmstradCPC.hpp
+++ b/Machines/AmstradCPC/AmstradCPC.hpp
@@ -18,9 +18,10 @@
 
 namespace AmstradCPC {
 
-enum ROMType: uint8_t {
-	OS464,		OS664,		OS6128,
-	BASIC464,	BASIC664,	BASIC6128,
+enum ROMType: int {
+	OS464 = 0,	BASIC464,
+	OS664,		BASIC664,
+	OS6128,		BASIC6128,
 	AMSDOS
 };
 

--- a/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
@@ -396,6 +396,7 @@
 		4BB73EC21B587A5100552FC2 /* Clock_SignalUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB73EC11B587A5100552FC2 /* Clock_SignalUITests.swift */; };
 		4BBB14311CD2CECE00BDB55C /* IntermediateShader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4BBB142F1CD2CECE00BDB55C /* IntermediateShader.cpp */; };
 		4BBC951E1F368D83008F4C34 /* i8272.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4BBC951C1F368D83008F4C34 /* i8272.cpp */; };
+		4BBC95221F36B16C008F4C34 /* MFMDiskController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4BBC95201F36B16C008F4C34 /* MFMDiskController.cpp */; };
 		4BBF49AF1ED2880200AB3669 /* FUSETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BBF49AE1ED2880200AB3669 /* FUSETests.swift */; };
 		4BBF99141C8FBA6F0075DAFB /* TextureBuilder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4BBF99081C8FBA6F0075DAFB /* TextureBuilder.cpp */; };
 		4BBF99151C8FBA6F0075DAFB /* CRTOpenGL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4BBF990A1C8FBA6F0075DAFB /* CRTOpenGL.cpp */; };
@@ -957,6 +958,8 @@
 		4BBC34241D2208B100FFC9DF /* CSFastLoading.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CSFastLoading.h; sourceTree = "<group>"; };
 		4BBC951C1F368D83008F4C34 /* i8272.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = i8272.cpp; path = 8272/i8272.cpp; sourceTree = "<group>"; };
 		4BBC951D1F368D83008F4C34 /* i8272.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = i8272.hpp; path = 8272/i8272.hpp; sourceTree = "<group>"; };
+		4BBC95201F36B16C008F4C34 /* MFMDiskController.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MFMDiskController.cpp; sourceTree = "<group>"; };
+		4BBC95211F36B16C008F4C34 /* MFMDiskController.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = MFMDiskController.hpp; sourceTree = "<group>"; };
 		4BBF49AE1ED2880200AB3669 /* FUSETests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FUSETests.swift; sourceTree = "<group>"; };
 		4BBF99081C8FBA6F0075DAFB /* TextureBuilder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TextureBuilder.cpp; sourceTree = "<group>"; };
 		4BBF99091C8FBA6F0075DAFB /* TextureBuilder.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = TextureBuilder.hpp; sourceTree = "<group>"; };
@@ -1528,6 +1531,7 @@
 				4BAB62AB1D3272D200DF5BA0 /* Disk.cpp */,
 				4B6C73BB1D387AE500AFCFCA /* DiskController.cpp */,
 				4B30512B1D989E2200B4FED8 /* Drive.cpp */,
+				4BBC95201F36B16C008F4C34 /* MFMDiskController.cpp */,
 				4B3F1B441E0388D200DB26EE /* PCMPatchedTrack.cpp */,
 				4B121F961E060CF000BFDA12 /* PCMSegment.cpp */,
 				4BAB62B61D3302CA00DF5BA0 /* PCMTrack.cpp */,
@@ -1535,6 +1539,7 @@
 				4BAB62AC1D3272D200DF5BA0 /* Disk.hpp */,
 				4B6C73BC1D387AE500AFCFCA /* DiskController.hpp */,
 				4B30512C1D989E2200B4FED8 /* Drive.hpp */,
+				4BBC95211F36B16C008F4C34 /* MFMDiskController.hpp */,
 				4B3F1B451E0388D200DB26EE /* PCMPatchedTrack.hpp */,
 				4B121F971E060CF000BFDA12 /* PCMSegment.hpp */,
 				4BAB62B71D3302CA00DF5BA0 /* PCMTrack.hpp */,
@@ -2745,6 +2750,7 @@
 				4BF829631D8F536B001BAE39 /* SSD.cpp in Sources */,
 				4B2E2D9D1C3A070400138695 /* Electron.cpp in Sources */,
 				4B3940E71DA83C8300427841 /* AsyncTaskQueue.cpp in Sources */,
+				4BBC95221F36B16C008F4C34 /* MFMDiskController.cpp in Sources */,
 				4BAB62B81D3302CA00DF5BA0 /* PCMTrack.cpp in Sources */,
 				4B69FB3D1C4D908A00B5F0AA /* Tape.cpp in Sources */,
 				4B8378DF1F33675F005CA9E4 /* CharacterMapper.cpp in Sources */,

--- a/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
@@ -395,6 +395,7 @@
 		4BB73EB71B587A5100552FC2 /* AllSuiteATests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB73EB61B587A5100552FC2 /* AllSuiteATests.swift */; };
 		4BB73EC21B587A5100552FC2 /* Clock_SignalUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB73EC11B587A5100552FC2 /* Clock_SignalUITests.swift */; };
 		4BBB14311CD2CECE00BDB55C /* IntermediateShader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4BBB142F1CD2CECE00BDB55C /* IntermediateShader.cpp */; };
+		4BBC951E1F368D83008F4C34 /* i8272.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4BBC951C1F368D83008F4C34 /* i8272.cpp */; };
 		4BBF49AF1ED2880200AB3669 /* FUSETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BBF49AE1ED2880200AB3669 /* FUSETests.swift */; };
 		4BBF99141C8FBA6F0075DAFB /* TextureBuilder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4BBF99081C8FBA6F0075DAFB /* TextureBuilder.cpp */; };
 		4BBF99151C8FBA6F0075DAFB /* CRTOpenGL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4BBF990A1C8FBA6F0075DAFB /* CRTOpenGL.cpp */; };
@@ -954,6 +955,8 @@
 		4BBB142F1CD2CECE00BDB55C /* IntermediateShader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IntermediateShader.cpp; sourceTree = "<group>"; };
 		4BBB14301CD2CECE00BDB55C /* IntermediateShader.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = IntermediateShader.hpp; sourceTree = "<group>"; };
 		4BBC34241D2208B100FFC9DF /* CSFastLoading.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CSFastLoading.h; sourceTree = "<group>"; };
+		4BBC951C1F368D83008F4C34 /* i8272.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = i8272.cpp; path = 8272/i8272.cpp; sourceTree = "<group>"; };
+		4BBC951D1F368D83008F4C34 /* i8272.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = i8272.hpp; path = 8272/i8272.hpp; sourceTree = "<group>"; };
 		4BBF49AE1ED2880200AB3669 /* FUSETests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FUSETests.swift; sourceTree = "<group>"; };
 		4BBF99081C8FBA6F0075DAFB /* TextureBuilder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TextureBuilder.cpp; sourceTree = "<group>"; };
 		4BBF99091C8FBA6F0075DAFB /* TextureBuilder.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = TextureBuilder.hpp; sourceTree = "<group>"; };
@@ -1982,6 +1985,15 @@
 			path = ../../Processors;
 			sourceTree = "<group>";
 		};
+		4BBC951F1F368D87008F4C34 /* 8272 */ = {
+			isa = PBXGroup;
+			children = (
+				4BBC951C1F368D83008F4C34 /* i8272.cpp */,
+				4BBC951D1F368D83008F4C34 /* i8272.hpp */,
+			);
+			name = 8272;
+			sourceTree = "<group>";
+		};
 		4BBF49B41ED2881600AB3669 /* FUSE */ = {
 			isa = PBXGroup;
 			children = (
@@ -2048,6 +2060,7 @@
 				4B4A762D1DB1A35C007AAE2E /* AY38910 */,
 				4BE845221F2FF7F400A5EA22 /* 6845 */,
 				4BD9137C1F3115AC009BCF85 /* 8255 */,
+				4BBC951F1F368D87008F4C34 /* 8272 */,
 			);
 			name = Components;
 			path = ../../Components;
@@ -2738,6 +2751,7 @@
 				4B8FE2291DA1EDDF0090D3CE /* ElectronOptionsPanel.swift in Sources */,
 				4B55CE5D1C3B7D6F0093A61B /* CSOpenGLView.m in Sources */,
 				4BB697CB1D4B6D3E00248BDF /* TimedEventLoop.cpp in Sources */,
+				4BBC951E1F368D83008F4C34 /* i8272.cpp in Sources */,
 				4BF1354C1D6D2C300054B2EA /* StaticAnalyser.cpp in Sources */,
 				4B4A76301DB1A3FA007AAE2E /* AY38910.cpp in Sources */,
 				4B2A53A31D117D36003C6002 /* CSVic20.mm in Sources */,

--- a/StaticAnalyser/AmstradCPC/StaticAnalyser.cpp
+++ b/StaticAnalyser/AmstradCPC/StaticAnalyser.cpp
@@ -19,5 +19,8 @@ void StaticAnalyser::AmstradCPC::AddTargets(
 	target.disks = disks;
 	target.tapes = tapes;
 	target.cartridges = cartridges;
+
+	target.amstradcpc.model = target.disks.empty() ? AmstradCPCModel::CPC464 : AmstradCPCModel::CPC664;
+
 	destination.push_back(target);
 }

--- a/StaticAnalyser/StaticAnalyser.hpp
+++ b/StaticAnalyser/StaticAnalyser.hpp
@@ -46,6 +46,12 @@ enum class ZX8081MemoryModel {
 	SixtyFourKB
 };
 
+enum class AmstradCPCModel {
+	CPC464,
+	CPC664,
+	CPC6128
+};
+
 /*!
 	A list of disks, tapes and cartridges plus information about the machine to which to attach them and its configuration,
 	and instructions on how to launch the software attached, plus a measure of confidence in this target's correctness.
@@ -61,6 +67,8 @@ struct Target {
 	} machine;
 	float probability;
 
+	// TODO: this is too C-like a solution; make Target a base class and
+	// turn the following into information held by more specific subclasses.
 	union {
 		struct {
 			bool has_adfs;
@@ -87,6 +95,10 @@ struct Target {
 			ZX8081MemoryModel memory_model;
 			bool isZX81;
 		} zx8081;
+
+		struct {
+			AmstradCPCModel model;
+		} amstradcpc;
 	};
 
 	std::string loadingCommand;

--- a/Storage/Disk/DiskController.cpp
+++ b/Storage/Disk/DiskController.cpp
@@ -11,8 +11,8 @@
 
 using namespace Storage::Disk;
 
-Controller::Controller(int clock_rate, int clock_rate_multiplier, int revolutions_per_minute) :
-		clock_rate_(clock_rate * clock_rate_multiplier),
+Controller::Controller(Cycles clock_rate, int clock_rate_multiplier, int revolutions_per_minute) :
+		clock_rate_(clock_rate.as_int() * clock_rate_multiplier),
 		clock_rate_multiplier_(clock_rate_multiplier),
 		rotational_multiplier_(60, revolutions_per_minute),
 
@@ -21,7 +21,7 @@ Controller::Controller(int clock_rate, int clock_rate_multiplier, int revolution
 
 		is_reading_(true),
 
-		TimedEventLoop((unsigned int)(clock_rate * clock_rate_multiplier)) {
+		TimedEventLoop((unsigned int)(clock_rate.as_int() * clock_rate_multiplier)) {
 	// seed this class with a PLL, any PLL, so that it's safe to assume non-nullptr later
 	Time one(1);
 	set_expected_bit_length(one);

--- a/Storage/Disk/DiskController.hpp
+++ b/Storage/Disk/DiskController.hpp
@@ -14,6 +14,7 @@
 #include "PCMSegment.hpp"
 #include "PCMPatchedTrack.hpp"
 #include "../TimedEventLoop.hpp"
+#include "../../ClockReceiver/ClockReceiver.hpp"
 
 namespace Storage {
 namespace Disk {
@@ -33,7 +34,7 @@ class Controller: public DigitalPhaseLockedLoop::Delegate, public TimedEventLoop
 			Constructs a @c DiskDrive that will be run at @c clock_rate and runs its PLL at @c clock_rate*clock_rate_multiplier,
 			spinning inserted disks at @c revolutions_per_minute.
 		*/
-		Controller(int clock_rate, int clock_rate_multiplier, int revolutions_per_minute);
+		Controller(Cycles clock_rate, int clock_rate_multiplier, int revolutions_per_minute);
 
 		/*!
 			Communicates to the PLL the expected length of a bit as a fraction of a second.

--- a/Storage/Disk/Formats/CPCDSK.cpp
+++ b/Storage/Disk/Formats/CPCDSK.cpp
@@ -27,6 +27,8 @@ CPCDSK::CPCDSK(const char *file_name) :
 	head_count_ = (unsigned int)fgetc(file_);
 
 	if(is_extended_) {
+		// Skip two unused bytes and grab the track size table.
+		fseek(file_, 2, SEEK_CUR);
 		for(unsigned int c = 0; c < head_position_count_ * head_count_; c++) {
 			track_sizes_.push_back((size_t)(fgetc(file_) << 8));
 		}

--- a/Storage/Disk/Formats/CPCDSK.cpp
+++ b/Storage/Disk/Formats/CPCDSK.cpp
@@ -16,6 +16,7 @@ CPCDSK::CPCDSK(const char *file_name) :
 	Storage::FileHolder(file_name), is_extended_(false) {
 	if(!check_signature("MV - CPC", 8)) {
 		is_extended_ = true;
+		fseek(file_, 0, SEEK_SET);
 		if(!check_signature("EXTENDED", 8))
 			throw ErrorNotCPCDSK;
 	}

--- a/Storage/Disk/Formats/CPCDSK.cpp
+++ b/Storage/Disk/Formats/CPCDSK.cpp
@@ -60,6 +60,7 @@ std::shared_ptr<Track> CPCDSK::get_uncached_track_at_position(unsigned int head,
 		unsigned int t = 0;
 		while(t < chronological_track && t < track_sizes_.size()) {
 			file_offset += track_sizes_[t];
+			t++;
 		}
 	} else {
 		// Tracks are a fixed size in the original DSK file format.

--- a/Storage/Disk/Formats/CPCDSK.cpp
+++ b/Storage/Disk/Formats/CPCDSK.cpp
@@ -124,6 +124,22 @@ std::shared_ptr<Track> CPCDSK::get_uncached_track_at_position(unsigned int head,
 
 		// TODO: obey the status bytes, somehow (?)
 		if(sector_info.status1 || sector_info.status2) {
+			if(sector_info.status1 & 0x08) {
+				// The CRC failed in the ID field.
+			}
+
+			if(sector_info.status2 & 0x20) {
+				// The CRC failed in the data field.
+			}
+
+			if(sector_info.status2 & 0x40) {
+				// This sector is marked as deleted.
+			}
+
+			if(sector_info.status2 & 0x01) {
+				// Data field wasn't found.
+			}
+
 			printf("Unhandled: status errors\n");
 		}
 

--- a/Storage/Disk/MFMDiskController.cpp
+++ b/Storage/Disk/MFMDiskController.cpp
@@ -20,11 +20,11 @@ MFMController::MFMController(Cycles clock_rate, int clock_rate_multiplier, int r
 }
 
 void MFMController::process_index_hole() {
-	posit_event(Event::IndexHole);
+	posit_event((int)Event::IndexHole);
 }
 
 void MFMController::process_write_completed() {
-	posit_event(Event::DataWritten);
+	posit_event((int)Event::DataWritten);
 }
 
 void MFMController::set_is_double_density(bool is_double_density) {
@@ -107,7 +107,7 @@ void MFMController::process_input_bit(int value, unsigned int cycles_since_index
 		if(token_type != Token::Byte) {
 			latest_token_.type = token_type;
 			bits_since_token_ = 0;
-			posit_event(Event::Token);
+			posit_event((int)Event::Token);
 			return;
 		}
 	}
@@ -145,7 +145,7 @@ void MFMController::process_input_bit(int value, unsigned int cycles_since_index
 		}
 
 		crc_generator_.add(latest_token_.byte_value);
-		posit_event(Event::Token);
+		posit_event((int)Event::Token);
 		return;
 	}
 }

--- a/Storage/Disk/MFMDiskController.cpp
+++ b/Storage/Disk/MFMDiskController.cpp
@@ -1,0 +1,151 @@
+//
+//  MFMDiskController.cpp
+//  Clock Signal
+//
+//  Created by Thomas Harte on 05/08/2017.
+//  Copyright © 2017 Thomas Harte. All rights reserved.
+//
+
+#include "MFMDiskController.hpp"
+
+#include "../../Storage/Disk/Encodings/MFM.hpp"
+
+using namespace Storage::Disk;
+
+MFMController::MFMController(int clock_rate, int clock_rate_multiplier, int revolutions_per_minute) :
+	Storage::Disk::Controller(clock_rate, clock_rate_multiplier, revolutions_per_minute),
+	crc_generator_(0x1021, 0xffff),
+	data_mode_(DataMode::Scanning),
+	is_awaiting_marker_value_(false) {
+}
+
+void MFMController::process_index_hole() {
+	posit_event(Event::IndexHole);
+}
+
+void MFMController::process_write_completed() {
+	posit_event(Event::DataWritten);
+}
+
+void MFMController::set_is_double_density(bool is_double_density) {
+	is_double_density_ = is_double_density;
+	Storage::Time bit_length;
+	bit_length.length = 1;
+	bit_length.clock_rate = is_double_density ? 500000 : 250000;
+	set_expected_bit_length(bit_length);
+
+	if(!is_double_density) is_awaiting_marker_value_ = false;
+}
+
+bool MFMController::get_is_double_density() {
+	return is_double_density_;
+}
+
+void MFMController::set_data_mode(DataMode mode) {
+	data_mode_ = mode;
+}
+
+MFMController::Token MFMController::get_latest_token() {
+	return latest_token_;
+}
+
+void MFMController::process_input_bit(int value, unsigned int cycles_since_index_hole) {
+	if(data_mode_ == DataMode::Writing) return;
+
+	shift_register_ = (shift_register_ << 1) | value;
+	bits_since_token_++;
+
+	if(data_mode_ == DataMode::Scanning) {
+		Token::Type token_type = Token::Byte;
+		if(!is_double_density_) {
+			switch(shift_register_ & 0xffff) {
+				case Storage::Encodings::MFM::FMIndexAddressMark:
+					token_type = Token::Index;
+					crc_generator_.reset();
+					crc_generator_.add(latest_token_.byte_value = Storage::Encodings::MFM::IndexAddressByte);
+				break;
+				case Storage::Encodings::MFM::FMIDAddressMark:
+					token_type = Token::ID;
+					crc_generator_.reset();
+					crc_generator_.add(latest_token_.byte_value = Storage::Encodings::MFM::IDAddressByte);
+				break;
+				case Storage::Encodings::MFM::FMDataAddressMark:
+					token_type = Token::Data;
+					crc_generator_.reset();
+					crc_generator_.add(latest_token_.byte_value = Storage::Encodings::MFM::DataAddressByte);
+				break;
+				case Storage::Encodings::MFM::FMDeletedDataAddressMark:
+					token_type = Token::DeletedData;
+					crc_generator_.reset();
+					crc_generator_.add(latest_token_.byte_value = Storage::Encodings::MFM::DeletedDataAddressByte);
+				break;
+				default:
+				break;
+			}
+		} else {
+			switch(shift_register_ & 0xffff) {
+				case Storage::Encodings::MFM::MFMIndexSync:
+					bits_since_token_ = 0;
+					is_awaiting_marker_value_ = true;
+
+					token_type = Token::Sync;
+					latest_token_.byte_value = Storage::Encodings::MFM::MFMIndexSyncByteValue;
+				break;
+				case Storage::Encodings::MFM::MFMSync:
+					bits_since_token_ = 0;
+					is_awaiting_marker_value_ = true;
+					crc_generator_.set_value(Storage::Encodings::MFM::MFMPostSyncCRCValue);
+
+					token_type = Token::Sync;
+					latest_token_.byte_value = Storage::Encodings::MFM::MFMSyncByteValue;
+				break;
+				default:
+				break;
+			}
+		}
+
+		if(token_type != Token::Byte) {
+			latest_token_.type = token_type;
+			bits_since_token_ = 0;
+			posit_event(Event::Token);
+			return;
+		}
+	}
+
+	if(bits_since_token_ == 16) {
+		latest_token_.type = Token::Byte;
+		latest_token_.byte_value = (uint8_t)(
+			((shift_register_ & 0x0001) >> 0) |
+			((shift_register_ & 0x0004) >> 1) |
+			((shift_register_ & 0x0010) >> 2) |
+			((shift_register_ & 0x0040) >> 3) |
+			((shift_register_ & 0x0100) >> 4) |
+			((shift_register_ & 0x0400) >> 5) |
+			((shift_register_ & 0x1000) >> 6) |
+			((shift_register_ & 0x4000) >> 7));
+		bits_since_token_ = 0;
+
+		if(is_awaiting_marker_value_ && is_double_density_) {
+			is_awaiting_marker_value_ = false;
+			switch(latest_token_.byte_value) {
+				case Storage::Encodings::MFM::IndexAddressByte:
+					latest_token_.type = Token::Index;
+				break;
+				case Storage::Encodings::MFM::IDAddressByte:
+					latest_token_.type = Token::ID;
+				break;
+				case Storage::Encodings::MFM::DataAddressByte:
+					latest_token_.type = Token::Data;
+				break;
+				case Storage::Encodings::MFM::DeletedDataAddressByte:
+					latest_token_.type = Token::DeletedData;
+				break;
+				default: break;
+			}
+		}
+
+		crc_generator_.add(latest_token_.byte_value);
+		posit_event(Event::Token);
+		return;
+	}
+}

--- a/Storage/Disk/MFMDiskController.cpp
+++ b/Storage/Disk/MFMDiskController.cpp
@@ -49,6 +49,10 @@ MFMController::Token MFMController::get_latest_token() {
 	return latest_token_;
 }
 
+NumberTheory::CRC16 &MFMController::get_crc_generator() {
+	return crc_generator_;
+}
+
 void MFMController::process_input_bit(int value, unsigned int cycles_since_index_hole) {
 	if(data_mode_ == DataMode::Writing) return;
 

--- a/Storage/Disk/MFMDiskController.cpp
+++ b/Storage/Disk/MFMDiskController.cpp
@@ -12,7 +12,7 @@
 
 using namespace Storage::Disk;
 
-MFMController::MFMController(int clock_rate, int clock_rate_multiplier, int revolutions_per_minute) :
+MFMController::MFMController(Cycles clock_rate, int clock_rate_multiplier, int revolutions_per_minute) :
 	Storage::Disk::Controller(clock_rate, clock_rate_multiplier, revolutions_per_minute),
 	crc_generator_(0x1021, 0xffff),
 	data_mode_(DataMode::Scanning),

--- a/Storage/Disk/MFMDiskController.hpp
+++ b/Storage/Disk/MFMDiskController.hpp
@@ -85,7 +85,7 @@ class MFMController: public Controller {
 				(ii) the index hole passes; or
 				(iii) the queue of data to be written has been exhausted.
 		*/
-		virtual void posit_event(Event type) = 0;
+		virtual void posit_event(int type) = 0;
 
 	private:
 		// Storage::Disk::Controller

--- a/Storage/Disk/MFMDiskController.hpp
+++ b/Storage/Disk/MFMDiskController.hpp
@@ -70,6 +70,9 @@ class MFMController: public Controller {
 		/// @returns The most-recently read token from the surface of the disk.
 		Token get_latest_token();
 
+		/// @returns The controller's CRC generator. This is automatically fed during reading.
+		NumberTheory::CRC16 &get_crc_generator();
+
 		// Events
 		enum class Event: int {
 			Token			= (1 << 0),	// Indicates recognition of a new token in the flux stream. Use get_latest_token() for more details.

--- a/Storage/Disk/MFMDiskController.hpp
+++ b/Storage/Disk/MFMDiskController.hpp
@@ -1,0 +1,80 @@
+//
+//  MFMDiskController.hpp
+//  Clock Signal
+//
+//  Created by Thomas Harte on 05/08/2017.
+//  Copyright © 2017 Thomas Harte. All rights reserved.
+//
+
+#ifndef MFMDiskController_hpp
+#define MFMDiskController_hpp
+
+#include "DiskController.hpp"
+#include "../../NumberTheory/CRC.hpp"
+
+namespace Storage {
+namespace Disk {
+
+/*!
+	Extends Controller with a built-in shift register and FM/MFM decoding logic,
+	being able to post event messages to subclasses.
+*/
+class MFMController: public Controller {
+	public:
+		MFMController(int clock_rate, int clock_rate_multiplier, int revolutions_per_minute);
+
+	protected:
+		void set_is_double_density(bool);
+		bool get_is_double_density();
+
+		enum DataMode {
+			Scanning,
+			Reading,
+			Writing
+		};
+		void set_data_mode(DataMode);
+
+		struct Token {
+			enum Type {
+				Index, ID, Data, DeletedData, Sync, Byte
+			} type;
+			uint8_t byte_value;
+		};
+		Token get_latest_token();
+
+		// Events
+		enum class Event: int {
+			Command			= (1 << 0),	// Indicates receipt of a new command.
+			Token			= (1 << 1),	// Indicates recognition of a new token in the flux stream. Use get_latest_token() for more details.
+			IndexHole		= (1 << 2),	// Indicates the passing of a physical index hole.
+			HeadLoad		= (1 << 3),	// Indicates the head has been loaded.
+			DataWritten		= (1 << 4),	// Indicates that all queued bits have been written
+		};
+		virtual void posit_event(Event type) = 0;
+
+	private:
+		// Storage::Disk::Controller
+		virtual void process_input_bit(int value, unsigned int cycles_since_index_hole);
+		virtual void process_index_hole();
+		virtual void process_write_completed();
+
+		// PLL input state
+		int bits_since_token_;
+		int shift_register_;
+		bool is_awaiting_marker_value_;
+
+		// input configuration
+		bool is_double_density_;
+		DataMode data_mode_;
+
+		// output
+		Token latest_token_;
+
+		// CRC generator
+		NumberTheory::CRC16 crc_generator_;
+};
+
+}
+}
+
+#endif /* MFMDiskController_hpp */

--- a/Storage/Disk/MFMDiskController.hpp
+++ b/Storage/Disk/MFMDiskController.hpp
@@ -11,6 +11,7 @@
 
 #include "DiskController.hpp"
 #include "../../NumberTheory/CRC.hpp"
+#include "../../ClockReceiver/ClockReceiver.hpp"
 
 namespace Storage {
 namespace Disk {
@@ -21,7 +22,7 @@ namespace Disk {
 */
 class MFMController: public Controller {
 	public:
-		MFMController(int clock_rate, int clock_rate_multiplier, int revolutions_per_minute);
+		MFMController(Cycles clock_rate, int clock_rate_multiplier, int revolutions_per_minute);
 
 	protected:
 		void set_is_double_density(bool);


### PR DESCRIPTION
This is achieved partly by copying out the PLL stream -> event stream code of the WD1770. A next step will be to turn that into a proper outward factoring; several other divergent possibilities present themselves though so this is offered for a merge.

Also included:
* improved .DSK support, including the EXTENDED version.