### PR TITLE
Introduces compile-time selection of minor CPU core features and applies forceinline when appropriate

### DIFF
--- a/ClockReceiver/ForceInline.hpp
+++ b/ClockReceiver/ForceInline.hpp
@@ -9,11 +9,11 @@
 #ifndef ForceInline_hpp
 #define ForceInline_hpp
 
-//#ifdef DEBUG
-//
-//#define forceinline inline
-//
-//#elseif
+#ifdef DEBUG
+
+#define forceinline
+
+#else
 
 #ifdef __GNUC__
 #define forceinline __attribute__((always_inline)) inline
@@ -21,6 +21,6 @@
 #define forceinline __forceinline
 #endif
 
-//#endif
+#endif
 
 #endif /* ForceInline_h */

--- a/ClockReceiver/ForceInline.hpp
+++ b/ClockReceiver/ForceInline.hpp
@@ -9,10 +9,18 @@
 #ifndef ForceInline_hpp
 #define ForceInline_hpp
 
+//#ifdef DEBUG
+//
+//#define forceinline inline
+//
+//#elseif
+
 #ifdef __GNUC__
 #define forceinline __attribute__((always_inline)) inline
 #elif _MSC_VER
 #define forceinline __forceinline
 #endif
+
+//#endif
 
 #endif /* ForceInline_h */

--- a/Machines/AmstradCPC/AmstradCPC.cpp
+++ b/Machines/AmstradCPC/AmstradCPC.cpp
@@ -992,7 +992,7 @@ class ConcreteMachine:
 			}
 		}
 
-		CPU::Z80::Processor<ConcreteMachine> z80_;
+		CPU::Z80::Processor<ConcreteMachine, false> z80_;
 
 		CRTCBusHandler crtc_bus_handler_;
 		Motorola::CRTC::CRTC6845<CRTCBusHandler> crtc_;

--- a/Machines/AmstradCPC/AmstradCPC.cpp
+++ b/Machines/AmstradCPC/AmstradCPC.cpp
@@ -827,35 +827,35 @@ class ConcreteMachine:
 		}
 
 		/// A CRTMachine function; indicates that outputs should be created now.
