### PR TITLE
Makes CPC-style .DSK files writeable

### DIFF
--- a/StaticAnalyser/AmstradCPC/StaticAnalyser.cpp
+++ b/StaticAnalyser/AmstradCPC/StaticAnalyser.cpp
@@ -153,12 +153,12 @@ static void InspectCatalogue(
 static bool CheckBootSector(const std::shared_ptr<Storage::Disk::Disk> &disk, StaticAnalyser::Target &target) {
 	Storage::Encodings::MFM::Parser parser(true, disk);
 	Storage::Encodings::MFM::Sector *boot_sector = parser.get_sector(0, 0, 0x41);
-	if(boot_sector != nullptr) {
+	if(boot_sector != nullptr && !boot_sector->samples.empty()) {
 		// Check that the first 64 bytes of the sector aren't identical; if they are then probably
 		// this disk was formatted and the filler byte never replaced.
 		bool matched = true;
 		for(size_t c = 1; c < 64; c++) {
-			if(boot_sector->data[c] != boot_sector->data[0]) {
+			if(boot_sector->samples[0][c] != boot_sector->samples[0][0]) {
 				matched = false;
 				break;
 			}

--- a/Storage/Disk/DiskImage/Formats/AcornADF.cpp
+++ b/Storage/Disk/DiskImage/Formats/AcornADF.cpp
@@ -20,17 +20,17 @@ using namespace Storage::Disk;
 AcornADF::AcornADF(const char *file_name) : MFMSectorDump(file_name) {
 	// very loose validation: the file needs to be a multiple of 256 bytes
 	// and not ungainly large
-	if(file_stats_.st_size % static_cast<off_t>(128 << sector_size)) throw ErrorNotAcornADF;
-	if(file_stats_.st_size < 7 * static_cast<off_t>(128 << sector_size)) throw ErrorNotAcornADF;
+	if(file_.stats().st_size % static_cast<off_t>(128 << sector_size)) throw ErrorNotAcornADF;
+	if(file_.stats().st_size < 7 * static_cast<off_t>(128 << sector_size)) throw ErrorNotAcornADF;
 
 	// check that the initial directory's 'Hugo's are present
-	fseek(file_, 513, SEEK_SET);
+	file_.seek(513, SEEK_SET);
 	uint8_t bytes[4];
-	fread(bytes, 1, 4, file_);
+	file_.read(bytes, 4);
 	if(bytes[0] != 'H' || bytes[1] != 'u' || bytes[2] != 'g' || bytes[3] != 'o') throw ErrorNotAcornADF;
 
-	fseek(file_, 0x6fb, SEEK_SET);
-	fread(bytes, 1, 4, file_);
+	file_.seek(0x6fb, SEEK_SET);
+	file_.read(bytes, 4);
 	if(bytes[0] != 'H' || bytes[1] != 'u' || bytes[2] != 'g' || bytes[3] != 'o') throw ErrorNotAcornADF;
 
 	set_geometry(sectors_per_track, sector_size, true);

--- a/Storage/Disk/DiskImage/Formats/CPCDSK.cpp
+++ b/Storage/Disk/DiskImage/Formats/CPCDSK.cpp
@@ -26,14 +26,133 @@ CPCDSK::CPCDSK(const char *file_name) :
 	head_position_count_ = fgetc(file_);
 	head_count_ = fgetc(file_);
 
+	// Used only for non-extended disks.
+	long size_of_a_track;
+
+	// Used only for extended disks.
+	std::vector<size_t> track_sizes;
+
 	if(is_extended_) {
 		// Skip two unused bytes and grab the track size table.
 		fseek(file_, 2, SEEK_CUR);
 		for(int c = 0; c < head_position_count_ * head_count_; c++) {
-			track_sizes_.push_back(static_cast<size_t>(fgetc(file_) << 8));
+			track_sizes.push_back(static_cast<size_t>(fgetc(file_) << 8));
 		}
 	} else {
-		size_of_a_track_ = fgetc16le();
+		size_of_a_track = fgetc16le();
+	}
+
+	long file_offset = 0x100;
+	for(size_t c = 0; c < static_cast<size_t>(head_position_count_ * head_count_); c++) {
+		if(!is_extended_ || (track_sizes[c] > 0)) {
+			// Skip the introductory text, 'Track-Info\r\n' and its unused bytes.
+			fseek(file_, file_offset + 16, SEEK_SET);
+
+			tracks_.emplace_back(new Track);
+			Track *track = tracks_.back().get();
+
+			// Track and side are stored, being a byte each.
+			track->track = static_cast<uint8_t>(fgetc(file_));
+			track->side = static_cast<uint8_t>(fgetc(file_));
+			
+			// If this is an extended disk image then John Elliott's extension provides some greater
+			// data rate and encoding context. Otherwise the next two bytes have no defined meaning.
+			if(is_extended_) {
+				switch(fgetc(file_)) {
+					default: track->data_rate = Track::DataRate::Unknown;				break;
+					case 1: track->data_rate = Track::DataRate::SingleOrDoubleDensity;	break;
+					case 2: track->data_rate = Track::DataRate::HighDensity;			break;
+					case 3: track->data_rate = Track::DataRate::ExtendedDensity;		break;
+				}
+				switch(fgetc(file_)) {
+					default: track->data_encoding = Track::DataEncoding::Unknown;		break;
+					case 1: track->data_encoding = Track::DataEncoding::FM;				break;
+					case 2: track->data_encoding = Track::Track::DataEncoding::MFM;		break;
+				}
+			} else {
+				track->data_rate = Track::DataRate::Unknown;
+				track->data_encoding = Track::DataEncoding::Unknown;
+				fseek(file_, 2, SEEK_CUR);
+			}
+			
+			// Sector size, number of sectors, gap 3 length and the filler byte are then common
+			// between both variants of DSK.
+			track->sector_length = static_cast<uint8_t>(fgetc(file_));
+			size_t number_of_sectors = static_cast<size_t>(fgetc(file_));
+			track->gap3_length = static_cast<uint8_t>(fgetc(file_));
+			track->filler_byte = static_cast<uint8_t>(fgetc(file_));
+
+			// Sector information begins immediately after the track information table.
+			while(number_of_sectors--) {
+				track->sectors.emplace_back();
+				Track::Sector &sector = track->sectors.back();
+
+				// Track, side, sector, size and two FDC8272-esque status bytes are stored
+				// per sector, in both regular and extended DSK files.
+				sector.track = static_cast<uint8_t>(fgetc(file_));
+				sector.side = static_cast<uint8_t>(fgetc(file_));
+				sector.sector = static_cast<uint8_t>(fgetc(file_));
+				sector.size = static_cast<uint8_t>(fgetc(file_));
+				sector.fdc_status1 = static_cast<uint8_t>(fgetc(file_));
+				sector.fdc_status2 = static_cast<uint8_t>(fgetc(file_));
+
+				// Figuring out the actual data size is a little more work...
+				size_t data_size = static_cast<size_t>(128 << sector.size);
+				size_t stored_data_size = data_size;
+				size_t number_of_samplings = 1;
+
+				if(is_extended_) {
+					// In an extended DSK, oblige two Simon Owen extensions:
+					//
+					// Allow a declared data size less than the sector's declared size to act as an abbreviation.
+					// Extended DSK varies the 8kb -> 0x1800 bytes special case by this means.
+					//
+					// Use a declared data size greater than the sector's declared size as a record that this
+					// sector was weak or fuzzy and that multiple samplings are provided. If the greater size
+					// is not an exact multiple then my reading of the documentation is that this is an invalid
+					// disk image.
+					size_t declared_data_size = fgetc16le();
+					if(declared_data_size != stored_data_size) {
+						if(declared_data_size > data_size) {
+							number_of_samplings = declared_data_size / data_size;
+							if(declared_data_size % data_size)
+								throw ErrorNotCPCDSK;
+						} else {
+							stored_data_size = declared_data_size;
+						}
+					}
+				} else {
+					// In a regular DSK, these two bytes are unused, and a special case is applied that ostensibly 8kb
+					// sectors are abbreviated to only 0x1800 bytes.
+					if(data_size == 0x2000) stored_data_size = 0x1800;
+					fseek(file_, 2, SEEK_CUR);
+				}
+
+				// As per the weak/fuzzy sector extension, multiple samplings may be stored here.
+				// Plan to tead as many as there were.
+				sector.data.resize(number_of_samplings);
+				while(number_of_samplings--) {
+					sector.data[number_of_samplings].resize(stored_data_size);
+				}
+			}
+			
+			// Sector contents are at offset 0x100 into the track.
+			fseek(file_, file_offset + 0x100, SEEK_SET);
+			for(auto &sector: track->sectors) {
+				for(auto &data : sector.data) {
+					fread(data.data(), 1, data.size(), file_);
+				}
+			}
+		} else {
+			// An extended disk image, which declares that there is no data stored for this track.
+			tracks_.emplace_back();
+		}
+
+		// Advance to the beginning of the next track.
+		if(is_extended_)
+			file_offset += static_cast<long>(track_sizes[c]);
+		else
+			file_offset += size_of_a_track;
 	}
 }
 
@@ -45,101 +164,45 @@ int CPCDSK::get_head_count() {
 	return head_count_;
 }
 
-std::shared_ptr<Track> CPCDSK::get_track_at_position(Track::Address address) {
+std::shared_ptr<Track> CPCDSK::get_track_at_position(::Storage::Disk::Track::Address address) {
 	// Given that thesea are interleaved images, determine which track, chronologically, is being requested.
 	size_t chronological_track = static_cast<size_t>((address.position * head_count_) + address.head);
 
-	// All DSK images reserve 0x100 bytes for their headers.
-	long file_offset = 0x100;
-	if(is_extended_) {
-		// Tracks are a variable size in the original DSK file format.
+	// Return a nullptr if out of range or not provided.
+	if(chronological_track >= tracks_.size()) return nullptr;
+	
+	Track *track = tracks_[chronological_track].get();
+	if(!track) return nullptr;
 
-		// Check that there is anything stored for this track.
-		if(!track_sizes_[chronological_track]) {
-			return nullptr;
-		}
-
-		// Sum the lengths of all tracks prior to the interesting one to get a file offset.
-		size_t t = 0;
-		while(t < chronological_track && t < track_sizes_.size()) {
-			file_offset += track_sizes_[t];
-			t++;
-		}
-	} else {
-		// Tracks are a fixed size in the original DSK file format.
-		file_offset += size_of_a_track_ * static_cast<long>(chronological_track);
-	}
-
-	// Find the track, and skip the unused part of track information.
-	fseek(file_, file_offset + 16, SEEK_SET);
-
-	// Grab the track information.
-	fseek(file_, 5, SEEK_CUR);	// skip track number, side number, sector size — each is given per sector
-	int number_of_sectors = fgetc(file_);
-	uint8_t gap3_length = static_cast<uint8_t>(fgetc(file_));
-	uint8_t filler_byte = static_cast<uint8_t>(fgetc(file_));
-
-	// Grab the sector information
-	struct SectorInfo {
-		uint8_t track;
-		uint8_t side;
-		uint8_t sector;
-		uint8_t length;
-		uint8_t status1;
-		uint8_t status2;
-		size_t actual_length;
-	};
-	std::vector<SectorInfo> sector_infos;
-	while(number_of_sectors--) {
-		SectorInfo sector_info;
-
-		sector_info.track = static_cast<uint8_t>(fgetc(file_));
-		sector_info.side = static_cast<uint8_t>(fgetc(file_));
-		sector_info.sector = static_cast<uint8_t>(fgetc(file_));
-		sector_info.length = static_cast<uint8_t>(fgetc(file_));
-		sector_info.status1 = static_cast<uint8_t>(fgetc(file_));
-		sector_info.status2 = static_cast<uint8_t>(fgetc(file_));
-		sector_info.actual_length = fgetc16le();
-
-		sector_infos.push_back(sector_info);
-	}
-
-	// Get the sectors.
-	fseek(file_, file_offset + 0x100, SEEK_SET);
+	// Transcribe sectors and return.
+	// TODO: is this transcription really necessary?
 	std::vector<Storage::Encodings::MFM::Sector> sectors;
-	for(auto &sector_info : sector_infos) {
+	for(auto &sector : track->sectors) {
 		Storage::Encodings::MFM::Sector new_sector;
-		new_sector.address.track = sector_info.track;
-		new_sector.address.side = sector_info.side;
-		new_sector.address.sector = sector_info.sector;
-		new_sector.size = sector_info.length;
+		new_sector.address.track = sector.track;
+		new_sector.address.side = sector.side;
+		new_sector.address.sector = sector.sector;
+		new_sector.size = sector.size;
 
-		size_t data_size;
-		if(is_extended_) {
-			data_size = sector_info.actual_length;
-		} else {
-			data_size = static_cast<size_t>(128 << sector_info.length);
-			if(data_size == 0x2000) data_size = 0x1800;
-		}
-		new_sector.data.resize(data_size);
-		fread(new_sector.data.data(), sizeof(uint8_t), data_size, file_);
+		// TODO: deal with weak/fuzzy sectors.
+		new_sector.data.insert(new_sector.data.begin(), sector.data[0].begin(), sector.data[0].end());
 
-		if(sector_info.status2 & 0x20) {
+		if(sector.fdc_status2 & 0x20) {
 			// The CRC failed in the data field.
 			new_sector.has_data_crc_error = true;
 		} else {
-			if(sector_info.status1 & 0x20) {
+			if(sector.fdc_status1 & 0x20) {
 				// The CRC failed in the ID field.
 				new_sector.has_header_crc_error = true;
 			}
 		}
 
-		if(sector_info.status2 & 0x40) {
+		if(sector.fdc_status2 & 0x40) {
 			// This sector is marked as deleted.
 			new_sector.is_deleted = true;
 		}
 
-		if(sector_info.status2 & 0x01) {
+		if(sector.fdc_status2 & 0x01) {
 			// Data field wasn't found.
 			new_sector.data.clear();
 		}
@@ -147,11 +210,6 @@ std::shared_ptr<Track> CPCDSK::get_track_at_position(Track::Address address) {
 		sectors.push_back(std::move(new_sector));
 	}
 
-	// TODO: extensions to the extended format; John Elliot's addition of single-density support,
-	// and Simon Owen's weak/random sectors, subject to adding some logic to pick a potential
-	// FM/MFM encoding that can produce specified weak values.
-
-	if(sectors.size()) return Storage::Encodings::MFM::GetMFMTrackWithSectors(sectors, gap3_length, filler_byte);
-
-	return nullptr;
+	// TODO: FM encoding, data rate?
+	return Storage::Encodings::MFM::GetMFMTrackWithSectors(sectors, track->gap3_length, track->filler_byte);
 }

--- a/Storage/Disk/DiskImage/Formats/CPCDSK.cpp
+++ b/Storage/Disk/DiskImage/Formats/CPCDSK.cpp
@@ -261,6 +261,13 @@ void CPCDSK::set_tracks(const std::map<::Storage::Disk::Track::Address, std::sha
 			sector.has_header_crc_error = source_sector.second.has_header_crc_error;
 			sector.is_deleted = source_sector.second.is_deleted;
 			sector.samples = std::move(source_sector.second.samples);
+
+			sector.fdc_status1 = 0;
+			sector.fdc_status2 = 0;
+
+			if(source_sector.second.has_data_crc_error) 	sector.fdc_status2 |= 0x20;
+			if(source_sector.second.has_header_crc_error)	sector.fdc_status1 |= 0x20;
+			if(source_sector.second.is_deleted)				sector.fdc_status2 |= 0x40;
 		}
 	}
 	

--- a/Storage/Disk/DiskImage/Formats/CPCDSK.cpp
+++ b/Storage/Disk/DiskImage/Formats/CPCDSK.cpp
@@ -8,23 +8,31 @@
 
 #include "CPCDSK.hpp"
 
+#include "../../Encodings/MFM/Constants.hpp"
 #include "../../Encodings/MFM/Encoder.hpp"
+#include "../../Encodings/MFM/SegmentParser.hpp"
+#include "../../Track/TrackSerialiser.hpp"
+
+#include <iostream>
 
 using namespace Storage::Disk;
 
 CPCDSK::CPCDSK(const char *file_name) :
-	Storage::FileHolder(file_name), is_extended_(false) {
-	if(!check_signature("MV - CPC", 8)) {
+	is_extended_(false) {
+	FileHolder file(file_name);
+	is_read_only_ = file.get_is_known_read_only();
+
+	if(!file.check_signature("MV - CPC")) {
 		is_extended_ = true;
-		fseek(file_, 0, SEEK_SET);
-		if(!check_signature("EXTENDED", 8))
+		file.seek(0, SEEK_SET);
+		if(!file.check_signature("EXTENDED"))
 			throw ErrorNotCPCDSK;
 	}
 
 	// Don't really care about about the creator; skip.
-	fseek(file_, 0x30, SEEK_SET);
-	head_position_count_ = fgetc(file_);
-	head_count_ = fgetc(file_);
+	file.seek(0x30, SEEK_SET);
+	head_position_count_ = file.get8();
+	head_count_ = file.get8();
 
 	// Used only for non-extended disks.
 	long size_of_a_track = 0;
@@ -34,37 +42,37 @@ CPCDSK::CPCDSK(const char *file_name) :
 
 	if(is_extended_) {
 		// Skip two unused bytes and grab the track size table.
-		fseek(file_, 2, SEEK_CUR);
+		file.seek(2, SEEK_CUR);
 		for(int c = 0; c < head_position_count_ * head_count_; c++) {
-			track_sizes.push_back(static_cast<size_t>(fgetc(file_) << 8));
+			track_sizes.push_back(static_cast<size_t>(file.get8()) << 8);
 		}
 	} else {
-		size_of_a_track = fgetc16le();
+		size_of_a_track = file.get16le();
 	}
 
 	long file_offset = 0x100;
 	for(size_t c = 0; c < static_cast<size_t>(head_position_count_ * head_count_); c++) {
 		if(!is_extended_ || (track_sizes[c] > 0)) {
 			// Skip the introductory text, 'Track-Info\r\n' and its unused bytes.
-			fseek(file_, file_offset + 16, SEEK_SET);
+			file.seek(file_offset + 16, SEEK_SET);
 
 			tracks_.emplace_back(new Track);
 			Track *track = tracks_.back().get();
 
 			// Track and side are stored, being a byte each.
-			track->track = static_cast<uint8_t>(fgetc(file_));
-			track->side = static_cast<uint8_t>(fgetc(file_));
+			track->track = file.get8();
+			track->side = file.get8();
 			
 			// If this is an extended disk image then John Elliott's extension provides some greater
 			// data rate and encoding context. Otherwise the next two bytes have no defined meaning.
 			if(is_extended_) {
-				switch(fgetc(file_)) {
+				switch(file.get8()) {
 					default: track->data_rate = Track::DataRate::Unknown;				break;
 					case 1: track->data_rate = Track::DataRate::SingleOrDoubleDensity;	break;
 					case 2: track->data_rate = Track::DataRate::HighDensity;			break;
 					case 3: track->data_rate = Track::DataRate::ExtendedDensity;		break;
 				}
-				switch(fgetc(file_)) {
+				switch(file.get8()) {
 					default: track->data_encoding = Track::DataEncoding::Unknown;		break;
 					case 1: track->data_encoding = Track::DataEncoding::FM;				break;
 					case 2: track->data_encoding = Track::Track::DataEncoding::MFM;		break;
@@ -72,15 +80,15 @@ CPCDSK::CPCDSK(const char *file_name) :
 			} else {
 				track->data_rate = Track::DataRate::Unknown;
 				track->data_encoding = Track::DataEncoding::Unknown;
-				fseek(file_, 2, SEEK_CUR);
+				file.seek(2, SEEK_CUR);
 			}
 			
 			// Sector size, number of sectors, gap 3 length and the filler byte are then common
 			// between both variants of DSK.
-			track->sector_length = static_cast<uint8_t>(fgetc(file_));
-			size_t number_of_sectors = static_cast<size_t>(fgetc(file_));
-			track->gap3_length = static_cast<uint8_t>(fgetc(file_));
-			track->filler_byte = static_cast<uint8_t>(fgetc(file_));
+			track->sector_length = file.get8();
+			size_t number_of_sectors = file.get8();
+			track->gap3_length = file.get8();
+			track->filler_byte = file.get8();
 
 			// Sector information begins immediately after the track information table.
 			while(number_of_sectors--) {
@@ -89,12 +97,12 @@ CPCDSK::CPCDSK(const char *file_name) :
 
 				// Track, side, sector, size and two FDC8272-esque status bytes are stored
 				// per sector, in both regular and extended DSK files.
-				sector.address.track = static_cast<uint8_t>(fgetc(file_));
-				sector.address.side = static_cast<uint8_t>(fgetc(file_));
-				sector.address.sector = static_cast<uint8_t>(fgetc(file_));
-				sector.size = static_cast<uint8_t>(fgetc(file_));
-				sector.fdc_status1 = static_cast<uint8_t>(fgetc(file_));
-				sector.fdc_status2 = static_cast<uint8_t>(fgetc(file_));
+				sector.address.track = file.get8();
+				sector.address.side = file.get8();
+				sector.address.sector = file.get8();
+				sector.size = file.get8();
+				sector.fdc_status1 = file.get8();
+				sector.fdc_status2 = file.get8();
 
 				if(sector.fdc_status2 & 0x20) {
 					// The CRC failed in the data field.
@@ -131,7 +139,7 @@ CPCDSK::CPCDSK(const char *file_name) :
 					// sector was weak or fuzzy and that multiple samplings are provided. If the greater size
 					// is not an exact multiple then my reading of the documentation is that this is an invalid
 					// disk image.
-					size_t declared_data_size = fgetc16le();
+					size_t declared_data_size = file.get16le();
 					if(declared_data_size != stored_data_size) {
 						if(declared_data_size > data_size) {
 							number_of_samplings = declared_data_size / data_size;
@@ -145,7 +153,7 @@ CPCDSK::CPCDSK(const char *file_name) :
 					// In a regular DSK, these two bytes are unused, and a special case is applied that ostensibly 8kb
 					// sectors are abbreviated to only 0x1800 bytes.
 					if(data_size == 0x2000) stored_data_size = 0x1800;
-					fseek(file_, 2, SEEK_CUR);
+					file.seek(2, SEEK_CUR);
 				}
 
 				// As per the weak/fuzzy sector extension, multiple samplings may be stored here.
@@ -158,10 +166,10 @@ CPCDSK::CPCDSK(const char *file_name) :
 			}
 
 			// Sector contents are at offset 0x100 into the track.
-			fseek(file_, file_offset + 0x100, SEEK_SET);
+			file.seek(file_offset + 0x100, SEEK_SET);
 			for(auto &sector: track->sectors) {
 				for(auto &data : sector.samples) {
-					fread(data.data(), 1, data.size(), file_);
+					file.read(data.data(), data.size());
 				}
 			}
 		} else {
@@ -185,9 +193,13 @@ int CPCDSK::get_head_count() {
 	return head_count_;
 }
 
+size_t CPCDSK::index_for_track(::Storage::Disk::Track::Address address) {
+	return static_cast<size_t>((address.position * head_count_) + address.head);
+}
+
 std::shared_ptr<Track> CPCDSK::get_track_at_position(::Storage::Disk::Track::Address address) {
 	// Given that thesea are interleaved images, determine which track, chronologically, is being requested.
-	size_t chronological_track = static_cast<size_t>((address.position * head_count_) + address.head);
+	size_t chronological_track = index_for_track(address);
 
 	// Return a nullptr if out of range or not provided.
 	if(chronological_track >= tracks_.size()) return nullptr;
@@ -202,4 +214,57 @@ std::shared_ptr<Track> CPCDSK::get_track_at_position(::Storage::Disk::Track::Add
 
 	// TODO: FM encoding, data rate?
 	return Storage::Encodings::MFM::GetMFMTrackWithSectors(sectors, track->gap3_length, track->filler_byte);
+}
+
+void CPCDSK::set_tracks(const std::map<::Storage::Disk::Track::Address, std::shared_ptr<::Storage::Disk::Track>> &tracks) {
+	// Patch changed tracks into the disk image.
+	for(auto &pair: tracks) {
+		// Assume MFM for now; with extensions DSK can contain FM tracks.
+		const bool is_double_density = true;
+		std::map<size_t, Storage::Encodings::MFM::Sector> sectors =
+			Storage::Encodings::MFM::sectors_from_segment(
+				Storage::Disk::track_serialisation(*pair.second, is_double_density ? Storage::Encodings::MFM::MFMBitLength : Storage::Encodings::MFM::FMBitLength),
+				is_double_density);
+
+		// Find slot for track, making it if neccessary.
+		size_t chronological_track = index_for_track(pair.first);
+		if(chronological_track >= tracks_.size()) {
+			tracks_.resize(chronological_track+1);
+		}
+
+		// Get the track, or create it if necessary.
+		Track *track = tracks_[chronological_track].get();
+		if(!track) {
+			track = new Track;
+			track->track = static_cast<uint8_t>(pair.first.position);
+			track->side = static_cast<uint8_t>(pair.first.head);
+			track->data_rate = Track::DataRate::SingleOrDoubleDensity;
+			track->data_encoding = Track::DataEncoding::MFM;
+			track->sector_length = 2;
+			track->gap3_length = 78;
+			track->filler_byte = 0xe5;
+
+			tracks_[chronological_track] = std::unique_ptr<Track>(track);
+		}
+
+		// Store sectors.
+		track->sectors.clear();
+		for(auto &source_sector: sectors) {
+			track->sectors.emplace_back();
+			Track::Sector &sector = track->sectors.back();
+
+			sector.address = source_sector.second.address;
+			sector.size = source_sector.second.size;
+			sector.has_data_crc_error = source_sector.second.has_data_crc_error;
+			sector.has_header_crc_error = source_sector.second.has_header_crc_error;
+			sector.is_deleted = source_sector.second.is_deleted;
+			sector.samples = std::move(source_sector.second.samples);
+		}
+	}
+	
+	// Rewrite the entire disk image, in extended form.
+}
+
+bool CPCDSK::get_is_read_only() {
+	return is_read_only_;
 }

--- a/Storage/Disk/DiskImage/Formats/CPCDSK.hpp
+++ b/Storage/Disk/DiskImage/Formats/CPCDSK.hpp
@@ -64,6 +64,7 @@ class CPCDSK: public DiskImage {
 
 			std::vector<Sector> sectors;
 		};
+		std::string file_name_;
 		std::vector<std::unique_ptr<Track>> tracks_;
 		size_t index_for_track(::Storage::Disk::Track::Address address);
 

--- a/Storage/Disk/DiskImage/Formats/CPCDSK.hpp
+++ b/Storage/Disk/DiskImage/Formats/CPCDSK.hpp
@@ -21,7 +21,7 @@ namespace Disk {
 /*!
 	Provies a @c Disk containing an Amstrad CPC-stype disk image — some arrangement of sectors with status bits.
 */
-class CPCDSK: public DiskImage, public Storage::FileHolder {
+class CPCDSK: public DiskImage {
 	public:
 		/*!
 			Construct an @c AcornADF containing content from the file with name @c file_name.
@@ -38,7 +38,9 @@ class CPCDSK: public DiskImage, public Storage::FileHolder {
 		// implemented to satisfy @c Disk
 		int get_head_position_count() override;
 		int get_head_count() override;
-		using DiskImage::get_is_read_only;
+		bool get_is_read_only() override;
+
+		void set_tracks(const std::map<Track::Address, std::shared_ptr<Track>> &tracks) override;
 		std::shared_ptr<::Storage::Disk::Track> get_track_at_position(::Storage::Disk::Track::Address address) override;
 
 	private:
@@ -63,10 +65,12 @@ class CPCDSK: public DiskImage, public Storage::FileHolder {
 			std::vector<Sector> sectors;
 		};
 		std::vector<std::unique_ptr<Track>> tracks_;
+		size_t index_for_track(::Storage::Disk::Track::Address address);
 
 		int head_count_;
 		int head_position_count_;
 		bool is_extended_;
+		bool is_read_only_;
 };
 
 }

--- a/Storage/Disk/DiskImage/Formats/CPCDSK.hpp
+++ b/Storage/Disk/DiskImage/Formats/CPCDSK.hpp
@@ -38,18 +38,42 @@ class CPCDSK: public DiskImage, public Storage::FileHolder {
 		int get_head_position_count() override;
 		int get_head_count() override;
 		using DiskImage::get_is_read_only;
-		std::shared_ptr<Track> get_track_at_position(Track::Address address) override;
+		std::shared_ptr<::Storage::Disk::Track> get_track_at_position(::Storage::Disk::Track::Address address) override;
 
 	private:
+		struct Track {
+			uint8_t track;
+			uint8_t side;
+			enum class DataRate {
+				Unknown, SingleOrDoubleDensity, HighDensity, ExtendedDensity
+			} data_rate;
+			enum class DataEncoding {
+				Unknown, FM, MFM
+			} data_encoding;
+			uint8_t sector_length;
+			uint8_t gap3_length;
+			uint8_t filler_byte;
+
+			struct Sector {
+				uint8_t track;
+				uint8_t side;
+				uint8_t sector;
+				uint8_t size;
+				uint8_t fdc_status1;
+				uint8_t fdc_status2;
+				
+				// If multiple copies are present, that implies a sector with weak bits, for which multiple
+				// samplings were obtained.
+				std::vector<std::vector<uint8_t>> data;
+			};
+
+			std::vector<Sector> sectors;
+		};
+		std::vector<std::unique_ptr<Track>> tracks_;
+
 		int head_count_;
 		int head_position_count_;
 		bool is_extended_;
-
-		// Used only for non-extended disks.
-		long size_of_a_track_;
-
-		// Used only for extended disks.
-		std::vector<size_t> track_sizes_;
 };
 
 }

--- a/Storage/Disk/DiskImage/Formats/CPCDSK.hpp
+++ b/Storage/Disk/DiskImage/Formats/CPCDSK.hpp
@@ -11,6 +11,7 @@
 
 #include "../DiskImage.hpp"
 #include "../../../FileHolder.hpp"
+#include "../../Encodings/MFM/Sector.hpp"
 
 #include <vector>
 
@@ -54,17 +55,9 @@ class CPCDSK: public DiskImage, public Storage::FileHolder {
 			uint8_t gap3_length;
 			uint8_t filler_byte;
 
-			struct Sector {
-				uint8_t track;
-				uint8_t side;
-				uint8_t sector;
-				uint8_t size;
+			struct Sector: public ::Storage::Encodings::MFM::Sector {
 				uint8_t fdc_status1;
 				uint8_t fdc_status2;
-				
-				// If multiple copies are present, that implies a sector with weak bits, for which multiple
-				// samplings were obtained.
-				std::vector<std::vector<uint8_t>> data;
 			};
 
 			std::vector<Sector> sectors;

--- a/Storage/Disk/DiskImage/Formats/D64.cpp
+++ b/Storage/Disk/DiskImage/Formats/D64.cpp
@@ -17,13 +17,13 @@
 using namespace Storage::Disk;
 
 D64::D64(const char *file_name) :
-		Storage::FileHolder(file_name) {
+		file_(file_name) {
 	// in D64, this is it for validation without imposing potential false-negative tests — check that
 	// the file size appears to be correct. Stone-age stuff.
-	if(file_stats_.st_size != 174848 && file_stats_.st_size != 196608)
+	if(file_.stats().st_size != 174848 && file_.stats().st_size != 196608)
 		throw ErrorNotD64;
 
-	number_of_tracks_ = (file_stats_.st_size == 174848) ? 35 : 40;
+	number_of_tracks_ = (file_.stats().st_size == 174848) ? 35 : 40;
 
 	// then, ostensibly, this is a valid file. Hmmm. Pick a disk ID as a function of the file_name,
 	// being the most stable thing available
@@ -59,7 +59,7 @@ std::shared_ptr<Track> D64::get_track_at_position(Track::Address address) {
 	}
 
 	// seek to start of data
-	fseek(file_, offset_to_track * 256, SEEK_SET);
+	file_.seek(offset_to_track * 256, SEEK_SET);
 
 	// build up a PCM sampling of the GCR version of this track
 
@@ -117,7 +117,7 @@ std::shared_ptr<Track> D64::get_track_at_position(Track::Address address) {
 
 		// get the actual contents
 		uint8_t source_data[256];
-		fread(source_data, 1, 256, file_);
+		file_.read(source_data, sizeof(source_data));
 
 		// compute the latest checksum
 		checksum = 0;

--- a/Storage/Disk/DiskImage/Formats/D64.hpp
+++ b/Storage/Disk/DiskImage/Formats/D64.hpp
@@ -18,7 +18,7 @@ namespace Disk {
 /*!
 	Provies a @c Disk containing a D64 disk image — a decoded sector dump of a C1540-format disk.
 */
-class D64: public DiskImage, public Storage::FileHolder {
+class D64: public DiskImage {
 	public:
 		/*!
 			Construct a @c D64 containing content from the file with name @c file_name.
@@ -38,6 +38,7 @@ class D64: public DiskImage, public Storage::FileHolder {
 		std::shared_ptr<Track> get_track_at_position(Track::Address address) override;
 
 	private:
+		Storage::FileHolder file_;
 		int number_of_tracks_;
 		uint16_t disk_id_;
 };

--- a/Storage/Disk/DiskImage/Formats/G64.hpp
+++ b/Storage/Disk/DiskImage/Formats/G64.hpp
@@ -18,7 +18,7 @@ namespace Disk {
 /*!
 	Provies a @c Disk containing a G64 disk image — a raw but perfectly-clocked GCR stream.
 */
-class G64: public DiskImage, public Storage::FileHolder {
+class G64: public DiskImage {
 	public:
 		/*!
 			Construct a @c G64 containing content from the file with name @c file_name.
@@ -41,6 +41,7 @@ class G64: public DiskImage, public Storage::FileHolder {
 		using DiskImage::get_is_read_only;
 
 	private:
+		Storage::FileHolder file_;
 		uint8_t number_of_tracks_;
 		uint16_t maximum_track_size_;
 };

--- a/Storage/Disk/DiskImage/Formats/HFE.hpp
+++ b/Storage/Disk/DiskImage/Formats/HFE.hpp
@@ -18,7 +18,7 @@ namespace Disk {
 /*!
 	Provies a @c Disk containing an HFE disk image — a bit stream representation of a floppy.
 */
-class HFE: public DiskImage, public Storage::FileHolder {
+class HFE: public DiskImage {
 	public:
 		/*!
 			Construct an @c SSD containing content from the file with name @c file_name.
@@ -36,11 +36,12 @@ class HFE: public DiskImage, public Storage::FileHolder {
 		// implemented to satisfy @c Disk
 		int get_head_position_count() override;
 		int get_head_count() override;
-		using Storage::FileHolder::get_is_read_only;
+		bool get_is_read_only() override;
 		void set_tracks(const std::map<Track::Address, std::shared_ptr<Track>> &tracks) override;
 		std::shared_ptr<Track> get_track_at_position(Track::Address address) override;
 
 	private:
+		Storage::FileHolder file_;
 		uint16_t seek_track(Track::Address address);
 
 		int head_count_;

--- a/Storage/Disk/DiskImage/Formats/MFMSectorDump.hpp
+++ b/Storage/Disk/DiskImage/Formats/MFMSectorDump.hpp
@@ -18,17 +18,19 @@ namespace Disk {
 /*!
 	Provies the base for writeable [M]FM disk images that just contain contiguous sector content dumps.
 */
-class MFMSectorDump: public DiskImage, public Storage::FileHolder {
+class MFMSectorDump: public DiskImage {
 	public:
 		MFMSectorDump(const char *file_name);
 		void set_geometry(int sectors_per_track, uint8_t sector_size, bool is_double_density);
 
-		using Storage::FileHolder::get_is_read_only;
+		bool get_is_read_only() override;
 		void set_tracks(const std::map<Track::Address, std::shared_ptr<Track>> &tracks) override;
 		std::shared_ptr<Track> get_track_at_position(Track::Address address) override;
 
+	protected:
+		Storage::FileHolder file_;
+
 	private:
-		std::mutex file_access_mutex_;
 		virtual long get_file_offset_for_position(Track::Address address) = 0;
 
 		int sectors_per_track_ = 0;

--- a/Storage/Disk/DiskImage/Formats/OricMFMDSK.cpp
+++ b/Storage/Disk/DiskImage/Formats/OricMFMDSK.cpp
@@ -17,13 +17,13 @@
 using namespace Storage::Disk;
 
 OricMFMDSK::OricMFMDSK(const char *file_name) :
-		Storage::FileHolder(file_name) {
-	if(!check_signature("MFM_DISK", 8))
+		file_(file_name) {
+	if(!file_.check_signature("MFM_DISK"))
 		throw ErrorNotOricMFMDSK;
 
-	head_count_ = fgetc32le();
-	track_count_ = fgetc32le();
-	geometry_type_ = fgetc32le();
+	head_count_ = file_.get32le();
+	track_count_ = file_.get32le();
+	geometry_type_ = file_.get32le();
 
 	if(geometry_type_ < 1 || geometry_type_ > 2)
 		throw ErrorNotOricMFMDSK;
@@ -53,8 +53,8 @@ long OricMFMDSK::get_file_offset_for_position(Track::Address address) {
 std::shared_ptr<Track> OricMFMDSK::get_track_at_position(Track::Address address) {
 	PCMSegment segment;
 	{
-		std::lock_guard<std::mutex> lock_guard(file_access_mutex_);
-		fseek(file_, get_file_offset_for_position(address), SEEK_SET);
+		std::lock_guard<std::mutex> lock_guard(file_.get_file_access_mutex());
+		file_.seek(get_file_offset_for_position(address), SEEK_SET);
 
 		// The file format omits clock bits. So it's not a genuine MFM capture.
 		// A consumer must contextually guess when an FB, FC, etc is meant to be a control mark.
@@ -63,7 +63,7 @@ std::shared_ptr<Track> OricMFMDSK::get_track_at_position(Track::Address address)
 		std::unique_ptr<Encodings::MFM::Encoder> encoder = Encodings::MFM::GetMFMEncoder(segment.data);
 		bool did_sync = false;
 		while(track_offset < 6250) {
-			uint8_t next_byte = static_cast<uint8_t>(fgetc(file_));
+			uint8_t next_byte = file_.get8();
 			track_offset++;
 
 			switch(next_byte) {
@@ -75,7 +75,7 @@ std::shared_ptr<Track> OricMFMDSK::get_track_at_position(Track::Address address)
 
 							case 0xfe:
 								for(int byte = 0; byte < 6; byte++) {
-									last_header[byte] = static_cast<uint8_t>(fgetc(file_));
+									last_header[byte] = file_.get8();
 									encoder->add_byte(last_header[byte]);
 									track_offset++;
 									if(track_offset == 6250) break;
@@ -84,7 +84,7 @@ std::shared_ptr<Track> OricMFMDSK::get_track_at_position(Track::Address address)
 
 							case 0xfb:
 								for(int byte = 0; byte < (128 << last_header[3]) + 2; byte++) {
-									encoder->add_byte(static_cast<uint8_t>(fgetc(file_)));
+									encoder->add_byte(file_.get8());
 									track_offset++;
 									if(track_offset == 6250) break;
 								}
@@ -156,9 +156,13 @@ void OricMFMDSK::set_tracks(const std::map<Track::Address, std::shared_ptr<Track
 
 		long file_offset = get_file_offset_for_position(track.first);
 
-		std::lock_guard<std::mutex> lock_guard(file_access_mutex_);
-		fseek(file_, file_offset, SEEK_SET);
+		std::lock_guard<std::mutex> lock_guard(file_.get_file_access_mutex());
+		file_.seek(file_offset, SEEK_SET);
 		size_t track_size = std::min(static_cast<size_t>(6400), parsed_track.size());
-		fwrite(parsed_track.data(), 1, track_size, file_);
+		file_.write(parsed_track.data(), track_size);
 	}
+}
+
+bool OricMFMDSK::get_is_read_only() {
+	return file_.get_is_known_read_only();
 }

--- a/Storage/Disk/DiskImage/Formats/OricMFMDSK.hpp
+++ b/Storage/Disk/DiskImage/Formats/OricMFMDSK.hpp
@@ -18,7 +18,7 @@ namespace Disk {
 /*!
 	Provies a @c Disk containing an Oric MFM-stype disk image — a stream of the MFM data bits with clocks omitted.
 */
-class OricMFMDSK: public DiskImage, public Storage::FileHolder {
+class OricMFMDSK: public DiskImage {
 	public:
 		/*!
 			Construct an @c OricMFMDSK containing content from the file with name @c file_name.
@@ -34,12 +34,13 @@ class OricMFMDSK: public DiskImage, public Storage::FileHolder {
 		// implemented to satisfy @c Disk
 		int get_head_position_count() override;
 		int get_head_count() override;
-		using Storage::FileHolder::get_is_read_only;
+		bool get_is_read_only() override;
+
 		void set_tracks(const std::map<Track::Address, std::shared_ptr<Track>> &tracks) override;
 		std::shared_ptr<Track> get_track_at_position(Track::Address address) override;
 
 	private:
-		std::mutex file_access_mutex_;
+		Storage::FileHolder file_;
 		long get_file_offset_for_position(Track::Address address);
 
 		uint32_t head_count_;

--- a/Storage/Disk/DiskImage/Formats/SSD.cpp
+++ b/Storage/Disk/DiskImage/Formats/SSD.cpp
@@ -21,13 +21,13 @@ SSD::SSD(const char *file_name) : MFMSectorDump(file_name) {
 	// very loose validation: the file needs to be a multiple of 256 bytes
 	// and not ungainly large
 
-	if(file_stats_.st_size & 255) throw ErrorNotSSD;
-	if(file_stats_.st_size < 512) throw ErrorNotSSD;
-	if(file_stats_.st_size > 800*256) throw ErrorNotSSD;
+	if(file_.stats().st_size & 255) throw ErrorNotSSD;
+	if(file_.stats().st_size < 512) throw ErrorNotSSD;
+	if(file_.stats().st_size > 800*256) throw ErrorNotSSD;
 
 	// this has two heads if the suffix is .dsd, one if it's .ssd
 	head_count_ = (tolower(file_name[strlen(file_name) - 3]) == 'd') ? 2 : 1;
-	track_count_ = static_cast<int>(file_stats_.st_size / (256 * 10));
+	track_count_ = static_cast<int>(file_.stats().st_size / (256 * 10));
 	if(track_count_ < 40) track_count_ = 40;
 	else if(track_count_ < 80) track_count_ = 80;
 

--- a/Storage/Disk/DiskImage/Formats/Utility/ImplicitSectors.cpp
+++ b/Storage/Disk/DiskImage/Formats/Utility/ImplicitSectors.cpp
@@ -31,7 +31,8 @@ std::shared_ptr<Track> Storage::Disk::track_for_sectors(uint8_t *const source, u
 		first_sector++;
 		new_sector.size = size;
 
-		new_sector.data.insert(new_sector.data.begin(), source + source_pointer, source + source_pointer + byte_size);
+		new_sector.samples.emplace_back();
+		new_sector.samples[0].insert(new_sector.samples[0].begin(), source + source_pointer, source + source_pointer + byte_size);
 		source_pointer += byte_size;
 	}
 
@@ -53,6 +54,7 @@ void Storage::Disk::decode_sectors(Track &track, uint8_t *const destination, uin
 		if(pair.second.address.sector > last_sector) continue;
 		if(pair.second.address.sector < first_sector) continue;
 		if(pair.second.size != sector_size) continue;
-		memcpy(&destination[pair.second.address.sector * byte_size], pair.second.data.data(), std::min(pair.second.data.size(), byte_size));
+		if(pair.second.samples.empty()) continue;
+		memcpy(&destination[pair.second.address.sector * byte_size], pair.second.samples[0].data(), std::min(pair.second.samples[0].size(), byte_size));
 	}
 }

--- a/Storage/Disk/Encodings/MFM/Encoder.hpp
+++ b/Storage/Disk/Encodings/MFM/Encoder.hpp
@@ -28,6 +28,7 @@ extern const size_t DefaultSectorGapLength;
 	@param sector_gap_filler_byte If specified, sets the value (unencoded) that is used to populate the gap between each ID and its data.
 */
 std::shared_ptr<Storage::Disk::Track> GetMFMTrackWithSectors(const std::vector<Sector> &sectors, size_t sector_gap_length = DefaultSectorGapLength, uint8_t sector_gap_filler_byte = 0x4e);
+std::shared_ptr<Storage::Disk::Track> GetMFMTrackWithSectors(const std::vector<const Sector *> &sectors, size_t sector_gap_length = DefaultSectorGapLength, uint8_t sector_gap_filler_byte = 0x4e);
 
 /*!
 	Converts a vector of sectors into a properly-encoded FM track.
@@ -37,6 +38,7 @@ std::shared_ptr<Storage::Disk::Track> GetMFMTrackWithSectors(const std::vector<S
 	@param sector_gap_filler_byte If specified, sets the value (unencoded) that is used to populate the gap between each ID and its data.
 */
 std::shared_ptr<Storage::Disk::Track> GetFMTrackWithSectors(const std::vector<Sector> &sectors, size_t sector_gap_length = DefaultSectorGapLength, uint8_t sector_gap_filler_byte = 0x4e);
+std::shared_ptr<Storage::Disk::Track> GetFMTrackWithSectors(const std::vector<const Sector *> &sectors, size_t sector_gap_length = DefaultSectorGapLength, uint8_t sector_gap_filler_byte = 0x4e);
 
 class Encoder {
 	public:

--- a/Storage/Disk/Encodings/MFM/Sector.hpp
+++ b/Storage/Disk/Encodings/MFM/Sector.hpp
@@ -34,7 +34,9 @@ struct Sector {
 
 	Address address;
 	uint8_t size = 0;
-	std::vector<uint8_t> data;
+
+	// Multiple samplings of the underlying data are accepted, to allow weak and fuzzy data to be communicated.
+	std::vector<std::vector<uint8_t>> samples;
 
 	bool has_data_crc_error = false;
 	bool has_header_crc_error = false;
@@ -45,7 +47,7 @@ struct Sector {
 	Sector(const Sector &&rhs) noexcept :
 		address(rhs.address),
 		size(rhs.size),
-		data(std::move(rhs.data)),
+		samples(std::move(rhs.samples)),
 		has_data_crc_error(rhs.has_data_crc_error),
 		has_header_crc_error(rhs.has_header_crc_error),
 		is_deleted(rhs.is_deleted ){}

--- a/Storage/Disk/Encodings/MFM/SegmentParser.cpp
+++ b/Storage/Disk/Encodings/MFM/SegmentParser.cpp
@@ -62,7 +62,8 @@ std::map<size_t, Storage::Encodings::MFM::Sector> Storage::Encodings::MFM::secto
 							shifter.set_should_obey_syncs(true);
 						break;
 						default:
-							new_sector->data.push_back(shifter.get_byte());
+							if(new_sector->samples.empty()) new_sector->samples.emplace_back();
+							new_sector->samples[0].push_back(shifter.get_byte());
 							++position;
 							if(position == size + 4) {
 								result.insert(std::make_pair(start_location, std::move(*new_sector)));

--- a/Storage/Disk/Parsers/CPM.cpp
+++ b/Storage/Disk/Parsers/CPM.cpp
@@ -27,12 +27,12 @@ std::unique_ptr<Storage::Disk::CPM::Catalogue> Storage::Disk::CPM::GetCatalogue(
 			size_t size_read = 0;
 			do {
 				Storage::Encodings::MFM::Sector *sector_contents = parser.get_sector(0, static_cast<uint8_t>(track), static_cast<uint8_t>(parameters.first_sector + sector));
-				if(!sector_contents) {
+				if(!sector_contents || sector_contents->samples.empty()) {
 					return nullptr;
 				}
 
-				catalogue.insert(catalogue.end(), sector_contents->data.begin(), sector_contents->data.end());
-				sector_size = sector_contents->data.size();
+				catalogue.insert(catalogue.end(), sector_contents->samples[0].begin(), sector_contents->samples[0].end());
+				sector_size = sector_contents->samples[0].size();
 
 				size_read += sector_size;
 				sector++;
@@ -136,7 +136,7 @@ std::unique_ptr<Storage::Disk::CPM::Catalogue> Storage::Disk::CPM::GetCatalogue(
 
 				for(int s = 0; s < sectors_per_block && record < number_of_records; s++) {
 					Storage::Encodings::MFM::Sector *sector_contents = parser.get_sector(0, static_cast<uint8_t>(track), static_cast<uint8_t>(parameters.first_sector +  sector));
-					if(!sector_contents) break;
+					if(!sector_contents || sector_contents->samples.empty()) break;
 					sector++;
 					if(sector == parameters.sectors_per_track) {
 						sector = 0;
@@ -144,7 +144,7 @@ std::unique_ptr<Storage::Disk::CPM::Catalogue> Storage::Disk::CPM::GetCatalogue(
 					}
 
 					int records_to_copy = std::min(entry->number_of_records - record, records_per_sector);
-					memcpy(&new_file.data[entry->extent * bytes_per_catalogue_entry + static_cast<size_t>(record) * 128], sector_contents->data.data(), static_cast<size_t>(records_to_copy) * 128);
+					memcpy(&new_file.data[entry->extent * bytes_per_catalogue_entry + static_cast<size_t>(record) * 128], sector_contents->samples[0].data(), static_cast<size_t>(records_to_copy) * 128);
 					record += records_to_copy;
 				}
 			}

--- a/Storage/FileHolder.cpp
+++ b/Storage/FileHolder.cpp
@@ -16,19 +16,122 @@ FileHolder::~FileHolder() {
 	if(file_) fclose(file_);
 }
 
-FileHolder::FileHolder(const std::string &file_name) : file_(nullptr), name_(file_name) {
+FileHolder::FileHolder(const std::string &file_name, FileMode ideal_mode)
+	: name_(file_name) {
 	stat(file_name.c_str(), &file_stats_);
 	is_read_only_ = false;
-	file_ = fopen(file_name.c_str(), "rb+");
-	if(!file_) {
-		is_read_only_ = true;
-		file_ = fopen(file_name.c_str(), "rb");
+
+	switch(ideal_mode) {
+		case FileMode::ReadWrite:
+			file_ = fopen(file_name.c_str(), "rb+");
+			if(file_) break;
+			is_read_only_ = true;
+
+		// deliberate fallthrough...
+		case FileMode::Read:
+			file_ = fopen(file_name.c_str(), "rb");
+		break;
+		
+		case FileMode::Rewrite:
+			file_ = fopen(file_name.c_str(), "w");
+		break;
 	}
+
 	if(!file_) throw ErrorCantOpen;
 }
 
+uint32_t FileHolder::get32le() {
+    uint32_t result = (uint32_t)fgetc(file_);
+    result |= (uint32_t)(fgetc(file_) << 8);
+    result |= (uint32_t)(fgetc(file_) << 16);
+    result |= (uint32_t)(fgetc(file_) << 24);
+
+    return result;
+}
+
+uint32_t FileHolder::get32be() {
+    uint32_t result = (uint32_t)(fgetc(file_) << 24);
+    result |= (uint32_t)(fgetc(file_) << 16);
+    result |= (uint32_t)(fgetc(file_) << 8);
+    result |= (uint32_t)fgetc(file_);
+
+    return result;
+}
+
+uint32_t FileHolder::get24le() {
+    uint32_t result = (uint32_t)fgetc(file_);
+    result |= (uint32_t)(fgetc(file_) << 8);
+    result |= (uint32_t)(fgetc(file_) << 16);
+
+    return result;
+}
+
+uint32_t FileHolder::get24be() {
+    uint32_t result = (uint32_t)(fgetc(file_) << 16);
+    result |= (uint32_t)(fgetc(file_) << 8);
+    result |= (uint32_t)fgetc(file_);
+
+    return result;
+}
+
+uint16_t FileHolder::get16le() {
+    uint16_t result = static_cast<uint16_t>(fgetc(file_));
+    result |= static_cast<uint16_t>(fgetc(file_) << 8);
+
+    return result;
+}
+
+uint16_t FileHolder::get16be() {
+    uint16_t result = static_cast<uint16_t>(fgetc(file_) << 8);
+    result |= static_cast<uint16_t>(fgetc(file_));
+
+    return result;
+}
+
+uint8_t FileHolder::get8() {
+    return static_cast<uint8_t>(fgetc(file_));
+}
+
+std::vector<uint8_t> FileHolder::read(size_t size) {
+	std::vector<uint8_t> result(size);
+	fread(result.data(), 1, size, file_);
+	return result;
+}
+
+size_t FileHolder::read(uint8_t *buffer, size_t size) {
+    return fread(buffer, 1, size, file_);
+}
+
+size_t FileHolder::write(const std::vector<uint8_t> &buffer) {
+	return fwrite(buffer.data(), 1, buffer.size(), file_);
+}
+
+size_t FileHolder::write(const uint8_t *buffer, size_t size) {
+    return fwrite(buffer, 1, size, file_);
+}
+
+void FileHolder::seek(long offset, int whence) {
+	fseek(file_, offset, whence);
+}
+
+long FileHolder::tell() {
+	return ftell(file_);
+}
+
+void FileHolder::flush() {
+	fflush(file_);
+}
+
+bool FileHolder::eof() {
+	return feof(file_);
+}
+
+FileHolder::BitStream FileHolder::get_bitstream(bool lsb_first) {
+	return BitStream(file_, lsb_first);
+}
+
 bool FileHolder::check_signature(const char *signature, size_t length) {
-	if(!length) length = strlen(signature)+1;
+	if(!length) length = strlen(signature);
 
 	// read and check the file signature
 	char stored_signature[12];
@@ -37,67 +140,35 @@ bool FileHolder::check_signature(const char *signature, size_t length) {
 	return true;
 }
 
-uint32_t FileHolder::fgetc32le() {
-	uint32_t result = (uint32_t)fgetc(file_);
-	result |= (uint32_t)(fgetc(file_) << 8);
-	result |= (uint32_t)(fgetc(file_) << 16);
-	result |= (uint32_t)(fgetc(file_) << 24);
+std::string FileHolder::extension() {
+    size_t pointer = name_.size() - 1;
+    while(pointer > 0 && name_[pointer] != '.') pointer--;
+    if(name_[pointer] == '.') pointer++;
 
-	return result;
+    std::string extension = name_.substr(pointer);
+    std::transform(extension.begin(), extension.end(), extension.begin(), ::tolower);
+    return extension;
 }
 
-uint32_t FileHolder::fgetc24le() {
-	uint32_t result = (uint32_t)fgetc(file_);
-	result |= (uint32_t)(fgetc(file_) << 8);
-	result |= (uint32_t)(fgetc(file_) << 16);
-
-	return result;
+void FileHolder::ensure_is_at_least_length(long length) {
+    fseek(file_, 0, SEEK_END);
+    long bytes_to_write = length - ftell(file_);
+    if(bytes_to_write > 0) {
+        uint8_t *empty = new uint8_t[static_cast<size_t>(bytes_to_write)];
+        memset(empty, 0, static_cast<size_t>(bytes_to_write));
+        fwrite(empty, sizeof(uint8_t), static_cast<size_t>(bytes_to_write), file_);
+        delete[] empty;
+    }
 }
 
-uint16_t FileHolder::fgetc16le() {
-	uint16_t result = static_cast<uint16_t>(fgetc(file_));
-	result |= static_cast<uint16_t>(fgetc(file_) << 8);
-
-	return result;
-}
-
-uint32_t FileHolder::fgetc32be() {
-	uint32_t result = (uint32_t)(fgetc(file_) << 24);
-	result |= (uint32_t)(fgetc(file_) << 16);
-	result |= (uint32_t)(fgetc(file_) << 8);
-	result |= (uint32_t)fgetc(file_);
-
-	return result;
-}
-
-uint16_t FileHolder::fgetc16be() {
-	uint16_t result = static_cast<uint16_t>(fgetc(file_) << 8);
-	result |= static_cast<uint16_t>(fgetc(file_));
-
-	return result;
-}
-
-bool FileHolder::get_is_read_only() {
+bool FileHolder::get_is_known_read_only() {
 	return is_read_only_;
 }
 
-void FileHolder::ensure_file_is_at_least_length(long length) {
-	fseek(file_, 0, SEEK_END);
-	long bytes_to_write = length - ftell(file_);
-	if(bytes_to_write > 0) {
-		uint8_t *empty = new uint8_t[static_cast<size_t>(bytes_to_write)];
-		memset(empty, 0, static_cast<size_t>(bytes_to_write));
-		fwrite(empty, sizeof(uint8_t), static_cast<size_t>(bytes_to_write), file_);
-		delete[] empty;
-	}
+struct stat &FileHolder::stats() {
+	return file_stats_;
 }
 
-std::string FileHolder::extension() {
-	size_t pointer = name_.size() - 1;
-	while(pointer > 0 && name_[pointer] != '.') pointer--;
-	if(name_[pointer] == '.') pointer++;
-
-	std::string extension = name_.substr(pointer);
-	std::transform(extension.begin(), extension.end(), extension.begin(), ::tolower);
-	return extension;
+std::mutex &FileHolder::get_file_access_mutex() {
+	return file_access_mutex_;
 }

--- a/Storage/FileHolder.cpp
+++ b/Storage/FileHolder.cpp
@@ -152,9 +152,9 @@ bool FileHolder::check_signature(const char *signature, size_t length) {
 	if(!length) length = strlen(signature);
 
 	// read and check the file signature
-	char stored_signature[12];
-	if(fread(stored_signature, 1, length, file_) != length)	return false;
-	if(memcmp(stored_signature, signature, length)) return false;
+	std::vector<uint8_t> stored_signature = read(length);
+	if(stored_signature.size() != length)					return false;
+	if(memcmp(stored_signature.data(), signature, length)) 	return false;
 	return true;
 }
 

--- a/Storage/FileHolder.cpp
+++ b/Storage/FileHolder.cpp
@@ -92,6 +92,24 @@ uint8_t FileHolder::get8() {
     return static_cast<uint8_t>(fgetc(file_));
 }
 
+void FileHolder::put16be(uint16_t value) {
+	fputc(value >> 8, file_);
+	fputc(value, file_);
+}
+
+void FileHolder::put16le(uint16_t value) {
+	fputc(value, file_);
+	fputc(value >> 8, file_);
+}
+
+void FileHolder::put8(uint8_t value) {
+	fputc(value, file_);
+}
+
+void FileHolder::putn(size_t repeats, uint8_t value) {
+	while(repeats--) put8(value);
+}
+
 std::vector<uint8_t> FileHolder::read(size_t size) {
 	std::vector<uint8_t> result(size);
 	fread(result.data(), 1, size, file_);

--- a/Storage/FileHolder.hpp
+++ b/Storage/FileHolder.hpp
@@ -14,84 +14,76 @@
 #include <cstdint>
 #include <mutex>
 #include <string>
+#include <vector>
 
 namespace Storage {
 
-class FileHolder {
+class FileHolder final {
 	public:
 		enum {
 			ErrorCantOpen = -1
 		};
+	
+		enum class FileMode {
+			ReadWrite,
+			Read,
+			Rewrite
+		};
 
-		virtual ~FileHolder();
-
-	protected:
-		FileHolder(const std::string &file_name);
-
-		/*!
-			Reads @c length bytes from the file and compares them to the first
-			@c length bytes of @c signature. If @c length is 0, it is computed
-			as the length of @c signature up to and including the terminating null.
-			
-			@returns @c true if the bytes read match the signature; @c false otherwise.
-		*/
-		bool check_signature(const char *signature, size_t length);
+		~FileHolder();
+		FileHolder(const std::string &file_name, FileMode ideal_mode = FileMode::ReadWrite);
 
 		/*!
-			Performs @c fgetc four times on @c file_, casting each result to a @c uint32_t
+			Performs @c get8 four times on @c file, casting each result to a @c uint32_t
 			and returning the four assembled in little endian order.
 		*/
-		uint32_t fgetc32le();
+		uint32_t get32le();
 
 		/*!
-			Performs @c fgetc three times on @c file_, casting each result to a @c uint32_t
-			and returning the three assembled in little endian order.
-		*/
-		uint32_t fgetc24le();
-
-		/*!
-			Performs @c fgetc two times on @c file_, casting each result to a @c uint32_t
-			and returning the two assembled in little endian order.
-		*/
-		uint16_t fgetc16le();
-
-		/*!
-			Performs @c fgetc four times on @c file_, casting each result to a @c uint32_t
+			Performs @c get8 four times on @c file, casting each result to a @c uint32_t
 			and returning the four assembled in big endian order.
 		*/
-		uint32_t fgetc32be();
+		uint32_t get32be();
 
 		/*!
-			Performs @c fgetc two times on @c file_, casting each result to a @c uint32_t
+			Performs @c get8 three times on @c file, casting each result to a @c uint32_t
+			and returning the three assembled in little endian order.
+		*/
+		uint32_t get24le();
+
+		/*!
+			Performs @c get8 three times on @c file, casting each result to a @c uint32_t
+			and returning the three assembled in big endian order.
+		*/
+		uint32_t get24be();
+
+		/*!
+			Performs @c get8 two times on @c file, casting each result to a @c uint32_t
+			and returning the two assembled in little endian order.
+		*/
+		uint16_t get16le();
+
+		/*!
+			Performs @c get8 two times on @c file, casting each result to a @c uint32_t
 			and returning the two assembled in big endian order.
 		*/
-		uint16_t fgetc16be();
+		uint16_t get16be();
 
-		/*!
-			Determines and returns the file extension — everything from the final character
-			back to the first dot. The string is converted to lowercase before being returned.
-		*/
-		std::string extension();
-
-		/*!
-			Ensures the file is at least @c length bytes long, appending 0s until it is
-			if necessary.
-		*/
-		void ensure_file_is_at_least_length(long length);
-
-		/*!
-			@returns @c true if this file is read-only; @c false otherwise.
-		*/
-		bool get_is_read_only();
+		/*! Reads a single byte from @c file */
+		uint8_t get8();
+	
+		std::vector<uint8_t> read(size_t size);
+		size_t read(uint8_t *buffer, size_t size);
+		size_t write(const std::vector<uint8_t> &);
+		size_t write(const uint8_t *buffer, size_t size);
+	
+		void seek(long offset, int whence);
+		long tell();
+		void flush();
+		bool eof();
 
 		class BitStream {
 			public:
-				BitStream(FILE *f, bool lsb_first) :
-					file_(f),
-					lsb_first_(lsb_first),
-					next_value_(0),
-					bits_remaining_(0) {}
-
 				uint8_t get_bits(int q) {
 					uint8_t result = 0;
 					while(q--) {
@@ -101,6 +93,13 @@ class FileHolder {
 				}
 
 			private:
+				BitStream(FILE *file, bool lsb_first) :
+					file_(file),
+					lsb_first_(lsb_first),
+					next_value_(0),
+					bits_remaining_(0) {}
+				friend FileHolder;
+
 				FILE *file_;
 				bool lsb_first_;
 				uint8_t next_value_;
@@ -126,14 +125,53 @@ class FileHolder {
 					return bit;
 				}
 		};
+	
+		/*!
+			Obtains a BitStream for reading from the file from the current reading cursor.
+		*/
+		BitStream get_bitstream(bool lsb_first);
 
-		FILE *file_;
-		struct stat file_stats_;
-		std::mutex file_access_mutex_;
+		/*!
+			Reads @c length bytes from the file and compares them to the first
+			@c length bytes of @c signature. If @c length is 0, it is computed
+			as the length of @c signature not including the terminating null.
 
-		const std::string name_;
+			@returns @c true if the bytes read match the signature; @c false otherwise.
+		*/
+		bool check_signature(const char *signature, size_t length = 0);
+
+		/*!
+			Determines and returns the file extension — everything from the final character
+			back to the first dot. The string is converted to lowercase before being returned.
+		*/
+		std::string extension();
+
+		/*!
+			Ensures the file is at least @c length bytes long, appending 0s until it is
+			if necessary.
+		*/
+		void ensure_is_at_least_length(long length);
+
+		/*!
+			@returns @c true if this file is read-only; @c false otherwise.
+		*/
+		bool get_is_known_read_only();
+
+		/*!
+			@returns the stat struct describing this file.
+		*/
+		struct stat &stats();
+	
+		std::mutex &get_file_access_mutex();
+
 	private:
-		bool is_read_only_;
+		FILE *file_ = nullptr;
+		const std::string name_;
+
+		struct stat file_stats_;
+		bool is_read_only_ = false;
+
+		std::mutex file_access_mutex_;
 };
 
 }

--- a/Storage/FileHolder.hpp
+++ b/Storage/FileHolder.hpp
@@ -62,21 +62,27 @@ class FileHolder final {
 			and returning the two assembled in little endian order.
 		*/
 		uint16_t get16le();
+		void put16le(uint16_t value);
 
 		/*!
 			Performs @c get8 two times on @c file, casting each result to a @c uint32_t
 			and returning the two assembled in big endian order.
 		*/
 		uint16_t get16be();
+		void put16be(uint16_t value);
 
-		/*! Reads a single byte from @c file */
+		/*! Reads a single byte from @c file. */
 		uint8_t get8();
-	
+
+		/*! Writes a single byte from @c file. */
+		void put8(uint8_t value);
+		void putn(size_t repeats, uint8_t value);
+
 		std::vector<uint8_t> read(size_t size);
 		size_t read(uint8_t *buffer, size_t size);
 		size_t write(const std::vector<uint8_t> &);
 		size_t write(const uint8_t *buffer, size_t size);
-	
+
 		void seek(long offset, int whence);
 		long tell();
 		void flush();

--- a/Storage/FileHolder.hpp
+++ b/Storage/FileHolder.hpp
@@ -31,6 +31,19 @@ class FileHolder final {
 		};
 
 		~FileHolder();
+
+		/*!
+			Attempts to open the file indicated by @c file_name. @c ideal_mode nominates how the file would
+			most ideally be opened. It can be one of:
+
+				ReadWrite	attempt to open this file for random access reading and writing. If that fails,
+							will attept to open in Read mode.
+				Read		attempts to open this file for reading only.
+				Rewrite		opens the file for rewriting — none of the original content is preserved; whatever
+							the caller outputs will replace the existing file.
+
+			@raises ErrorCantOpen if the file cannot be opened.
+		*/
 		FileHolder(const std::string &file_name, FileMode ideal_mode = FileMode::ReadWrite);
 
 		/*!
@@ -62,6 +75,10 @@ class FileHolder final {
 			and returning the two assembled in little endian order.
 		*/
 		uint16_t get16le();
+
+		/*!
+			Writes @c value using two successive @c put8s, in little endian order.
+		*/
 		void put16le(uint16_t value);
 
 		/*!
@@ -69,6 +86,10 @@ class FileHolder final {
 			and returning the two assembled in big endian order.
 		*/
 		uint16_t get16be();
+
+		/*!
+			Writes @c value using two successive @c put8s, in big endian order.
+		*/
 		void put16be(uint16_t value);
 
 		/*! Reads a single byte from @c file. */
@@ -76,16 +97,32 @@ class FileHolder final {
 
 		/*! Writes a single byte from @c file. */
 		void put8(uint8_t value);
+
+		/*! Writes @c value a total of @c repeats times. */
 		void putn(size_t repeats, uint8_t value);
 
+		/*! Reads @c size bytes and returns them as a vector. */
 		std::vector<uint8_t> read(size_t size);
+
+		/*! Reads @c size bytes and writes them to @c buffer. */
 		size_t read(uint8_t *buffer, size_t size);
-		size_t write(const std::vector<uint8_t> &);
+
+		/*! Writes @c buffer one byte at a time in order. */
+		size_t write(const std::vector<uint8_t> &buffer);
+
+		/*! Writes @c buffer one byte at a time in order, writing @c size bytes in total. */
 		size_t write(const uint8_t *buffer, size_t size);
 
+		/*! Moves @c bytes from the anchor indicated by @c whence — SEEK_SET, SEEK_CUR or SEEK_END. */
 		void seek(long offset, int whence);
+
+		/*! @returns The current cursor position within this file. */
 		long tell();
+
+		/*! Flushes any queued content that has not yet been written to disk. */
 		void flush();
+
+		/*! @returns @c true if the end-of-file indicator is set, @c false otherwise. */
 		bool eof();
 
 		class BitStream {
@@ -159,7 +196,7 @@ class FileHolder final {
 		void ensure_is_at_least_length(long length);
 
 		/*!
-			@returns @c true if this file is read-only; @c false otherwise.
+			@returns @c true if an attempt was made to read this file in ReadWrite mode but it could be opened only for reading; @c false otherwise.
 		*/
 		bool get_is_known_read_only();
 
@@ -168,6 +205,9 @@ class FileHolder final {
 		*/
 		struct stat &stats();
 	
+		/*!
+			@returns a mutex owned by the file that can be used to serialise file access.
+		*/
 		std::mutex &get_file_access_mutex();
 
 	private:

--- a/Storage/Tape/Formats/CSW.hpp
+++ b/Storage/Tape/Formats/CSW.hpp
@@ -21,7 +21,7 @@ namespace Tape {
 /*!
 	Provides a @c Tape containing a CSW tape image, which is a compressed 1-bit sampling.
 */
-class CSW: public Tape, public Storage::FileHolder {
+class CSW: public Tape {
 	public:
 		/*!
 			Constructs a @c CSW containing content from the file with name @c file_name.
@@ -38,6 +38,8 @@ class CSW: public Tape, public Storage::FileHolder {
 		bool is_at_end();
 
 	private:
+		Storage::FileHolder file_;
+
 		void virtual_reset();
 		Pulse virtual_get_next_pulse();
 

--- a/Storage/Tape/Formats/CommodoreTAP.cpp
+++ b/Storage/Tape/Formats/CommodoreTAP.cpp
@@ -14,14 +14,13 @@ using namespace Storage::Tape;
 
 CommodoreTAP::CommodoreTAP(const char *file_name) :
 	is_at_end_(false),
-	Storage::FileHolder(file_name)
+	file_(file_name)
 {
-	if(!check_signature("C64-TAPE-RAW", 12))
+	if(!file_.check_signature("C64-TAPE-RAW"))
 		throw ErrorNotCommodoreTAP;
 
 	// check the file version
-	int version = fgetc(file_);
-	switch(version)
+	switch(file_.get8())
 	{
 		case 0:		updated_layout_ = false;	break;
 		case 1:		updated_layout_ = true;		break;
@@ -29,10 +28,10 @@ CommodoreTAP::CommodoreTAP(const char *file_name) :
 	}
 
 	// skip reserved bytes
-	fseek(file_, 3, SEEK_CUR);
+	file_.seek(3, SEEK_CUR);
 
 	// read file size
-	file_size_ = fgetc32le();
+	file_size_ = file_.get32le();
 
 	// set up for pulse output at the PAL clock rate, with each high and
 	// low being half of whatever length values will be read; pretend that
@@ -44,7 +43,7 @@ CommodoreTAP::CommodoreTAP(const char *file_name) :
 
 void CommodoreTAP::virtual_reset()
 {
-	fseek(file_, 0x14, SEEK_SET);
+	file_.seek(0x14, SEEK_SET);
 	current_pulse_.type = Pulse::High;
 	is_at_end_ = false;
 }
@@ -64,17 +63,17 @@ Storage::Tape::Tape::Pulse CommodoreTAP::virtual_get_next_pulse()
 	if(current_pulse_.type == Pulse::High)
 	{
 		uint32_t next_length;
-		uint8_t next_byte = static_cast<uint8_t>(fgetc(file_));
+		uint8_t next_byte = file_.get8();
 		if(!updated_layout_ || next_byte > 0)
 		{
 			next_length = (uint32_t)next_byte << 3;
 		}
 		else
 		{
-			next_length = fgetc24le();
+			next_length = file_.get24le();
 		}
 
-		if(feof(file_))
+		if(file_.eof())
 		{
 			is_at_end_ = true;
 			current_pulse_.length.length = current_pulse_.length.clock_rate;

--- a/Storage/Tape/Formats/CommodoreTAP.hpp
+++ b/Storage/Tape/Formats/CommodoreTAP.hpp
@@ -19,7 +19,7 @@ namespace Tape {
 /*!
 	Provides a @c Tape containing a Commodore-format tape image, which is simply a timed list of downward-going zero crossings.
 */
-class CommodoreTAP: public Tape, public Storage::FileHolder {
+class CommodoreTAP: public Tape {
 	public:
 		/*!
 			Constructs a @c CommodoreTAP containing content from the file with name @c file_name.
@@ -36,6 +36,7 @@ class CommodoreTAP: public Tape, public Storage::FileHolder {
 		bool is_at_end();
 
 	private:
+		Storage::FileHolder file_;
 		void virtual_reset();
 		Pulse virtual_get_next_pulse();
 

--- a/Storage/Tape/Formats/OricTAP.hpp
+++ b/Storage/Tape/Formats/OricTAP.hpp
@@ -19,7 +19,7 @@ namespace Tape {
 /*!
 	Provides a @c Tape containing an Oric-format tape image, which is a byte stream capture.
 */
-class OricTAP: public Tape, public Storage::FileHolder {
+class OricTAP: public Tape {
 	public:
 		/*!
 			Constructs an @c OricTAP containing content from the file with name @c file_name.
@@ -36,6 +36,7 @@ class OricTAP: public Tape, public Storage::FileHolder {
 		bool is_at_end();
 
 	private:
+		Storage::FileHolder file_;
 		void virtual_reset();
 		Pulse virtual_get_next_pulse();
 

--- a/Storage/Tape/Formats/TZX.hpp
+++ b/Storage/Tape/Formats/TZX.hpp
@@ -18,7 +18,7 @@ namespace Tape {
 /*!
 	Provides a @c Tape containing a CSW tape image, which is a compressed 1-bit sampling.
 */
-class TZX: public PulseQueuedTape, public Storage::FileHolder {
+class TZX: public PulseQueuedTape {
 	public:
 		/*!
 			Constructs a @c TZX containing content from the file with name @c file_name.
@@ -32,6 +32,8 @@ class TZX: public PulseQueuedTape, public Storage::FileHolder {
 		};
 
 	private:
+		Storage::FileHolder file_;
+
 		void virtual_reset();
 		void get_next_pulses();
 

--- a/Storage/Tape/Formats/TapePRG.hpp
+++ b/Storage/Tape/Formats/TapePRG.hpp
@@ -19,7 +19,7 @@ namespace Tape {
 /*!
 	Provides a @c Tape containing a .PRG, which is a direct local file.
 */
-class PRG: public Tape, public Storage::FileHolder {
+class PRG: public Tape {
 	public:
 		/*!
 			Constructs a @c T64 containing content from the file with name @c file_name, of type @c type.
@@ -37,6 +37,7 @@ class PRG: public Tape, public Storage::FileHolder {
 		bool is_at_end();
 
 	private:
+		FileHolder file_;
 		Pulse virtual_get_next_pulse();
 		void virtual_reset();
 

--- a/Storage/Tape/Formats/ZX80O81P.cpp
+++ b/Storage/Tape/Formats/ZX80O81P.cpp
@@ -11,15 +11,15 @@
 
 using namespace Storage::Tape;
 
-ZX80O81P::ZX80O81P(const char *file_name) :
-	Storage::FileHolder(file_name) {
+ZX80O81P::ZX80O81P(const char *file_name) {
+	Storage::FileHolder file(file_name);
 
 	// Grab the actual file contents
-	data_.resize(static_cast<size_t>(file_stats_.st_size));
-	fread(data_.data(), 1, static_cast<size_t>(file_stats_.st_size), file_);
+	data_.resize(static_cast<size_t>(file.stats().st_size));
+	file.read(data_.data(), static_cast<size_t>(file.stats().st_size));
 
 	// If it's a ZX81 file, prepend a file name.
-	std::string type = extension();
+	std::string type = file.extension();
 	platform_type_ = TargetPlatform::ZX80;
 	if(type == "p" || type == "81") {
 		// TODO, maybe: prefix a proper file name; this is leaving the file nameless.
@@ -27,8 +27,8 @@ ZX80O81P::ZX80O81P(const char *file_name) :
 		platform_type_ = TargetPlatform::ZX81;
 	}
 
-	std::shared_ptr<::Storage::Data::ZX8081::File> file = Storage::Data::ZX8081::FileFromData(data_);
-	if(!file) throw ErrorNotZX80O81P;
+	std::shared_ptr<::Storage::Data::ZX8081::File> zx_file = Storage::Data::ZX8081::FileFromData(data_);
+	if(!zx_file) throw ErrorNotZX80O81P;
 
 	// then rewind and start again
 	virtual_reset();

--- a/Storage/Tape/Formats/ZX80O81P.hpp
+++ b/Storage/Tape/Formats/ZX80O81P.hpp
@@ -23,7 +23,7 @@ namespace Tape {
 /*!
 	Provides a @c Tape containing a ZX80-format .O tape image, which is a byte stream capture.
 */
-class ZX80O81P: public Tape, public Storage::FileHolder, public TargetPlatform::TypeDistinguisher {
+class ZX80O81P: public Tape, public TargetPlatform::TypeDistinguisher {
 	public:
 		/*!
 			Constructs a @c ZX80O containing content from the file with name @c file_name.


### PR DESCRIPTION
In pursuit of which:
* corrects minor issues in the DSK reading implementation, causing previously broken titles including the unhacked Robocop to work;
* rejigs ownership model for files: has-a, not is-a; and
* generalises [future] support for weak/fuzzy sector communication with [M]FM file formats.