### PR TITLE
Factors the concept of a target platform out from the static analyser, allowing file formats to opine

### DIFF
--- a/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
@@ -1060,6 +1060,7 @@
 		4BEF6AAB1D35D1C400E73575 /* DPLLTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DPLLTests.swift; sourceTree = "<group>"; };
 		4BF1354A1D6D2C300054B2EA /* StaticAnalyser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = StaticAnalyser.cpp; path = ../../StaticAnalyser/StaticAnalyser.cpp; sourceTree = "<group>"; };
 		4BF1354B1D6D2C300054B2EA /* StaticAnalyser.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = StaticAnalyser.hpp; path = ../../StaticAnalyser/StaticAnalyser.hpp; sourceTree = "<group>"; };
+		4BF4A2D91F534DB300B171F4 /* TargetPlatforms.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = TargetPlatforms.hpp; sourceTree = "<group>"; };
 		4BF6606A1F281573002CB053 /* ClockReceiver.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = ClockReceiver.hpp; sourceTree = "<group>"; };
 		4BF8295B1D8F048B001BAE39 /* MFM.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = MFM.cpp; path = Encodings/MFM.cpp; sourceTree = "<group>"; };
 		4BF8295C1D8F048B001BAE39 /* MFM.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = MFM.hpp; path = Encodings/MFM.hpp; sourceTree = "<group>"; };
@@ -1457,6 +1458,7 @@
 				4BB697C91D4B6D3E00248BDF /* TimedEventLoop.cpp */,
 				4B5FADB91DE3151600AEC565 /* FileHolder.hpp */,
 				4BAB62AE1D32730D00DF5BA0 /* Storage.hpp */,
+				4BF4A2D91F534DB300B171F4 /* TargetPlatforms.hpp */,
 				4BB697CA1D4B6D3E00248BDF /* TimedEventLoop.hpp */,
 				4BEE0A691D72496600532C7B /* Cartridge */,
 				4B8805F81DCFF6CD003085B1 /* Data */,