-		void setup_output(float aspect_ratio) final override {
+		void setup_output(float aspect_ratio) override final {
 			crtc_bus_handler_.setup_output(aspect_ratio);
 			ay_.setup_output();
 			ay_.ay()->set_port_handler(&key_state_);
 		}
 
 		/// A CRTMachine function; indicates that outputs should be destroyed now.
-		void close_output() final override {
+		void close_output() override final {
 			crtc_bus_handler_.close_output();
 			ay_.close_output();
 		}
 
 		/// @returns the CRT in use.
-		std::shared_ptr<Outputs::CRT::CRT> get_crt() final override {
+		std::shared_ptr<Outputs::CRT::CRT> get_crt() override final {
 			return crtc_bus_handler_.get_crt();
 		}
 
 		/// @returns the speaker in use.
-		std::shared_ptr<Outputs::Speaker> get_speaker() final override {
+		std::shared_ptr<Outputs::Speaker> get_speaker() override final {
 			return ay_.get_speaker();
 		}
 
 		/// Wires virtual-dispatched CRTMachine run_for requests to the static Z80 method.
-		void run_for(const Cycles cycles) final override {
+		void run_for(const Cycles cycles) override final {
 			z80_.run_for(cycles);
 		}
 
 		/// The ConfigurationTarget entry point; should configure this meachine as described by @c target.
-		void configure_as_target(const StaticAnalyser::Target &target) final override  {
+		void configure_as_target(const StaticAnalyser::Target &target) override final  {
 			switch(target.amstradcpc.model) {
 				case StaticAnalyser::AmstradCPCModel::CPC464:
 					rom_model_ = ROMType::OS464;
@@ -896,7 +896,7 @@ class ConcreteMachine:
 			insert_media(target.media);
 		}
 
-		bool insert_media(const StaticAnalyser::Media &media) final override {
+		bool insert_media(const StaticAnalyser::Media &media) override final {
 			// If there are any tapes supplied, use the first of them.
 			if(!media.tapes.empty()) {
 				tape_player_.set_tape(media.tapes.front());
@@ -914,37 +914,37 @@ class ConcreteMachine:
 		}
 
 		// See header; provides the system ROMs.
-		void set_rom(ROMType type, std::vector<uint8_t> data) final override {
+		void set_rom(ROMType type, std::vector<uint8_t> data) override final {
 			roms_[(int)type] = data;
 		}
 
-		void set_component_is_sleeping(void *component, bool is_sleeping) final override {
+		void set_component_is_sleeping(void *component, bool is_sleeping) override final {
 			fdc_is_sleeping_ = fdc_.is_sleeping();
 			tape_player_is_sleeping_ = tape_player_.is_sleeping();
 		}
 
 #pragma mark - Keyboard
 
-		void set_typer_for_string(const char *string) final override {
+		void set_typer_for_string(const char *string) override final {
 			std::unique_ptr<CharacterMapper> mapper(new CharacterMapper());
 			Utility::TypeRecipient::set_typer_for_string(string, std::move(mapper));
 		}
 
-		HalfCycles get_typer_delay() final override {
+		HalfCycles get_typer_delay() override final {
 			return Cycles(4000000);	// Wait 1 second before typing.
 		}
 
-		HalfCycles get_typer_frequency() final override {
+		HalfCycles get_typer_frequency() override final {
 			return Cycles(160000);	// Type one character per frame.
 		}
 
 		// See header; sets a key as either pressed or released.
-		void set_key_state(uint16_t key, bool isPressed) final override {
+		void set_key_state(uint16_t key, bool isPressed) override final {
 			key_state_.set_is_pressed(isPressed, key >> 4, key & 7);
 		}
 
 		// See header; sets all keys to released.
-		void clear_all_keys() final override {
+		void clear_all_keys() override final {
 			key_state_.clear_all_keys();
 		}
 

--- a/Machines/AmstradCPC/AmstradCPC.cpp
+++ b/Machines/AmstradCPC/AmstradCPC.cpp
@@ -22,6 +22,8 @@
 
 #include "../../Storage/Tape/Tape.hpp"
 
+#include "../../ClockReceiver/ForceInline.hpp"
+
 namespace AmstradCPC {
 
 /*!
@@ -173,7 +175,7 @@ class CRTCBusHandler {
 			The CRTC entry function; takes the current bus state and determines what output 
 			to produce based on the current palette and mode.
 		*/
-		inline void perform_bus_cycle(const Motorola::CRTC::BusState &state) {
+		forceinline void perform_bus_cycle(const Motorola::CRTC::BusState &state) {
 			// The gate array waits 2µs to react to the CRTC's vsync signal, and then
 			// caps output at 4µs. Since the clock rate is 1Mhz, that's 2 and 4 cycles,
 			// respectively.
@@ -691,7 +693,7 @@ class ConcreteMachine:
 		}
 
 		/// The entry point for performing a partial Z80 machine cycle.
-		inline HalfCycles perform_machine_cycle(const CPU::Z80::PartialMachineCycle &cycle) {
+		forceinline HalfCycles perform_machine_cycle(const CPU::Z80::PartialMachineCycle &cycle) {
 			// Amstrad CPC timing scheme: assert WAIT for three out of four cycles
 			clock_offset_ = (clock_offset_ + cycle.length) & HalfCycles(7);
 			z80_.set_wait_line(clock_offset_ >= HalfCycles(2));
@@ -825,35 +827,35 @@ class ConcreteMachine:
 		}
 
 		/// A CRTMachine function; indicates that outputs should be created now.
-		void setup_output(float aspect_ratio) {
+		void setup_output(float aspect_ratio) final override {
 			crtc_bus_handler_.setup_output(aspect_ratio);
 			ay_.setup_output();
 			ay_.ay()->set_port_handler(&key_state_);
 		}
 
 		/// A CRTMachine function; indicates that outputs should be destroyed now.
-		void close_output() {
+		void close_output() final override {
 			crtc_bus_handler_.close_output();
 			ay_.close_output();
 		}
 
 		/// @returns the CRT in use.
-		std::shared_ptr<Outputs::CRT::CRT> get_crt() {
+		std::shared_ptr<Outputs::CRT::CRT> get_crt() final override {
 			return crtc_bus_handler_.get_crt();
 		}
 
 		/// @returns the speaker in use.
-		std::shared_ptr<Outputs::Speaker> get_speaker() {
+		std::shared_ptr<Outputs::Speaker> get_speaker() final override {
 			return ay_.get_speaker();
 		}
 
 		/// Wires virtual-dispatched CRTMachine run_for requests to the static Z80 method.
-		void run_for(const Cycles cycles) {
+		void run_for(const Cycles cycles) final override {
 			z80_.run_for(cycles);
 		}
 
 		/// The ConfigurationTarget entry point; should configure this meachine as described by @c target.
-		void configure_as_target(const StaticAnalyser::Target &target) {
+		void configure_as_target(const StaticAnalyser::Target &target) final override  {
 			switch(target.amstradcpc.model) {
 				case StaticAnalyser::AmstradCPCModel::CPC464:
 					rom_model_ = ROMType::OS464;
@@ -894,7 +896,7 @@ class ConcreteMachine:
 			insert_media(target.media);
 		}
 
-		bool insert_media(const StaticAnalyser::Media &media) {
+		bool insert_media(const StaticAnalyser::Media &media) final override {
 			// If there are any tapes supplied, use the first of them.
 			if(!media.tapes.empty()) {
 				tape_player_.set_tape(media.tapes.front());
@@ -912,37 +914,37 @@ class ConcreteMachine:
 		}
 
 		// See header; provides the system ROMs.
-		void set_rom(ROMType type, std::vector<uint8_t> data) {
+		void set_rom(ROMType type, std::vector<uint8_t> data) final override {
 			roms_[(int)type] = data;
 		}
 
-		void set_component_is_sleeping(void *component, bool is_sleeping) {
+		void set_component_is_sleeping(void *component, bool is_sleeping) final override {
 			fdc_is_sleeping_ = fdc_.is_sleeping();
 			tape_player_is_sleeping_ = tape_player_.is_sleeping();
 		}
 
 #pragma mark - Keyboard
 
-		void set_typer_for_string(const char *string) {
+		void set_typer_for_string(const char *string) final override {
 			std::unique_ptr<CharacterMapper> mapper(new CharacterMapper());
 			Utility::TypeRecipient::set_typer_for_string(string, std::move(mapper));
 		}
 
-		HalfCycles get_typer_delay() {
+		HalfCycles get_typer_delay() final override {
 			return Cycles(4000000);	// Wait 1 second before typing.
 		}
 
-		HalfCycles get_typer_frequency() {
+		HalfCycles get_typer_frequency() final override {
 			return Cycles(160000);	// Type one character per frame.
 		}
 
 		// See header; sets a key as either pressed or released.
-		void set_key_state(uint16_t key, bool isPressed) {
+		void set_key_state(uint16_t key, bool isPressed) final override {
 			key_state_.set_is_pressed(isPressed, key >> 4, key & 7);
 		}
 
 		// See header; sets all keys to released.
-		void clear_all_keys() {
+		void clear_all_keys() final override {
 			key_state_.clear_all_keys();
 		}
 

--- a/Machines/Atari2600/Cartridges/Cartridge.hpp
+++ b/Machines/Atari2600/Cartridges/Cartridge.hpp
@@ -184,7 +184,7 @@ template<class T> class Cartridge:
 		}
 
 	protected:
-		CPU::MOS6502::Processor<Cartridge<T>> m6502_;
+		CPU::MOS6502::Processor<Cartridge<T>, true> m6502_;
 		std::vector<uint8_t> rom_;
 
 	private:

--- a/Machines/Commodore/1540/C1540.hpp
+++ b/Machines/Commodore/1540/C1540.hpp
@@ -152,7 +152,7 @@ class Machine:
 		void drive_via_did_set_data_density(void *driveVIA, int density);
 
 	private:
-		CPU::MOS6502::Processor<Machine> m6502_;
+		CPU::MOS6502::Processor<Machine, false> m6502_;
 
 		uint8_t ram_[0x800];
 		uint8_t rom_[0x4000];

--- a/Machines/ZX8081/ZX8081.cpp
+++ b/Machines/ZX8081/ZX8081.cpp
@@ -330,7 +330,7 @@ class ConcreteMachine:
 		HalfCycles get_typer_frequency() { return Cycles(390000); }
 
 	private:
-		CPU::Z80::Processor<ConcreteMachine> z80_;
+		CPU::Z80::Processor<ConcreteMachine, false> z80_;
 
 		std::shared_ptr<Video> video_;
 		std::vector<uint8_t> zx81_rom_, zx80_rom_;

--- a/OSBindings/Mac/Clock SignalTests/Bridges/TestMachine6502.h
+++ b/OSBindings/Mac/Clock SignalTests/Bridges/TestMachine6502.h
@@ -31,8 +31,6 @@ extern const uint8_t CSTestMachine6502JamOpcode;
 - (void)setValue:(uint16_t)value forRegister:(CSTestMachine6502Register)reg;
 - (uint16_t)valueForRegister:(CSTestMachine6502Register)reg;
 
-- (void)returnFromSubroutine;
-
 @property (nonatomic, readonly) BOOL isJammed;
 @property (nonatomic, readonly) uint32_t timestamp;
 @property (nonatomic, assign) BOOL irqLine;

--- a/OSBindings/Mac/Clock SignalTests/Bridges/TestMachine6502.mm
+++ b/OSBindings/Mac/Clock SignalTests/Bridges/TestMachine6502.mm
@@ -97,10 +97,6 @@ static CPU::MOS6502::Register registerForRegister(CSTestMachine6502Register reg)
 
 #pragma mark - Actions
 
-- (void)returnFromSubroutine {
-	_processor->return_from_subroutine();
-}
-
 - (void)runForNumberOfCycles:(int)cycles {
 	_processor->run_for(Cycles(cycles));
 }

--- a/Processors/6502/6502AllRAM.cpp
+++ b/Processors/6502/6502AllRAM.cpp
@@ -14,10 +14,11 @@ using namespace CPU::MOS6502;
 
 namespace {
 
-class ConcreteAllRAMProcessor: public AllRAMProcessor, public Processor<ConcreteAllRAMProcessor> {
+class ConcreteAllRAMProcessor: public AllRAMProcessor, public BusHandler {
 	public:
-		ConcreteAllRAMProcessor() {
-			set_power_on(false);
+		ConcreteAllRAMProcessor() :
+			mos6502_(*this) {
+			mos6502_.set_power_on(false);
 		}
 
 		inline Cycles perform_bus_operation(BusOperation operation, uint16_t address, uint8_t *value) {
@@ -37,32 +38,31 @@ class ConcreteAllRAMProcessor: public AllRAMProcessor, public Processor<Concrete
 		}
 
 		void run_for(const Cycles cycles) {
-			Processor<ConcreteAllRAMProcessor>::run_for(cycles);
+			mos6502_.run_for(cycles);
 		}
 
 		bool is_jammed() {
-			return Processor<ConcreteAllRAMProcessor>::is_jammed();
+			return mos6502_.is_jammed();
 		}
 
 		void set_irq_line(bool value) {
-			Processor<ConcreteAllRAMProcessor>::set_irq_line(value);
+			mos6502_.set_irq_line(value);
 		}
 
 		void set_nmi_line(bool value) {
-			Processor<ConcreteAllRAMProcessor>::set_nmi_line(value);
-		}
-
-		void return_from_subroutine() {
-			Processor<ConcreteAllRAMProcessor>::return_from_subroutine();
+			mos6502_.set_nmi_line(value);
 		}
 
 		uint16_t get_value_of_register(Register r) {
-			return Processor<ConcreteAllRAMProcessor>::get_value_of_register(r);
+			return mos6502_.get_value_of_register(r);
 		}
 
 		void set_value_of_register(Register r, uint16_t value) {
-			Processor<ConcreteAllRAMProcessor>::set_value_of_register(r, value);
+			mos6502_.set_value_of_register(r, value);
 		}
+
+	private:
+		CPU::MOS6502::Processor<ConcreteAllRAMProcessor, false> mos6502_;
 };
 
 }

--- a/Processors/6502/6502AllRAM.hpp
+++ b/Processors/6502/6502AllRAM.hpp
@@ -26,7 +26,6 @@ class AllRAMProcessor:
 		virtual bool is_jammed() = 0;
 		virtual void set_irq_line(bool value) = 0;
 		virtual void set_nmi_line(bool value) = 0;
-		virtual void return_from_subroutine() = 0;
 		virtual uint16_t get_value_of_register(Register r) = 0;
 		virtual void set_value_of_register(Register r, uint16_t value) = 0;
 

--- a/Processors/Z80/Z80AllRAM.cpp
+++ b/Processors/Z80/Z80AllRAM.cpp
@@ -96,7 +96,7 @@ class ConcreteAllRAMProcessor: public AllRAMProcessor, public BusHandler {
 		}
 
 	private:
-		CPU::Z80::Processor<ConcreteAllRAMProcessor> z80_;
+		CPU::Z80::Processor<ConcreteAllRAMProcessor, false> z80_;
 };
 
 }


### PR DESCRIPTION
Also:
* gets a bit more explicit with `override final` in all files that were touched anyway for forceinline;
* removes `return_from_subroutine` from the 6502 on the grounds that (i) nobody uses it; and (ii) doing so reduces the number of call sites to `perform_bus_cycle` to just one for 6502 machines that don't use the ready line; and
* fixes the 6502 test vehicle.