### PR TITLE
Improves the CPC static analyser's correct file name predictions

### DIFF
--- a/StaticAnalyser/AmstradCPC/StaticAnalyser.cpp
+++ b/StaticAnalyser/AmstradCPC/StaticAnalyser.cpp
@@ -199,15 +199,6 @@ void StaticAnalyser::AmstradCPC::AddTargets(const Media &media, std::list<Target
 		data_format.first_sector = 0xc1;
 		data_format.catalogue_allocation_bitmap = 0xc000;
 		data_format.reserved_tracks = 0;
-			Storage::Disk::CPM::ParameterBlock system_format;
-			system_format.sectors_per_track = 9;
-			system_format.tracks = 40;
-			system_format.block_size = 1024;
-			system_format.first_sector = 0x41;
-			system_format.catalogue_allocation_bitmap = 0xc000;
-			system_format.reserved_tracks = 2;
-
-			std::unique_ptr<Storage::Disk::CPM::Catalogue> system_catalogue = Storage::Disk::CPM::GetCatalogue(target.media.disks.front(), system_format);
 
 		std::unique_ptr<Storage::Disk::CPM::Catalogue> data_catalogue = Storage::Disk::CPM::GetCatalogue(target.media.disks.front(), data_format);
 		if(data_catalogue) {

--- a/Storage/Disk/Parsers/CPM.cpp
+++ b/Storage/Disk/Parsers/CPM.cpp
@@ -46,8 +46,6 @@ std::unique_ptr<Storage::Disk::CPM::Catalogue> Storage::Disk::CPM::GetCatalogue(
 		catalogue_allocation_bitmap <<= 1;
 	}
 
-	printf("%lu\n", catalogue.size());
-
 	std::unique_ptr<Catalogue> result(new Catalogue);
 	bool has_long_allocation_units = (parameters.tracks * parameters.sectors_per_track * (int)sector_size / parameters.block_size) >= 256;
 	size_t bytes_per_catalogue_entry = (has_long_allocation_units ? 16 : 8) * (size_t)parameters.block_size;


### PR DESCRIPTION
Specifically by considering that:
* it won't be anything with a special character in it;
* if all that's left is system files, it might actually be a system file;
* another potential way that one file can be intended to draw a reader's eye is if it is the only one with a different name.

Also adjusts the CP/M catalogue fetcher: the catalogue allocation bitmap is supposed to be in units of a block, not units of a sector. So on the CPC I was throwing half the catalogue away.