### PR TITLE
Improves CPC disk emulation

### DIFF
--- a/Components/8272/i8272.cpp
+++ b/Components/8272/i8272.cpp
@@ -26,7 +26,7 @@ using namespace Intel::i8272;
 
 #define SetBusy()						(main_status_ |= 0x10)
 #define ResetBusy()						(main_status_ &= ~0x10)
-#define IsBusy()						(main_status_ & 0x10)
+#define Busy()							(main_status_ & 0x10)
 
 #define SetAbnormalTermination()		(status_[0] |= 0x40)
 #define SetInvalidCommand()				(status_[0] |= 0x80)

--- a/Components/8272/i8272.cpp
+++ b/Components/8272/i8272.cpp
@@ -539,7 +539,6 @@ void i8272::posit_event(int event_type) {
 			WAIT_FOR_EVENT(Event::DataWritten);
 			if(!has_input_) {
 				SetOverrun();
-				end_writing();
 				goto abort;
 			}
 			write_byte(input_);
@@ -660,7 +659,6 @@ void i8272::posit_event(int event_type) {
 			switch(event_type) {
 				case (int)Event::IndexHole:
 					SetOverrun();
-					end_writing();
 					goto abort;
 				break;
 				case (int)Event::DataWritten:

--- a/Components/8272/i8272.hpp
+++ b/Components/8272/i8272.hpp
@@ -65,6 +65,7 @@ class i8272: public Storage::Disk::MFMController {
 			CommandByte	= (1 << 3),
 			Timer = (1 << 4),
 			ResultEmpty = (1 << 5),
+			NoLongerReady = (1 << 6)
 		};
 		void posit_event(int type);
 		int interesting_event_mask_;
@@ -107,10 +108,11 @@ class i8272: public Storage::Disk::MFMController {
 		bool seek_is_satisfied(int drive);
 
 		// User-supplied parameters; as per the specify command.
-		int step_rate_time_;
-		int head_unload_time_;
-		int head_load_time_;
-		bool dma_mode_;
+		int step_rate_time_ = 1;
+		int head_unload_time_ = 1;
+		int head_load_time_ = 1;
+		bool dma_mode_ = false;
+		bool is_executing_ = false;
 
 		// A count of head unload timers currently running.
 		int head_timers_running_;

--- a/Machines/AmstradCPC/AmstradCPC.cpp
+++ b/Machines/AmstradCPC/AmstradCPC.cpp
@@ -587,7 +587,7 @@ class FDC: public Intel::i8272::i8272 {
 	public:
 		FDC() :
 			i8272(bus_handler_, Cycles(8000000)),
-			drive_(new Storage::Disk::Drive(8000000, 300)) {
+			drive_(new Storage::Disk::Drive(8000000, 300, 1)) {
 			set_drive(drive_);
 		}
 

--- a/Machines/Commodore/1540/Implementation/C1540.cpp
+++ b/Machines/Commodore/1540/Implementation/C1540.cpp
@@ -23,7 +23,7 @@ MachineBase::MachineBase() :
 		serial_port_VIA_port_handler_(new SerialPortVIA(serial_port_VIA_)),
 		drive_VIA_(drive_VIA_port_handler_),
 		serial_port_VIA_(*serial_port_VIA_port_handler_),
-		drive_(new Storage::Disk::Drive(1000000, 300)) {
+		drive_(new Storage::Disk::Drive(1000000, 300, 2)) {
 	// attach the serial port to its VIA and vice versa
 	serial_port_->set_serial_port_via(serial_port_VIA_port_handler_);
 	serial_port_VIA_port_handler_->set_serial_port(serial_port_);

--- a/Machines/Electron/Plus3.cpp
+++ b/Machines/Electron/Plus3.cpp
@@ -16,7 +16,7 @@ Plus3::Plus3() : WD1770(P1770) {
 
 void Plus3::set_disk(std::shared_ptr<Storage::Disk::Disk> disk, int drive) {
 	if(!drives_[drive]) {
-		drives_[drive].reset(new Storage::Disk::Drive(8000000, 300));
+		drives_[drive].reset(new Storage::Disk::Drive(8000000, 300, 2));
 		if(drive == selected_drive_) set_drive(drives_[drive]);
 	}
 	drives_[drive]->set_disk(disk);

--- a/Machines/Oric/Microdisc.cpp
+++ b/Machines/Oric/Microdisc.cpp
@@ -30,7 +30,7 @@ Microdisc::Microdisc() :
 
 void Microdisc::set_disk(std::shared_ptr<Storage::Disk::Disk> disk, int drive) {
 	if(!drives_[drive]) {
-		drives_[drive].reset(new Storage::Disk::Drive(8000000, 300));
+		drives_[drive].reset(new Storage::Disk::Drive(8000000, 300, 2));
 		if(drive == selected_drive_) set_drive(drives_[drive]);
 	}
 	drives_[drive]->set_disk(disk);

--- a/StaticAnalyser/Commodore/Disk.cpp
+++ b/StaticAnalyser/Commodore/Disk.cpp
@@ -22,7 +22,7 @@ class CommodoreGCRParser: public Storage::Disk::Controller {
 		std::shared_ptr<Storage::Disk::Drive> drive;
 
 		CommodoreGCRParser() : Storage::Disk::Controller(4000000), shift_register_(0), track_(1) {
-			drive.reset(new Storage::Disk::Drive(4000000, 300));
+			drive.reset(new Storage::Disk::Drive(4000000, 300, 2));
 			set_drive(drive);
 			drive->set_motor_on(true);
 		}

--- a/Storage/Disk/DiskController.cpp
+++ b/Storage/Disk/DiskController.cpp
@@ -104,8 +104,10 @@ void Controller::begin_writing(bool clamp_to_index_hole) {
 }
 
 void Controller::end_writing() {
-	is_reading_ = true;
-	get_drive().end_writing();
+	if(!is_reading_) {
+		is_reading_ = true;
+		get_drive().end_writing();
+	}
 }
 
 bool Controller::is_reading() {

--- a/Storage/Disk/DiskController.cpp
+++ b/Storage/Disk/DiskController.cpp
@@ -15,7 +15,7 @@ using namespace Storage::Disk;
 Controller::Controller(Cycles clock_rate) :
 		clock_rate_multiplier_(128000000 / clock_rate.as_int()),
 		clock_rate_(clock_rate.as_int() * clock_rate_multiplier_),
-		empty_drive_(new Drive((unsigned int)clock_rate.as_int(), 1)) {
+		empty_drive_(new Drive((unsigned int)clock_rate.as_int(), 1, 1)) {
 	// seed this class with a PLL, any PLL, so that it's safe to assume non-nullptr later
 	Time one(1);
 	set_expected_bit_length(one);

--- a/Storage/Disk/Drive.cpp
+++ b/Storage/Disk/Drive.cpp
@@ -15,9 +15,10 @@
 
 using namespace Storage::Disk;
 
-Drive::Drive(unsigned int input_clock_rate, int revolutions_per_minute):
+Drive::Drive(unsigned int input_clock_rate, int revolutions_per_minute, unsigned int number_of_heads):
 	Storage::TimedEventLoop(input_clock_rate),
-	rotational_multiplier_(60, revolutions_per_minute) {
+	rotational_multiplier_(60, revolutions_per_minute),
+	available_heads_(number_of_heads) {
 }
 
 void Drive::set_disk(const std::shared_ptr<Disk> &disk) {
@@ -51,6 +52,7 @@ void Drive::step(int direction) {
 }
 
 void Drive::set_head(unsigned int head) {
+	head = std::min(head, available_heads_ - 1);
 	if(head != head_) {
 		head_ = head;
 		track_ = nullptr;
@@ -73,6 +75,7 @@ bool Drive::get_is_read_only() {
 }
 
 bool Drive::get_is_ready() {
+	return true;
 	return ready_index_count_ == 2;
 }
 

--- a/Storage/Disk/Drive.cpp
+++ b/Storage/Disk/Drive.cpp
@@ -237,16 +237,18 @@ void Drive::write_bit(bool value) {
 }
 
 void Drive::end_writing() {
-	is_reading_ = true;
+	if(!is_reading_) {
+		is_reading_ = true;
 
-	if(!patched_track_) {
-		// Avoid creating a new patched track if this one is already patched
-		patched_track_ = std::dynamic_pointer_cast<PCMPatchedTrack>(track_);
 		if(!patched_track_) {
-			patched_track_.reset(new PCMPatchedTrack(track_));
+			// Avoid creating a new patched track if this one is already patched
+			patched_track_ = std::dynamic_pointer_cast<PCMPatchedTrack>(track_);
+			if(!patched_track_) {
+				patched_track_.reset(new PCMPatchedTrack(track_));
+			}
 		}
+		patched_track_->add_segment(write_start_time_, write_segment_, clamp_writing_to_index_hole_);
+		cycles_since_index_hole_ %= get_input_clock_rate();
+		invalidate_track();
 	}
-	patched_track_->add_segment(write_start_time_, write_segment_, clamp_writing_to_index_hole_);
-	cycles_since_index_hole_ %= get_input_clock_rate();
-	invalidate_track();
 }

--- a/Storage/Disk/Drive.hpp
+++ b/Storage/Disk/Drive.hpp
@@ -23,7 +23,7 @@ namespace Disk {
 
 class Drive: public Sleeper, public TimedEventLoop {
 	public:
-		Drive(unsigned int input_clock_rate, int revolutions_per_minute);
+		Drive(unsigned int input_clock_rate, int revolutions_per_minute, unsigned int number_of_heads);
 
 		/*!
 			Replaces whatever is in the drive with @c disk.
@@ -140,6 +140,7 @@ class Drive: public Sleeper, public TimedEventLoop {
 		// A record of head position and active head.
 		int head_position_ = 0;
 		unsigned int head_ = 0;
+		unsigned int available_heads_ = 0;
 
 		// Motor control state.
 		bool motor_is_on_ = false;

--- a/Storage/Disk/Encodings/MFM.cpp
+++ b/Storage/Disk/Encodings/MFM.cpp
@@ -244,7 +244,7 @@ Parser::Parser(bool is_mfm) :
 	bit_length.clock_rate = is_mfm ? 500000 : 250000;	// i.e. 250 kbps (including clocks)
 	set_expected_bit_length(bit_length);
 
-	drive_.reset(new Storage::Disk::Drive(4000000, 300));
+	drive_.reset(new Storage::Disk::Drive(4000000, 300, 2));
 	set_drive(drive_);
 	drive_->set_motor_on(true);
 }


### PR DESCRIPTION
* the drive now really is single sided;
* the 8272 can no longer end up with a surplus of result bytes upon overrun;
* the 8272 reacts if a drive ceases to be ready while a command is ongoing.