### PR TITLE
Cleans up issues affecting the sleeper mechanism and the CPC

### DIFF
--- a/Machines/AmstradCPC/AmstradCPC.cpp
+++ b/Machines/AmstradCPC/AmstradCPC.cpp
@@ -917,8 +917,8 @@ class ConcreteMachine:
 		}
 
 		void set_component_is_sleeping(void *component, bool is_sleeping) {
-			if(component == &fdc_) fdc_is_sleeping_ = is_sleeping;
-			else tape_player_is_sleeping_ = is_sleeping;
+			fdc_is_sleeping_ = fdc_.is_sleeping();
+			tape_player_is_sleeping_ = tape_player_.is_sleeping();
 		}
 
 #pragma mark - Keyboard

--- a/Storage/Tape/Tape.cpp
+++ b/Storage/Tape/Tape.cpp
@@ -125,8 +125,10 @@ bool BinaryTapePlayer::is_sleeping() {
 }
 
 void BinaryTapePlayer::set_motor_control(bool enabled) {
-	motor_is_running_ = enabled;
-	update_sleep_observer();
+	if(motor_is_running_ != enabled) {
+		motor_is_running_ = enabled;
+		update_sleep_observer();
+	}
 }
 
 void BinaryTapePlayer::set_tape_output(bool set) {


### PR DESCRIPTION
Specifically:
* the false belief that `this` will always be the address known to the object owner (it won't be, because of inheritance); and
* the binary tape player's habit of announcing upon every message it receives about the tape motor, which in a CPC is wired to the same atomic output as keyboard row selection.