### PR TITLE
Makes a variety of minor performance improvements to the CPC

### DIFF
--- a/Components/8272/i8272.cpp
+++ b/Components/8272/i8272.cpp
@@ -129,19 +129,20 @@ void i8272::run_for(Cycles cycles) {
 	// check for any head unloads
 	if(head_timers_running_) {
 		int timers_left = head_timers_running_;
-		for(int c = 0; c < 4; c++) {
-			for(int h = 0; h < 2; h++) {
-				if(drives_[c].head_unload_delay[c] > 0) {
-					if(cycles.as_int() >= drives_[c].head_unload_delay[c]) {
-						drives_[c].head_unload_delay[c] = 0;
-						drives_[c].head_is_loaded[c] = false;
-						head_timers_running_--;
-					} else {
-						drives_[c].head_unload_delay[c] -= cycles.as_int();
-					}
-					timers_left--;
-					if(!timers_left) return;
+		for(int c = 0; c < 8; c++) {
+			int drive = (c >> 1);
+			int head = c&1;
+
+			if(drives_[drive].head_unload_delay[head] > 0) {
+				if(cycles.as_int() >= drives_[drive].head_unload_delay[head]) {
+					drives_[drive].head_unload_delay[head] = 0;
+					drives_[drive].head_is_loaded[head] = false;
+					head_timers_running_--;
+				} else {
+					drives_[drive].head_unload_delay[head] -= cycles.as_int();
 				}
+				timers_left--;
+				if(!timers_left) break;
 			}
 		}
 	}

--- a/Components/8272/i8272.cpp
+++ b/Components/8272/i8272.cpp
@@ -128,6 +128,7 @@ void i8272::run_for(Cycles cycles) {
 
 	// check for any head unloads
 	if(head_timers_running_) {
+		int timers_left = head_timers_running_;
 		for(int c = 0; c < 4; c++) {
 			for(int h = 0; h < 2; h++) {
 				if(drives_[c].head_unload_delay[c] > 0) {
@@ -135,10 +136,11 @@ void i8272::run_for(Cycles cycles) {
 						drives_[c].head_unload_delay[c] = 0;
 						drives_[c].head_is_loaded[c] = false;
 						head_timers_running_--;
-						if(!head_timers_running_) return;
 					} else {
 						drives_[c].head_unload_delay[c] -= cycles.as_int();
 					}
+					timers_left--;
+					if(!timers_left) return;
 				}
 			}
 		}

--- a/Components/8272/i8272.hpp
+++ b/Components/8272/i8272.hpp
@@ -102,7 +102,8 @@ class i8272: public Storage::Disk::MFMController {
 			Drive() :
 				head_position(0), phase(NotSeeking),
 				drive(new Storage::Disk::Drive),
-				head_is_loaded{false, false} {};
+				head_is_loaded{false, false},
+				head_unload_delay{0, 0} {};
 		} drives_[4];
 		int drives_seeking_;
 

--- a/Components/8272/i8272.hpp
+++ b/Components/8272/i8272.hpp
@@ -128,6 +128,8 @@ class i8272: public Storage::Disk::MFMController {
 		// Internal registers.
 		uint8_t cylinder_, head_, sector_, size_;
 
+		// Master switch on not performing any work.
+		bool is_sleeping_;
 };
 
 }

--- a/Machines/AmstradCPC/AmstradCPC.cpp
+++ b/Machines/AmstradCPC/AmstradCPC.cpp
@@ -353,6 +353,19 @@ class CRTCBusHandler {
 
 		void patch_mode_table(int pen) {
 			// TODO: patch, don't rebuild.
+			switch(mode_) {
+				case 0:
+				break;
+				case 1:
+					if(pen > 3) return;
+				break;
+				case 2:
+					if(pen > 1) return;
+				break;
+				case 3:
+					if(pen > 3) return;
+				break;
+			}
 			build_mode_table();
 		}
 

--- a/Machines/AmstradCPC/AmstradCPC.cpp
+++ b/Machines/AmstradCPC/AmstradCPC.cpp
@@ -159,6 +159,7 @@ class CRTCBusHandler {
 			mode_(2),
 			next_mode_(2),
 			cycles_into_hsync_(0) {
+				establish_palette_hits();
 				build_mode_table();
 			}
 
@@ -351,32 +352,41 @@ class CRTCBusHandler {
 			crt_->output_level(length * 16);
 		}
 
-		void patch_mode_table(int pen) {
-			// TODO: patch, don't rebuild.
-			switch(mode_) {
-				case 0:
-				break;
-				case 1:
-					if(pen > 3) return;
-				break;
-				case 2:
-					if(pen > 1) return;
-				break;
-				case 3:
-					if(pen > 3) return;
-				break;
+#define Mode0Colour0(c) ((c & 0x80) >> 7) | ((c & 0x20) >> 3) | ((c & 0x08) >> 2) | ((c & 0x02) << 2)
+#define Mode0Colour1(c) ((c & 0x40) >> 6) | ((c & 0x10) >> 2) | ((c & 0x04) >> 1) | ((c & 0x01) << 3)
+
+#define Mode1Colour0(c) ((c & 0x80) >> 7) | ((c & 0x08) >> 2)
+#define Mode1Colour1(c) ((c & 0x40) >> 6) | ((c & 0x04) >> 1)
+#define Mode1Colour2(c) ((c & 0x20) >> 5) | ((c & 0x02) >> 0)
+#define Mode1Colour3(c) ((c & 0x10) >> 4) | ((c & 0x01) << 1)
+
+#define Mode3Colour0(c)	((c & 0x80) >> 7) | ((c & 0x08) >> 2)
+#define Mode3Colour1(c) ((c & 0x40) >> 6) | ((c & 0x04) >> 1)
+
+		void establish_palette_hits() {
+			for(int c = 0; c < 256; c++) {
+				mode0_palette_hits_[Mode0Colour0(c)].push_back((uint8_t)c);
+				mode0_palette_hits_[Mode0Colour1(c)].push_back((uint8_t)c);
+
+				mode1_palette_hits_[Mode1Colour0(c)].push_back((uint8_t)c);
+				mode1_palette_hits_[Mode1Colour1(c)].push_back((uint8_t)c);
+				mode1_palette_hits_[Mode1Colour2(c)].push_back((uint8_t)c);
+				mode1_palette_hits_[Mode1Colour3(c)].push_back((uint8_t)c);
+
+				mode3_palette_hits_[Mode3Colour0(c)].push_back((uint8_t)c);
+				mode3_palette_hits_[Mode3Colour1(c)].push_back((uint8_t)c);
 			}
-			build_mode_table();
 		}
 
 		void build_mode_table() {
 			switch(mode_) {
 				case 0:
+					// Mode 0: abcdefgh -> [gcea] [hdfb]
 					for(int c = 0; c < 256; c++) {
 						// prepare mode 0
 						uint8_t *mode0_pixels = (uint8_t *)&mode0_output_[c];
-						mode0_pixels[0] = palette_[((c & 0x80) >> 7) | ((c & 0x20) >> 3) | ((c & 0x08) >> 2) | ((c & 0x02) << 2)];
-						mode0_pixels[1] = palette_[((c & 0x40) >> 6) | ((c & 0x10) >> 2) | ((c & 0x04) >> 1) | ((c & 0x01) << 3)];
+						mode0_pixels[0] = palette_[Mode0Colour0(c)];
+						mode0_pixels[1] = palette_[Mode0Colour1(c)];
 					}
 				break;
 
@@ -384,10 +394,10 @@ class CRTCBusHandler {
 					for(int c = 0; c < 256; c++) {
 						// prepare mode 1
 						uint8_t *mode1_pixels = (uint8_t *)&mode1_output_[c];
-						mode1_pixels[0] = palette_[((c & 0x80) >> 7) | ((c & 0x08) >> 2)];
-						mode1_pixels[1] = palette_[((c & 0x40) >> 6) | ((c & 0x04) >> 1)];
-						mode1_pixels[2] = palette_[((c & 0x20) >> 5) | ((c & 0x02) >> 0)];
-						mode1_pixels[3] = palette_[((c & 0x10) >> 4) | ((c & 0x01) << 1)];
+						mode1_pixels[0] = palette_[Mode1Colour0(c)];
+						mode1_pixels[1] = palette_[Mode1Colour1(c)];
+						mode1_pixels[2] = palette_[Mode1Colour2(c)];
+						mode1_pixels[3] = palette_[Mode1Colour3(c)];
 					}
 				break;
 
@@ -410,12 +420,60 @@ class CRTCBusHandler {
 					for(int c = 0; c < 256; c++) {
 						// prepare mode 3
 						uint8_t *mode3_pixels = (uint8_t *)&mode3_output_[c];
-						mode3_pixels[0] = palette_[((c & 0x80) >> 7) | ((c & 0x08) >> 2)];
-						mode3_pixels[1] = palette_[((c & 0x40) >> 6) | ((c & 0x04) >> 1)];
+						mode3_pixels[0] = palette_[Mode3Colour0(c)];
+						mode3_pixels[1] = palette_[Mode3Colour1(c)];
 					}
 				break;
 			}
 		}
+
+		void patch_mode_table(int pen) {
+			switch(mode_) {
+				case 0: {
+					for(uint8_t c : mode0_palette_hits_[pen]) {
+						uint8_t *mode0_pixels = (uint8_t *)&mode0_output_[c];
+						mode0_pixels[0] = palette_[Mode0Colour0(c)];
+						mode0_pixels[1] = palette_[Mode0Colour1(c)];
+					}
+				} break;
+				case 1:
+					if(pen > 3) return;
+					for(uint8_t c : mode1_palette_hits_[pen]) {
+						uint8_t *mode1_pixels = (uint8_t *)&mode1_output_[c];
+						mode1_pixels[0] = palette_[Mode1Colour0(c)];
+						mode1_pixels[1] = palette_[Mode1Colour1(c)];
+						mode1_pixels[2] = palette_[Mode1Colour2(c)];
+						mode1_pixels[3] = palette_[Mode1Colour3(c)];
+					}
+				break;
+				case 2:
+					if(pen > 1) return;
+					// Whichever pen this is, there's only one table entry it doesn't touch, so just
+					// rebuild the whole thing.
+					build_mode_table();
+				break;
+				case 3:
+					if(pen > 3) return;
+					// Same argument applies here as to case 1, as the unused bits aren't masked out.
+					for(uint8_t c : mode3_palette_hits_[pen]) {
+						uint8_t *mode3_pixels = (uint8_t *)&mode3_output_[c];
+						mode3_pixels[0] = palette_[Mode3Colour0(c)];
+						mode3_pixels[1] = palette_[Mode3Colour1(c)];
+					}
+				break;
+			}
+		}
+
+#undef Mode0Colour0
+#undef Mode0Colour1
+
+#undef Mode1Colour0
+#undef Mode1Colour1
+#undef Mode1Colour2
+#undef Mode1Colour3
+
+#undef Mode3Colour0
+#undef Mode3Colour1
 
 		uint8_t mapped_palette_value(uint8_t colour) {
 #define COL(r, g, b) (r << 4) | (g << 2) | b
@@ -450,6 +508,10 @@ class CRTCBusHandler {
 		uint32_t mode1_output_[256];
 		uint64_t mode2_output_[256];
 		uint16_t mode3_output_[256];
+
+		std::vector<uint8_t> mode0_palette_hits_[16];
+		std::vector<uint8_t> mode1_palette_hits_[4];
+		std::vector<uint8_t> mode3_palette_hits_[4];
 
 		int pen_;
 		uint8_t palette_[16];

--- a/Machines/Typer.hpp
+++ b/Machines/Typer.hpp
@@ -107,12 +107,21 @@ class TypeRecipient: public Typer::Delegate {
 		*/
 		void typer_reset(Typer *typer) {
 			clear_all_keys();
+
+			// It's unsafe to deallocate typer right now, since it is the caller, but also it has a small
+			// memory footprint and it's desireable not to imply that the subclass need call it any more.
+			// So shuffle it off into a siding.
+			previous_typer_ = std::move(typer_);
+			typer_ = nullptr;
 		}
 
 	protected:
 		virtual HalfCycles get_typer_delay() { return HalfCycles(0); }
 		virtual HalfCycles get_typer_frequency() { return HalfCycles(0); }
 		std::unique_ptr<Typer> typer_;
+
+	private:
+		std::unique_ptr<Typer> previous_typer_;
 };
 
 }

--- a/Storage/Disk/Drive.cpp
+++ b/Storage/Disk/Drive.cpp
@@ -12,20 +12,22 @@
 using namespace Storage::Disk;
 
 Drive::Drive()
-	: head_position_(0), head_(0) {}
+	: head_position_(0), head_(0), has_disk_(false) {}
 
 void Drive::set_disk(const std::shared_ptr<Disk> &disk) {
 	disk_ = disk;
 	track_ = nullptr;
+	has_disk_ = !!disk_;
 }
 
 void Drive::set_disk_with_track(const std::shared_ptr<Track> &track) {
 	disk_ = nullptr;
 	track_ = track;
+	has_disk_ = !!track_;
 }
 
 bool Drive::has_disk() {
-	return (bool)disk_ || (bool)track_;
+	return has_disk_;
 }
 
 bool Drive::get_is_track_zero() {

--- a/Storage/Disk/Drive.hpp
+++ b/Storage/Disk/Drive.hpp
@@ -73,6 +73,7 @@ class Drive {
 	private:
 		std::shared_ptr<Track> track_;
 		std::shared_ptr<Disk> disk_;
+		bool has_disk_;
 		int head_position_;
 		unsigned int head_;
 };


### PR DESCRIPTION
Primarily:
* being smarter about which parts of the palette tables to touch upon palette changes;
* ensuring a timed typer stops being talked to once finished (which will benefit the Electron too);
* applying an even broader sleep test in the 8272, and ensuring it starts up in a valid state; and
* applying a slightly faster has_disk test in drives (which will benefit all disk-based machines).