### PR TITLE
Corrects a couple of cases in which the CPC analyser could pick an incorrect loading command

### DIFF
--- a/Machines/AmstradCPC/AmstradCPC.cpp
+++ b/Machines/AmstradCPC/AmstradCPC.cpp
@@ -812,7 +812,7 @@ class ConcreteMachine:
 		}
 
 		HalfCycles get_typer_frequency() {
-			return Cycles(80000);	// Type one character per frame.
+			return Cycles(160000);	// Type one character per frame.
 		}
 
 		// See header; sets a key as either pressed or released.


### PR DESCRIPTION
Also removes from the loading command any extraneous spaces and adds the logic to type the file extension if required, though at the minute such a file is never selected.