### PR TITLE
Corrects a couple of CPC static analysis pitfalls

### DIFF
--- a/StaticAnalyser/AmstradCPC/StaticAnalyser.cpp
+++ b/StaticAnalyser/AmstradCPC/StaticAnalyser.cpp
@@ -38,7 +38,7 @@ static void InspectDataCatalogue(
 
 	for(size_t c = 0; c < data_catalogue->files.size(); c++) {
 		// Check for whether this is [potentially] BASIC.
-		if(!((data_catalogue->files[c].data[18] >> 1) & 7)) {
+		if(data_catalogue->files[c].data.size() >= 128 && !((data_catalogue->files[c].data[18] >> 1) & 7)) {
 			basic_files++;
 			last_basic_file = c;
 		}

--- a/StaticAnalyser/AmstradCPC/StaticAnalyser.cpp
+++ b/StaticAnalyser/AmstradCPC/StaticAnalyser.cpp
@@ -9,6 +9,16 @@
 #include "StaticAnalyser.hpp"
 #include "../../Storage/Disk/Parsers/CPM.hpp"
 
+static bool strcmp_insensitive(const char *a, const char *b) {
+	if(strlen(a) != strlen(b)) return false;
+	while(*a) {
+		if(tolower(*a) != towlower(*b)) return false;
+		a++;
+		b++;
+	}
+	return true;
+}
+
 static void InspectDataCatalogue(
 	const std::unique_ptr<Storage::Disk::CPM::Catalogue> &data_catalogue,
 	StaticAnalyser::Target &target) {
@@ -18,12 +28,14 @@ static void InspectDataCatalogue(
 		return;
 	}
 
-	// If only one file is [potentially] BASIC, run that one; otherwise if only one has no suffix,
-	// pick that one.
+	// If only one file is [potentially] BASIC, run that one; otherwise if only one has a suffix
+	// that AMSDOS allows to be omitted, pick that one.
 	int basic_files = 0;
-	int nonsuffixed_files = 0;
+	int implicit_suffixed_files = 0;
+
 	size_t last_basic_file = 0;
-	size_t last_nonsuffixed_file = 0;
+	size_t last_implicit_suffixed_file = 0;
+
 	for(size_t c = 0; c < data_catalogue->files.size(); c++) {
 		// Check for whether this is [potentially] BASIC.
 		if(!((data_catalogue->files[c].data[18] >> 1) & 7)) {
@@ -32,13 +44,17 @@ static void InspectDataCatalogue(
 		}
 
 		// Check suffix for emptiness.
-		if(data_catalogue->files[c].type == "   ") {
-			nonsuffixed_files++;
-			last_nonsuffixed_file = c;
+		if(
+			data_catalogue->files[c].type == "   " ||
+			strcmp_insensitive(data_catalogue->files[c].type.c_str(), "BAS") ||
+			strcmp_insensitive(data_catalogue->files[c].type.c_str(), "BIN")
+		) {
+			implicit_suffixed_files++;
+			last_implicit_suffixed_file = c;
 		}
 	}
-	if(basic_files == 1 || nonsuffixed_files == 1) {
-		size_t selected_file = (basic_files == 1) ? last_basic_file : last_nonsuffixed_file;
+	if(basic_files == 1 || implicit_suffixed_files == 1) {
+		size_t selected_file = (basic_files == 1) ? last_basic_file : last_implicit_suffixed_file;
 		target.loadingCommand = "run\"" + data_catalogue->files[selected_file].name + "\n";
 		return;
 	}

--- a/Storage/Disk/Encodings/MFM.cpp
+++ b/Storage/Disk/Encodings/MFM.cpp
@@ -432,10 +432,10 @@ std::shared_ptr<Sector> Parser::get_next_sector() {
 		sector->track = get_next_byte();
 		sector->side = get_next_byte();
 		sector->sector = get_next_byte();
-		uint8_t size = get_next_byte();
+		sector->size = get_next_byte();
 		uint16_t header_crc = crc_generator_.get_value();
-		if((header_crc >> 8) != get_next_byte()) continue;
-		if((header_crc & 0xff) != get_next_byte()) continue;
+		if((header_crc >> 8) != get_next_byte()) sector->has_header_crc_error = true;
+		if((header_crc & 0xff) != get_next_byte()) sector->has_header_crc_error = true;
 
 		// look for data mark
 		bool data_found = false;
@@ -462,14 +462,14 @@ std::shared_ptr<Sector> Parser::get_next_sector() {
 		}
 		crc_generator_.add(DataAddressByte);
 
-		size_t data_size = (size_t)(128 << size);
+		size_t data_size = (size_t)(128 << sector->size);
 		sector->data.reserve(data_size);
 		for(size_t c = 0; c < data_size; c++) {
 			sector->data.push_back(get_next_byte());
 		}
 		uint16_t data_crc = crc_generator_.get_value();
-		if((data_crc >> 8) != get_next_byte()) continue;
-		if((data_crc & 0xff) != get_next_byte()) continue;
+		if((data_crc >> 8) != get_next_byte()) sector->has_data_crc_error = true;
+		if((data_crc & 0xff) != get_next_byte()) sector->has_data_crc_error = true;
 
 		// Put this sector into the cache.
 		int index = get_index(head_, track_, sector->sector);


### PR DESCRIPTION
1. treating ".   " as a special case, rather than in combination with ".BIN" and ".BAS" (i.e. the three that AMSDOS is happy to take an implicit suffix for);
2. not recognising that some files have no storage whatsoever, and therefore no header to check for a BASIC flag in.