### PR TITLE
Refines observable 6845 behaviour

### DIFF
--- a/Components/6845/CRTC6845.hpp
+++ b/Components/6845/CRTC6845.hpp
@@ -87,16 +87,17 @@ template <class T> class CRTC6845 {
 		void run_for(Cycles cycles) {
 			int cyles_remaining = cycles.as_int();
 			while(cyles_remaining--) {
-				// check for end of horizontal sync
-				if(bus_state_.hsync) {
-					hsync_counter_ = (hsync_counter_ + 1) & 15;
-					bus_state_.hsync = hsync_counter_ != (registers_[3] & 15);
-				}
-
 				// check for start of horizontal sync
 				if(character_counter_ == registers_[2]) {
 					hsync_counter_ = 0;
-					if(registers_[3] & 15) bus_state_.hsync = true;
+					bus_state_.hsync = true;
+				}
+
+				// check for end of horizontal sync; note that a sync time of zero will result in an immediate
+				// cancellation of the plan to perform sync
+				if(bus_state_.hsync) {
+					bus_state_.hsync = hsync_counter_ != (registers_[3] & 15);
+					hsync_counter_ = (hsync_counter_ + 1) & 15;
 				}
 
 				// check for end of visible characters

--- a/Components/6845/CRTC6845.hpp
+++ b/Components/6845/CRTC6845.hpp
@@ -41,18 +41,18 @@ enum Personality {
 template <class T> class CRTC6845 {
 	public:
 
-		CRTC6845(Personality p, T &bus_handler) :
+		CRTC6845(Personality p, T &bus_handler) noexcept :
 			personality_(p), bus_handler_(bus_handler) {}
 
 		void select_register(uint8_t r) {
 			selected_register_ = r;
 		}
 
-		uint8_t get_status() {
+		uint8_t get_status() const {
 			return 0xff;
 		}
 
-		uint8_t get_register() {
+		uint8_t get_register() const {
 			if(selected_register_ < 12 || selected_register_ > 17) return 0xff;
 			return registers_[selected_register_];
 		}
@@ -73,9 +73,6 @@ template <class T> class CRTC6845 {
 		}
 
 		void run_for(Cycles cycles) {
-			static int c = 0;
-			c++;
-
 			int cyles_remaining = cycles.as_int();
 			while(cyles_remaining--) {
 				// check for end of horizontal sync
@@ -110,6 +107,10 @@ template <class T> class CRTC6845 {
 					character_counter_++;
 				}
 			}
+		}
+
+		const BusState &get_bus_state() const {
+			return bus_state_;
 		}
 
 	private:


### PR DESCRIPTION
Specifically to allow for sync signals becoming active during phase 2 of a clock cycle (which is accurate to my current understanding). Also adjusts the CPC to catch and react appropriately.