--- a/StaticAnalyser/StaticAnalyser.cpp
+++ b/StaticAnalyser/StaticAnalyser.cpp
@@ -63,6 +63,8 @@ static Media GetMediaAndPlatforms(const char *file_name, TargetPlatform::IntType
 #define Insert(list, class, platforms) \
 	list.emplace_back(new Storage::class(file_name));\
 	potential_platforms |= platforms;\
+	TargetPlatform::TypeDistinguisher *distinguisher = dynamic_cast<TargetPlatform::TypeDistinguisher *>(list.back().get());\
+	if(distinguisher) potential_platforms &= distinguisher->target_platform_type();
 
 #define TryInsert(list, class, platforms) \
 	try {\
@@ -115,6 +117,8 @@ static Media GetMediaAndPlatforms(const char *file_name, TargetPlatform::IntType
 #undef Insert
 #undef TryInsert
 
+		// Filter potential platforms as per file preferences, if any.
+
 		free(lowercase_extension);
 	}
 
@@ -141,7 +145,7 @@ std::list<Target> StaticAnalyser::GetTargets(const char *file_name) {
 	if(potential_platforms & TargetPlatform::Atari2600)		Atari::AddTargets(media, targets);
 	if(potential_platforms & TargetPlatform::Commodore)		Commodore::AddTargets(media, targets);
 	if(potential_platforms & TargetPlatform::Oric)			Oric::AddTargets(media, targets);
-	if(potential_platforms & TargetPlatform::ZX8081)		ZX8081::AddTargets(media, targets);
+	if(potential_platforms & TargetPlatform::ZX8081)		ZX8081::AddTargets(media, targets, potential_platforms);
 
 	// Reset any tapes to their initial position
 	for(auto target : targets) {

--- a/StaticAnalyser/StaticAnalyser.cpp
+++ b/StaticAnalyser/StaticAnalyser.cpp
@@ -40,22 +40,12 @@
 #include "../Storage/Tape/Formats/TZX.hpp"
 #include "../Storage/Tape/Formats/ZX80O81P.hpp"
 
-typedef int TargetPlatformType;
-enum class TargetPlatform: TargetPlatformType {
-	Acorn		=	1 << 0,
-	AmstradCPC	=	1 << 1,
-	Atari2600	=	1 << 2,
-	Commodore	=	1 << 3,
-	Oric		=	1 << 4,
-	ZX8081		=	1 << 5,
-
-	AllTape		= Acorn | AmstradCPC | Commodore | Oric | ZX8081,
-	AllDisk		= Acorn | AmstradCPC | Commodore | Oric,
-};
+// Target Platform Types
+#include "../Storage/TargetPlatforms.hpp"
 
 using namespace StaticAnalyser;
 
-static Media GetMediaAndPlatforms(const char *file_name, TargetPlatformType &potential_platforms) {
+static Media GetMediaAndPlatforms(const char *file_name, TargetPlatform::IntType &potential_platforms) {
 	// Get the extension, if any; it will be assumed that extensions are reliable, so an extension is a broad-phase
 	// test as to file format.
 	const char *mixed_case_extension = strrchr(file_name, '.');
@@ -72,7 +62,7 @@ static Media GetMediaAndPlatforms(const char *file_name, TargetPlatformType &pot
 	Media result;
 #define Insert(list, class, platforms) \
 	list.emplace_back(new Storage::class(file_name));\
-	potential_platforms |= (TargetPlatformType)(platforms);\
+	potential_platforms |= platforms;\
 
 #define TryInsert(list, class, platforms) \
 	try {\
@@ -132,7 +122,7 @@ static Media GetMediaAndPlatforms(const char *file_name, TargetPlatformType &pot
 }
 
 Media StaticAnalyser::GetMedia(const char *file_name) {
-	TargetPlatformType throwaway;
+	TargetPlatform::IntType throwaway;
 	return GetMediaAndPlatforms(file_name, throwaway);
 }
 
@@ -141,17 +131,17 @@ std::list<Target> StaticAnalyser::GetTargets(const char *file_name) {
 
 	// Collect all disks, tapes and ROMs as can be extrapolated from this file, forming the
 	// union of all platforms this file might be a target for.
-	TargetPlatformType potential_platforms = 0;
+	TargetPlatform::IntType potential_platforms = 0;
 	Media media = GetMediaAndPlatforms(file_name, potential_platforms);
 
 	// Hand off to platform-specific determination of whether these things are actually compatible and,
 	// if so, how to load them.
-	if(potential_platforms & (TargetPlatformType)TargetPlatform::Acorn)			Acorn::AddTargets(media, targets);
-	if(potential_platforms & (TargetPlatformType)TargetPlatform::AmstradCPC)	AmstradCPC::AddTargets(media, targets);
-	if(potential_platforms & (TargetPlatformType)TargetPlatform::Atari2600)		Atari::AddTargets(media, targets);
-	if(potential_platforms & (TargetPlatformType)TargetPlatform::Commodore)		Commodore::AddTargets(media, targets);
-	if(potential_platforms & (TargetPlatformType)TargetPlatform::Oric)			Oric::AddTargets(media, targets);
-	if(potential_platforms & (TargetPlatformType)TargetPlatform::ZX8081)		ZX8081::AddTargets(media, targets);
+	if(potential_platforms & TargetPlatform::Acorn)			Acorn::AddTargets(media, targets);
+	if(potential_platforms & TargetPlatform::AmstradCPC)	AmstradCPC::AddTargets(media, targets);
+	if(potential_platforms & TargetPlatform::Atari2600)		Atari::AddTargets(media, targets);
+	if(potential_platforms & TargetPlatform::Commodore)		Commodore::AddTargets(media, targets);
+	if(potential_platforms & TargetPlatform::Oric)			Oric::AddTargets(media, targets);
+	if(potential_platforms & TargetPlatform::ZX8081)		ZX8081::AddTargets(media, targets);
 
 	// Reset any tapes to their initial position
 	for(auto target : targets) {

--- a/StaticAnalyser/ZX8081/StaticAnalyser.cpp
+++ b/StaticAnalyser/ZX8081/StaticAnalyser.cpp
@@ -27,14 +27,24 @@ static std::vector<Storage::Data::ZX8081::File> GetFiles(const std::shared_ptr<S
 	return files;
 }
 
-void StaticAnalyser::ZX8081::AddTargets(const Media &media, std::list<Target> &destination) {
+void StaticAnalyser::ZX8081::AddTargets(const Media &media, std::list<Target> &destination, TargetPlatform::IntType potential_platforms) {
 	if(!media.tapes.empty()) {
 		std::vector<Storage::Data::ZX8081::File> files = GetFiles(media.tapes.front());
 		media.tapes.front()->reset();
 		if(!files.empty()) {
 			StaticAnalyser::Target target;
 			target.machine = Target::ZX8081;
-			target.zx8081.isZX81 = files.front().isZX81;
+
+			// Guess the machine type from the file only if it isn't already known.
+			switch(potential_platforms & (TargetPlatform::ZX80 | TargetPlatform::ZX81)) {
+				default:
+					target.zx8081.isZX81 = files.front().isZX81;
+				break;
+
+				case TargetPlatform::ZX80:	target.zx8081.isZX81 = false;	break;
+				case TargetPlatform::ZX81:	target.zx8081.isZX81 = true;	break;
+			}
+
 			/*if(files.front().data.size() > 16384) {
 				target.zx8081.memory_model = ZX8081MemoryModel::SixtyFourKB;
 			} else*/ if(files.front().data.size() > 1024) {

--- a/StaticAnalyser/ZX8081/StaticAnalyser.hpp
+++ b/StaticAnalyser/ZX8081/StaticAnalyser.hpp
@@ -10,11 +10,12 @@
 #define StaticAnalyser_ZX8081_StaticAnalyser_hpp
 
 #include "../StaticAnalyser.hpp"
+#include "../../Storage/TargetPlatforms.hpp"
 
 namespace StaticAnalyser {
 namespace ZX8081 {
 
-void AddTargets(const Media &media, std::list<Target> &destination);
+void AddTargets(const Media &media, std::list<Target> &destination, TargetPlatform::IntType potential_platforms);
 
 }
 }

--- a/Storage/Cartridge/Cartridge.hpp
+++ b/Storage/Cartridge/Cartridge.hpp
@@ -52,6 +52,7 @@ class Cartridge {
 		};
 
 		const std::list<Segment> &get_segments() {	return segments_; }
+		virtual ~Cartridge() {}
 
 	protected:
 		std::list<Segment> segments_;

--- a/Storage/Tape/Formats/TapeUEF.hpp
+++ b/Storage/Tape/Formats/TapeUEF.hpp
@@ -10,9 +10,11 @@
 #define TapeUEF_hpp
 
 #include "../PulseQueuedTape.hpp"
+
+#include "../../TargetPlatforms.hpp"
+
 #include <zlib.h>
 #include <cstdint>
-#include <vector>
 
 namespace Storage {
 namespace Tape {
@@ -20,7 +22,7 @@ namespace Tape {
 /*!
 	Provides a @c Tape containing a UEF tape image, a slightly-convoluted description of pulses.
 */
-class UEF : public PulseQueuedTape {
+class UEF : public PulseQueuedTape, public TargetPlatform::TypeDistinguisher {
 	public:
 		/*!
 			Constructs a @c UEF containing content from the file with name @c file_name.
@@ -37,10 +39,21 @@ class UEF : public PulseQueuedTape {
 	private:
 		void virtual_reset();
 
+		void set_platform_type();
+		TargetPlatform::Type target_platform_type();
+		TargetPlatform::Type platform_type_;
+
 		gzFile file_;
 		unsigned int time_base_;
 		bool is_300_baud_;
 
+		struct Chunk {
+			uint16_t id;
+			uint32_t length;
+			z_off_t start_of_next_chunk;
+		};
+
+		bool get_next_chunk(Chunk &);
 		void get_next_pulses();
 
 		void queue_implicit_bit_pattern(uint32_t length);

--- a/Storage/Tape/Formats/ZX80O81P.cpp
+++ b/Storage/Tape/Formats/ZX80O81P.cpp
@@ -20,9 +20,11 @@ ZX80O81P::ZX80O81P(const char *file_name) :
 
 	// If it's a ZX81 file, prepend a file name.
 	std::string type = extension();
+	platform_type_ = TargetPlatform::ZX80;
 	if(type == "p" || type == "81") {
 		// TODO, maybe: prefix a proper file name; this is leaving the file nameless.
 		data_.insert(data_.begin(), 0x80);
+		platform_type_ = TargetPlatform::ZX81;
 	}
 
 	std::shared_ptr<::Storage::Data::ZX8081::File> file = Storage::Data::ZX8081::FileFromData(data_);
@@ -99,4 +101,8 @@ Tape::Pulse ZX80O81P::virtual_get_next_pulse() {
 	}
 
 	return pulse;
+}
+
+TargetPlatform::Type ZX80O81P::target_platform_type() {
+	return platform_type_;
 }

--- a/Storage/Tape/Formats/ZX80O81P.hpp
+++ b/Storage/Tape/Formats/ZX80O81P.hpp
@@ -10,6 +10,7 @@
 #define ZX80O81P_hpp
 
 #include "../Tape.hpp"
+
 #include "../../FileHolder.hpp"
 #include "../../TargetPlatforms.hpp"
 

--- a/Storage/Tape/Formats/ZX80O81P.hpp
+++ b/Storage/Tape/Formats/ZX80O81P.hpp
@@ -11,6 +11,7 @@
 
 #include "../Tape.hpp"
 #include "../../FileHolder.hpp"
+#include "../../TargetPlatforms.hpp"
 
 #include <cstdint>
 #include <vector>
@@ -21,7 +22,7 @@ namespace Tape {
 /*!
 	Provides a @c Tape containing a ZX80-format .O tape image, which is a byte stream capture.
 */
-class ZX80O81P: public Tape, public Storage::FileHolder {
+class ZX80O81P: public Tape, public Storage::FileHolder, public TargetPlatform::TypeDistinguisher {
 	public:
 		/*!
 			Constructs a @c ZX80O containing content from the file with name @c file_name.
@@ -34,10 +35,14 @@ class ZX80O81P: public Tape, public Storage::FileHolder {
 			ErrorNotZX80O81P
 		};
 
+	private:
 		// implemented to satisfy @c Tape
 		bool is_at_end();
 
-	private:
+		// implemented to satisfy TargetPlatform::TypeDistinguisher
+		TargetPlatform::Type target_platform_type();
+		TargetPlatform::Type platform_type_;
+
 		void virtual_reset();
 		Pulse virtual_get_next_pulse();
 		bool has_finished_data();

--- a/Storage/TargetPlatforms.hpp
+++ b/Storage/TargetPlatforms.hpp
@@ -13,17 +13,22 @@ namespace TargetPlatform {
 
 typedef int IntType;
 enum Type: IntType {
-	Acorn		=	1 << 0,
-	AmstradCPC	=	1 << 1,
-	Atari2600	=	1 << 2,
-	Commodore	=	1 << 3,
-	Oric		=	1 << 4,
-	ZX80		=	1 << 5,
-	ZX81		=	1 << 6,
+	AmstradCPC		=	1 << 1,
+	Atari2600		=	1 << 2,
+	AcornAtom		=	1 << 3,
+	AcornElectron	=	1 << 4,
+	BBCMaster		=	1 << 5,
+	BBCModelA		=	1 << 6,
+	BBCModelB		=	1 << 7,
+	Commodore		=	1 << 8,
+	Oric			=	1 << 9,
+	ZX80			=	1 << 10,
+	ZX81			=	1 << 11,
 
-	ZX8081		= ZX80 | ZX81,
-	AllTape		= Acorn | AmstradCPC | Commodore | Oric | ZX80 | ZX81,
-	AllDisk		= Acorn | AmstradCPC | Commodore | Oric,
+	Acorn			=	AcornAtom | AcornElectron | BBCMaster | BBCModelA | BBCModelB,
+	ZX8081			=	ZX80 | ZX81,
+	AllTape			=	Acorn | AmstradCPC | Commodore | Oric | ZX80 | ZX81,
+	AllDisk			=	Acorn | AmstradCPC | Commodore | Oric,
 };
 
 class TypeDistinguisher {

--- a/Storage/TargetPlatforms.hpp
+++ b/Storage/TargetPlatforms.hpp
@@ -1,0 +1,31 @@
+//
+//  TargetPlatforms.h
+//  Clock Signal
+//
+//  Created by Thomas Harte on 27/08/2017.
+//  Copyright © 2017 Thomas Harte. All rights reserved.
+//
+
+#ifndef TargetPlatforms_hpp
+#define TargetPlatforms_hpp
+
+namespace TargetPlatform {
+
+typedef int IntType;
+enum Type: IntType {
+	Acorn		=	1 << 0,
+	AmstradCPC	=	1 << 1,
+	Atari2600	=	1 << 2,
+	Commodore	=	1 << 3,
+	Oric		=	1 << 4,
+	ZX80		=	1 << 5,
+	ZX81		=	1 << 6,
+
+	ZX8081		= ZX80 | ZX81,
+	AllTape		= Acorn | AmstradCPC | Commodore | Oric | ZX80 | ZX81,
+	AllDisk		= Acorn | AmstradCPC | Commodore | Oric,
+};
+
+}
+
+#endif /* TargetPlatforms_h */

--- a/Storage/TargetPlatforms.hpp
+++ b/Storage/TargetPlatforms.hpp
@@ -26,6 +26,11 @@ enum Type: IntType {
 	AllDisk		= Acorn | AmstradCPC | Commodore | Oric,
 };
 
+class TypeDistinguisher {
+	public:
+		virtual Type target_platform_type() = 0;
+};
+
 }
 
 #endif /* TargetPlatforms_h */


### PR DESCRIPTION
Which specifically resolves .o/.p ZX80/81 confusion as a first step, causes the UEF's 0005 chunk to be obeyed, and will likely permit similar support for TZX's hardware info in the future.