### PR TITLE
Makes various AY input/output fixes, and a few 8255 fixes along the way

### DIFF
--- a/Components/8255/i8255.hpp
+++ b/Components/8255/i8255.hpp
@@ -46,9 +46,13 @@ template <class T> class i8255 {
 
 		uint8_t get_register(int address) {
 			switch(address & 3) {
-				case 0:	return port_handler_.get_value(0);
-				case 1:	return port_handler_.get_value(1);
-				case 2:	return port_handler_.get_value(2);
+				case 0:	return (control_ & 0x10) ? port_handler_.get_value(0) : outputs_[0];
+				case 1:	return (control_ & 0x02) ? port_handler_.get_value(1) : outputs_[1];
+				case 2:	{
+					if(!(control_ & 0x09)) return outputs_[2];
+					uint8_t input = port_handler_.get_value(2);
+					return ((control_ & 0x01) ? (input & 0x0f) : (outputs_[2] & 0x0f)) | ((control_ & 0x08) ? (input & 0xf0) : (outputs_[2] & 0xf0));
+				}
 				case 3:	return control_;
 			}
 			return 0xff;

--- a/Components/8255/i8255.hpp
+++ b/Components/8255/i8255.hpp
@@ -26,8 +26,17 @@ template <class T> class i8255 {
 
 		void set_register(int address, uint8_t value) {
 			switch(address & 3) {
-				case 0:	outputs_[0] = value; port_handler_.set_value(0, value);	break;
-				case 1:	outputs_[1] = value; port_handler_.set_value(1, value);	break;
+				case 0:
+					if(!(control_ & 0x10)) {
+						// TODO: so what would output be when switching from input to output mode?
+						outputs_[0] = value; port_handler_.set_value(0, value);
+					}
+				break;
+				case 1:
+					if(!(control_ & 0x02)) {
+						outputs_[1] = value; port_handler_.set_value(1, value);
+					}
+				break;
 				case 2:	outputs_[2] = value; port_handler_.set_value(2, value);	break;
 				case 3:
 					if(value & 0x80) {

--- a/Components/AY38910/AY38910.cpp
+++ b/Components/AY38910/AY38910.cpp
@@ -227,7 +227,7 @@ uint8_t AY38910::get_register_value() {
 	};
 
 	switch(selected_register_) {
-		default:	return registers_[selected_register_] | register_masks[selected_register_];
+		default:	return registers_[selected_register_] & ~register_masks[selected_register_];
 		case 14:	return (registers_[0x7] & 0x40) ? registers_[14] : port_inputs_[0];
 		case 15:	return (registers_[0x7] & 0x80) ? registers_[15] : port_inputs_[1];
 	}

--- a/Components/AY38910/AY38910.cpp
+++ b/Components/AY38910/AY38910.cpp
@@ -169,10 +169,11 @@ void AY38910::evaluate_output_volume() {
 #pragma mark - Register manipulation
 
 void AY38910::select_register(uint8_t r) {
-	selected_register_ = r & 0xf;
+	selected_register_ = r;
 }
 
 void AY38910::set_register_value(uint8_t value) {
+	if(selected_register_ > 15) return;
 	registers_[selected_register_] = value;
 	if(selected_register_ < 14) {
 		int selected_register = selected_register_;
@@ -226,6 +227,7 @@ uint8_t AY38910::get_register_value() {
 		0xe0, 0xe0, 0xe0, 0x00, 0x00, 0xf0, 0x00, 0x00
 	};
 
+	if(selected_register_ > 15) return 0xff;
 	switch(selected_register_) {
 		default:	return registers_[selected_register_] & ~register_masks[selected_register_];
 		case 14:	return (registers_[0x7] & 0x40) ? registers_[14] : port_inputs_[0];

--- a/Components/AY38910/AY38910.cpp
+++ b/Components/AY38910/AY38910.cpp
@@ -226,7 +226,11 @@ uint8_t AY38910::get_register_value() {
 		0xe0, 0xe0, 0xe0, 0x00, 0x00, 0xf0, 0x00, 0x00
 	};
 
-	return registers_[selected_register_] | register_masks[selected_register_];
+	switch(selected_register_) {
+		default:	return registers_[selected_register_] | register_masks[selected_register_];
+		case 14:	return (registers_[0x7] & 0x40) ? registers_[14] : port_inputs_[0];
+		case 15:	return (registers_[0x7] & 0x80) ? registers_[15] : port_inputs_[1];
+	}
 }
 
 #pragma mark - Port handling
@@ -236,7 +240,7 @@ uint8_t AY38910::get_port_output(bool port_b) {
 }
 
 void AY38910::set_port_input(bool port_b, uint8_t value) {
-	registers_[port_b ? 15 : 14] = value;
+	port_inputs_[port_b ? 1 : 0] = value;
 	update_bus();
 }
 

--- a/Components/AY38910/AY38910.hpp
+++ b/Components/AY38910/AY38910.hpp
@@ -59,6 +59,7 @@ class AY38910: public ::Outputs::Filter<AY38910> {
 	private:
 		int selected_register_;
 		uint8_t registers_[16], output_registers_[16];
+		uint8_t port_inputs_[2];
 
 		int master_divider_;
 


### PR DESCRIPTION
Specifically, on the AY, to ensure that ports configured as output return their outputting values as input, and to treat selection of an invalid register as a way of avoiding any effect from future writes. On the 8255, to introduce some respect for input/output selection in the control word.