### PR TITLE
Improves the 8272 and the whole disk infrastructure behind it

### DIFF
--- a/Components/1770/1770.cpp
+++ b/Components/1770/1770.cpp
@@ -502,7 +502,7 @@ void WD1770::posit_event(int new_event_type) {
 		}
 
 		set_data_mode(DataMode::Writing);
-		begin_writing();
+		begin_writing(false);
 		for(int c = 0; c < (get_is_double_density() ? 12 : 6); c++) {
 			write_byte(0);
 		}
@@ -694,7 +694,7 @@ void WD1770::posit_event(int new_event_type) {
 		}
 
 		WAIT_FOR_EVENT(Event1770::IndexHoleTarget);
-		begin_writing();
+		begin_writing(true);
 		index_hole_count_ = 0;
 
 	write_track_write_loop:

--- a/Components/8272/i8272.cpp
+++ b/Components/8272/i8272.cpp
@@ -812,7 +812,7 @@ void i8272::posit_event(int event_type) {
 	// Posts whatever is in result_stack_ as a result phase. Be aware that it is a stack — the
 	// last thing in it will be returned first.
 	post_result:
-			printf("Result to %02x: ", command_[0] & 0x1f);
+			printf("Result to %02x, main %02x: ", command_[0] & 0x1f, main_status_);
 			for(size_t c = 0; c < result_stack_.size(); c++) {
 				printf("%02x ", result_stack_[result_stack_.size() - 1 - c]);
 			}

--- a/Components/8272/i8272.cpp
+++ b/Components/8272/i8272.cpp
@@ -205,7 +205,7 @@ void i8272::set_disk(std::shared_ptr<Storage::Disk::Disk> disk, int drive) {
 	set_data_mode(DataMode::Scanning);	\
 	CONCAT(find_data, __LINE__): WAIT_FOR_EVENT((int)Event::Token | (int)Event::IndexHole); \
 	if(event_type == (int)Event::Token) { \
-		if(get_latest_token().type == Token::Byte) goto CONCAT(find_data, __LINE__);	\
+		if(get_latest_token().type == Token::Byte || get_latest_token().type == Token::Sync) goto CONCAT(find_data, __LINE__);	\
 	}
 
 #define READ_HEADER()	\

--- a/Components/8272/i8272.cpp
+++ b/Components/8272/i8272.cpp
@@ -195,7 +195,7 @@ void i8272::set_disk(std::shared_ptr<Storage::Disk::Disk> disk, int drive) {
 #define FIND_HEADER()	\
 	set_data_mode(DataMode::Scanning);	\
 	CONCAT(find_header, __LINE__): WAIT_FOR_EVENT((int)Event::Token | (int)Event::IndexHole); \
-	if(event_type == (int)Event::IndexHole) { printf("I\n"); index_hole_limit_--; }	\
+	if(event_type == (int)Event::IndexHole) { index_hole_limit_--; }	\
 	else if(get_latest_token().type == Token::ID) goto CONCAT(header_found, __LINE__);	\
 	\
 	if(index_hole_limit_) goto CONCAT(find_header, __LINE__);	\
@@ -216,8 +216,6 @@ void i8272::set_disk(std::shared_ptr<Storage::Disk::Disk> disk, int drive) {
 	distance_into_section_++; \
 	if(distance_into_section_ < 6) goto CONCAT(read_header, __LINE__);	\
 
-//	printf("%02x -> %04x\n", header_[distance_into_section_], get_crc_generator().get_value());	\
-
 #define SET_DRIVE_HEAD_MFM()	\
 	active_drive_ = command_[1]&3;	\
 	active_head_ = (command_[1] >> 2)&1;	\
@@ -231,8 +229,6 @@ void i8272::set_disk(std::shared_ptr<Storage::Disk::Disk> disk, int drive) {
 	CONCAT(wait_bytes, __LINE__): WAIT_FOR_EVENT(Event::Token);	\
 	if(get_latest_token().type == Token::Byte) distance_into_section_++;	\
 	if(distance_into_section_ < (n)) goto CONCAT(wait_bytes, __LINE__);
-
-// printf("%02x\n", get_latest_token().byte_value);
 
 #define LOAD_HEAD()	\
 	if(!drives_[active_drive_].head_is_loaded[active_head_]) {	\

--- a/Components/8272/i8272.hpp
+++ b/Components/8272/i8272.hpp
@@ -117,7 +117,7 @@ class i8272: public Storage::Disk::MFMController {
 		// Transient storage and counters used while reading the disk.
 		uint8_t header_[6];
 		int distance_into_section_;
-		int index_hole_limit_;
+		int index_hole_count_, index_hole_limit_;
 
 		// Keeps track of the drive and head in use during commands.
 		int active_drive_;

--- a/Components/8272/i8272.hpp
+++ b/Components/8272/i8272.hpp
@@ -66,6 +66,7 @@ class i8272: public Storage::Disk::MFMController {
 		void posit_event(int type);
 		int interesting_event_mask_;
 		int resume_point_;
+		bool is_access_command_;
 
 		// The counter used for ::Timer events.
 		int delay_time_;

--- a/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
@@ -121,6 +121,7 @@
 		4BAB62B51D327F7E00DF5BA0 /* G64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4BAB62B31D327F7E00DF5BA0 /* G64.cpp */; };
 		4BAB62B81D3302CA00DF5BA0 /* PCMTrack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4BAB62B61D3302CA00DF5BA0 /* PCMTrack.cpp */; };
 		4BACC5B11F3DFF7C0037C015 /* CharacterMapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4BACC5AF1F3DFF7C0037C015 /* CharacterMapper.cpp */; };
+		4BAD9B961F43D7E900724854 /* UnformattedTrack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4BAD9B941F43D7E900724854 /* UnformattedTrack.cpp */; };
 		4BB17D4E1ED7909F00ABD1E1 /* tests.expected.json in Resources */ = {isa = PBXBuildFile; fileRef = 4BB17D4C1ED7909F00ABD1E1 /* tests.expected.json */; };
 		4BB17D4F1ED7909F00ABD1E1 /* tests.in.json in Resources */ = {isa = PBXBuildFile; fileRef = 4BB17D4D1ED7909F00ABD1E1 /* tests.in.json */; };
 		4BB298F11B587D8400A49093 /*  start in Resources */ = {isa = PBXBuildFile; fileRef = 4BB297E51B587D8300A49093 /*  start */; };
@@ -673,6 +674,8 @@
 		4BAB62B71D3302CA00DF5BA0 /* PCMTrack.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = PCMTrack.hpp; sourceTree = "<group>"; };
 		4BACC5AF1F3DFF7C0037C015 /* CharacterMapper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CharacterMapper.cpp; path = AmstradCPC/CharacterMapper.cpp; sourceTree = "<group>"; };
 		4BACC5B01F3DFF7C0037C015 /* CharacterMapper.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CharacterMapper.hpp; path = AmstradCPC/CharacterMapper.hpp; sourceTree = "<group>"; };
+		4BAD9B941F43D7E900724854 /* UnformattedTrack.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UnformattedTrack.cpp; sourceTree = "<group>"; };
+		4BAD9B951F43D7E900724854 /* UnformattedTrack.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = UnformattedTrack.hpp; sourceTree = "<group>"; };
 		4BB06B211F316A3F00600C7A /* ForceInline.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ForceInline.h; sourceTree = "<group>"; };
 		4BB17D4C1ED7909F00ABD1E1 /* tests.expected.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = tests.expected.json; path = FUSE/tests.expected.json; sourceTree = "<group>"; };
 		4BB17D4D1ED7909F00ABD1E1 /* tests.in.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = tests.in.json; path = FUSE/tests.in.json; sourceTree = "<group>"; };
@@ -1552,6 +1555,7 @@
 				4B3F1B441E0388D200DB26EE /* PCMPatchedTrack.cpp */,
 				4B121F961E060CF000BFDA12 /* PCMSegment.cpp */,
 				4BAB62B61D3302CA00DF5BA0 /* PCMTrack.cpp */,
+				4BAD9B941F43D7E900724854 /* UnformattedTrack.cpp */,
 				4B0BE4271D3481E700D5256B /* DigitalPhaseLockedLoop.hpp */,
 				4BAB62AC1D3272D200DF5BA0 /* Disk.hpp */,
 				4B6C73BC1D387AE500AFCFCA /* DiskController.hpp */,
@@ -1560,6 +1564,7 @@
 				4B3F1B451E0388D200DB26EE /* PCMPatchedTrack.hpp */,
 				4B121F971E060CF000BFDA12 /* PCMSegment.hpp */,
 				4BAB62B71D3302CA00DF5BA0 /* PCMTrack.hpp */,
+				4BAD9B951F43D7E900724854 /* UnformattedTrack.hpp */,
 				4BB697CF1D4BA44900248BDF /* Encodings */,
 				4BAB62B21D327F7E00DF5BA0 /* Formats */,
 				4B3FE75F1F3CF6BA00448EE4 /* Parsers */,
@@ -2709,6 +2714,7 @@
 				4BD14B111D74627C0088EAD6 /* StaticAnalyser.cpp in Sources */,
 				4BBF99151C8FBA6F0075DAFB /* CRTOpenGL.cpp in Sources */,
 				4B95FA9D1F11893B0008E395 /* ZX8081OptionsPanel.swift in Sources */,
+				4BAD9B961F43D7E900724854 /* UnformattedTrack.cpp in Sources */,
 				4B0CCC451C62D0B3001CAC5F /* CRT.cpp in Sources */,
 				4B8378DC1F336631005CA9E4 /* CharacterMapper.cpp in Sources */,
 				4B8378E51F3378C4005CA9E4 /* CharacterMapper.cpp in Sources */,

--- a/Storage/Disk/Disk.cpp
+++ b/Storage/Disk/Disk.cpp
@@ -28,6 +28,9 @@ void Disk::set_track_at_position(unsigned int head, unsigned int position, const
 }
 
 std::shared_ptr<Track> Disk::get_track_at_position(unsigned int head, unsigned int position) {
+	if(head >= get_head_count()) return nullptr;
+	if(position >= get_head_position_count()) return nullptr;
+
 	int address = get_id_for_track_at_position(head, position);
 	std::map<int, std::shared_ptr<Track>>::iterator cached_track = cached_tracks_.find(address);
 	if(cached_track != cached_tracks_.end()) return cached_track->second;

--- a/Storage/Disk/DiskController.cpp
+++ b/Storage/Disk/DiskController.cpp
@@ -157,11 +157,7 @@ void Controller::end_writing() {
 		patched_track_ = std::dynamic_pointer_cast<PCMPatchedTrack>(track_);
 		if(!patched_track_) {
 			patched_track_.reset(new PCMPatchedTrack(track_));
-		} else {
-			printf("");
 		}
-	} else {
-		printf("");
 	}
 	patched_track_->add_segment(write_start_time_, write_segment_, clamp_writing_to_index_hole_);
 	cycles_since_index_hole_ %= 8000000 * clock_rate_multiplier_;

--- a/Storage/Disk/DiskController.cpp
+++ b/Storage/Disk/DiskController.cpp
@@ -8,6 +8,7 @@
 
 #include "DiskController.hpp"
 #include "../../NumberTheory/Factors.hpp"
+#include <cassert>
 
 using namespace Storage::Disk;
 
@@ -32,8 +33,10 @@ void Controller::setup_track() {
 
 	Time offset;
 	Time track_time_now = get_time_into_track();
+	assert(track_time_now >= Time(0) && current_event_.length <= Time(1));
 	if(track_) {
 		Time time_found = track_->seek_to(track_time_now);
+		assert(time_found >= Time(0) && time_found <= track_time_now);
 		offset = track_time_now - time_found;
 	}
 
@@ -93,7 +96,9 @@ void Controller::get_next_event(const Time &duration_already_passed) {
 
 	// divide interval, which is in terms of a single rotation of the disk, by rotation speed to
 	// convert it into revolutions per second; this is achieved by multiplying by rotational_multiplier_
-	set_next_event_time_interval((current_event_.length - duration_already_passed) * rotational_multiplier_);
+	assert(current_event_.length <= Time(1) && current_event_.length >= Time(0));
+	Time interval = (current_event_.length - duration_already_passed) * rotational_multiplier_;
+	set_next_event_time_interval(interval);
 }
 
 void Controller::process_next_event()

--- a/Storage/Disk/DiskController.cpp
+++ b/Storage/Disk/DiskController.cpp
@@ -7,6 +7,7 @@
 //
 
 #include "DiskController.hpp"
+#include "UnformattedTrack.hpp"
 #include "../../NumberTheory/Factors.hpp"
 #include <cassert>
 
@@ -30,15 +31,17 @@ Controller::Controller(Cycles clock_rate, int clock_rate_multiplier, int revolut
 
 void Controller::setup_track() {
 	track_ = drive_->get_track();
+	if(!track_) {
+		track_.reset(new UnformattedTrack);
+	}
 
 	Time offset;
 	Time track_time_now = get_time_into_track();
 	assert(track_time_now >= Time(0) && current_event_.length <= Time(1));
-	if(track_) {
-		Time time_found = track_->seek_to(track_time_now);
-		assert(time_found >= Time(0) && time_found <= track_time_now);
-		offset = track_time_now - time_found;
-	}
+
+	Time time_found = track_->seek_to(track_time_now);
+	assert(time_found >= Time(0) && time_found <= track_time_now);
+	offset = track_time_now - time_found;
 
 	get_next_event(offset);
 }

--- a/Storage/Disk/DiskController.hpp
+++ b/Storage/Disk/DiskController.hpp
@@ -72,8 +72,11 @@ class Controller: public DigitalPhaseLockedLoop::Delegate, public TimedEventLoop
 			@c write_bit. They will be written with the length set via @c set_expected_bit_length.
 			It is acceptable to supply a backlog of bits. Flux transition events will not be reported
 			while writing.
+
+			@param clamp_to_index_hole If @c true then writing will automatically be truncated by
+			the index hole. Writing will continue over the index hole otherwise.
 		*/
-		void begin_writing();
+		void begin_writing(bool clamp_to_index_hole);
 
 		/*!
 			Writes the bit @c value as the next in the PCM stream initiated by @c begin_writing.
@@ -129,6 +132,7 @@ class Controller: public DigitalPhaseLockedLoop::Delegate, public TimedEventLoop
 		bool motor_is_on_;
 
 		bool is_reading_;
+		bool clamp_writing_to_index_hole_;
 		std::shared_ptr<PCMPatchedTrack> patched_track_;
 		PCMSegment write_segment_;
 		Time write_start_time_;

--- a/Storage/Disk/MFMDiskController.cpp
+++ b/Storage/Disk/MFMDiskController.cpp
@@ -199,15 +199,15 @@ void MFMController::write_id_joiner() {
 	}
 }
 
-void MFMController::write_id_data_joiner(bool is_deleted) {
+void MFMController::write_id_data_joiner(bool is_deleted, bool skip_first_gap) {
 	if(get_is_double_density()) {
-		write_n_bytes(22, 0x4e);
+		if(!skip_first_gap) write_n_bytes(22, 0x4e);
 		write_n_bytes(12, 0x00);
 		for(int c = 0; c < 3; c++) write_raw_short(Storage::Encodings::MFM::MFMSync);
 		get_crc_generator().set_value(Storage::Encodings::MFM::MFMPostSyncCRCValue);
 		write_byte(is_deleted ? Storage::Encodings::MFM::DeletedDataAddressByte : Storage::Encodings::MFM::DataAddressByte);
 	} else {
-		write_n_bytes(11, 0xff);
+		if(!skip_first_gap) write_n_bytes(11, 0xff);
 		write_n_bytes(6, 0x00);
 		get_crc_generator().reset();
 		get_crc_generator().add(is_deleted ? Storage::Encodings::MFM::DeletedDataAddressByte : Storage::Encodings::MFM::DataAddressByte);
@@ -227,7 +227,7 @@ void MFMController::write_start_of_track() {
 	if(get_is_double_density()) {
 		write_n_bytes(80, 0x4e);
 		write_n_bytes(12, 0x00);
-		for(int c = 0; c < 3; c++)	write_raw_short(Storage::Encodings::MFM::MFMIndexSync);
+		for(int c = 0; c < 3; c++) write_raw_short(Storage::Encodings::MFM::MFMIndexSync);
 		write_byte(Storage::Encodings::MFM::IndexAddressByte);
 		write_n_bytes(50, 0x4e);
 	} else {

--- a/Storage/Disk/MFMDiskController.hpp
+++ b/Storage/Disk/MFMDiskController.hpp
@@ -125,11 +125,12 @@ class MFMController: public Controller {
 		void write_id_joiner();
 
 		/*!
-			Writes everything that should, per the spec, appear after the ID's CRC, up to and
+			Writes at most what should, per the spec, appear after the ID's CRC, up to and
 			including the mark that indicates the beginning of data, appropriately seeding
-			the CRC generator.
+			the CRC generator; if @c skip_first_gap is set then the initial gap after the
+			CRC isn't written.
 		*/
-		void write_id_data_joiner(bool is_deleted);
+		void write_id_data_joiner(bool is_deleted, bool skip_first_gap);
 
 		/*!
 			Writes the gap expected after a sector's data CRC and before the beginning of the

--- a/Storage/Disk/PCMPatchedTrack.cpp
+++ b/Storage/Disk/PCMPatchedTrack.cpp
@@ -195,11 +195,14 @@ Storage::Time PCMPatchedTrack::seek_to(const Time &time_since_index_hole) {
 		active_period_++;
 	}
 
-	// allow whatever storage represents the period found to perform its seek
+	// allow whatever storage represents the period found to perform its seek; calculation for periods
+	// with an event source is, in effect: seek_to(offset_into_segment + distance_into_period) - offset_into_segment.
 	if(active_period_->event_source)
-		current_time_ = active_period_->event_source->seek_to(active_period_->segment_start_time + time_since_index_hole - active_period_->start_time) + active_period_->start_time;
+		current_time_ = active_period_->event_source->seek_to(active_period_->segment_start_time + time_since_index_hole - active_period_->start_time) + active_period_->start_time - active_period_->segment_start_time;
 	else
 		current_time_ = underlying_track_->seek_to(time_since_index_hole);
+
+	assert(current_time_ <= time_since_index_hole);
 	return current_time_;
 }
 

--- a/Storage/Disk/PCMPatchedTrack.cpp
+++ b/Storage/Disk/PCMPatchedTrack.cpp
@@ -31,15 +31,18 @@ Track *PCMPatchedTrack::clone() {
 	return new PCMPatchedTrack(*this);
 }
 
-void PCMPatchedTrack::add_segment(const Time &start_time, const PCMSegment &segment) {
+void PCMPatchedTrack::add_segment(const Time &start_time, const PCMSegment &segment, bool clamp_to_index_hole) {
 	std::shared_ptr<PCMSegmentEventSource> event_source(new PCMSegmentEventSource(segment));
 
 	Time zero(0);
+	Time one(1);
 	Time end_time = start_time + event_source->get_length();
+	if(clamp_to_index_hole && end_time > one) {
+		end_time = one;
+	}
 	Period insertion_period(start_time, end_time, zero, event_source);
 
 	// the new segment may wrap around, so divide it up into track-length parts if required
-	Time one = Time(1);
 	assert(insertion_period.start_time <= one);
 	while(insertion_period.end_time > one) {
 		Time next_end_time = insertion_period.end_time - one;

--- a/Storage/Disk/PCMPatchedTrack.hpp
+++ b/Storage/Disk/PCMPatchedTrack.hpp
@@ -34,8 +34,13 @@ class PCMPatchedTrack: public Track {
 		/*!
 			Replaces whatever is currently on the track from @c start_position to @c start_position + segment length
 			with the contents of @c segment.
+			
+			@param start_time The time at which this segment begins. Must be in the range [0, 1).
+			@param segment The PCM segment to add.
+			@param clamp_to_index_hole If @c true then the new segment will be truncated if it overruns the index hole;
+			it will otherwise write over the index hole and continue.
 		*/
-		void add_segment(const Time &start_time, const PCMSegment &segment);
+		void add_segment(const Time &start_time, const PCMSegment &segment, bool clamp_to_index_hole);
 
 		// To satisfy Storage::Disk::Track
 		Event get_next_event();

--- a/Storage/Disk/PCMPatchedTrack.hpp
+++ b/Storage/Disk/PCMPatchedTrack.hpp
@@ -9,7 +9,7 @@
 #ifndef PCMPatchedTrack_hpp
 #define PCMPatchedTrack_hpp
 
-#include "PCMTrack.hpp"
+#include "Disk.hpp"
 #include "PCMSegment.hpp"
 
 namespace Storage {

--- a/Storage/Disk/UnformattedTrack.cpp
+++ b/Storage/Disk/UnformattedTrack.cpp
@@ -1,0 +1,26 @@
+//
+//  UnformattedTrack.cpp
+//  Clock Signal
+//
+//  Created by Thomas Harte on 15/08/2017.
+//  Copyright © 2017 Thomas Harte. All rights reserved.
+//
+
+#include "UnformattedTrack.hpp"
+
+using namespace Storage::Disk;
+
+Track::Event UnformattedTrack::get_next_event() {
+	Track::Event event;
+	event.type = Event::IndexHole;
+	event.length = Time(1);
+	return event;
+}
+
+Storage::Time UnformattedTrack::seek_to(const Time &time_since_index_hole) {
+	return Time(0);
+}
+
+Track *UnformattedTrack::clone() {
+	return new UnformattedTrack;
+}

--- a/Storage/Disk/UnformattedTrack.hpp
+++ b/Storage/Disk/UnformattedTrack.hpp
@@ -1,0 +1,30 @@
+//
+//  UnformattedTrack.hpp
+//  Clock Signal
+//
+//  Created by Thomas Harte on 15/08/2017.
+//  Copyright © 2017 Thomas Harte. All rights reserved.
+//
+
+#ifndef UnformattedTrack_hpp
+#define UnformattedTrack_hpp
+
+#include "Disk.hpp"
+
+namespace Storage {
+namespace Disk {
+
+/*!
+	A subclass of @c Track with no contents. Just an index hole.
+*/
+class UnformattedTrack: public Track {
+	public:
+		Event get_next_event();
+		Time seek_to(const Time &time_since_index_hole);
+		Track *clone();
+};
+
+}
+}
+
+#endif /* UnformattedTrack_hpp */


### PR DESCRIPTION
Specifically to fix:
* an issue with patches on PCM patched tracks that have been left trimmed;
* to add asserts generally around that area;
* better to handle writes that run over the index hole;
* to make it easy for controllers to avoid writing over the index hole if desired; and
* in the 8272, to collect a bunch of repetitive actions into a common location and better to find error conditions.