### PR TITLE
Corrects Vic-I NTSC colour output

### DIFF
--- a/Components/6560/6560.hpp
+++ b/Components/6560/6560.hpp
@@ -100,10 +100,10 @@ template <class T> class MOS6560 {
 				8,		88,		120,	56,
 			};
 			const uint8_t ntsc_chrominances[16] = {
-				255,	255,	40,		104,
-				64,		120,	80,		16,
-				32,		32,		40,		104,
-				64,		120,	80,		16,
+				255,	255,	8,		72,
+				32,		88,		48,		112,
+				0,		0,		8,		72,
+				32,		88,		48,		112,
 			};
 			const uint8_t *chrominances;
 			Outputs::CRT::DisplayType display_type;


### PR DESCRIPTION
Undoing a phoney adjustment in the other direction.