### PR TITLE
Commutes cross-platform `#pragma mark`s to `//MARK:`s.

### DIFF
--- a/Components/AY38910/AY38910.cpp
+++ b/Components/AY38910/AY38910.cpp
@@ -158,7 +158,7 @@ void AY38910::evaluate_output_volume() {
 	);
 }
 
-#pragma mark - Register manipulation
+// MARK: - Register manipulation
 
 void AY38910::select_register(uint8_t r) {
 	selected_register_ = r;
@@ -224,13 +224,13 @@ uint8_t AY38910::get_register_value() {
 	}
 }
 
-#pragma mark - Port handling
+// MARK: - Port handling
 
 uint8_t AY38910::get_port_output(bool port_b) {
 	return registers_[port_b ? 15 : 14];
 }
 
-#pragma mark - Bus handling
+// MARK: - Bus handling
 
 void AY38910::set_port_handler(PortHandler *handler) {
 	port_handler_ = handler;

--- a/Machines/AmstradCPC/AmstradCPC.cpp
+++ b/Machines/AmstradCPC/AmstradCPC.cpp
@@ -949,7 +949,7 @@ class ConcreteMachine:
 			tape_player_is_sleeping_ = tape_player_.is_sleeping();
 		}
 
-#pragma mark - Keyboard
+// MARK: - Keyboard
 
 		void set_typer_for_string(const char *string) override final {
 			std::unique_ptr<CharacterMapper> mapper(new CharacterMapper());

--- a/Machines/Atari2600/Cartridges/Pitfall2.hpp
+++ b/Machines/Atari2600/Cartridges/Pitfall2.hpp
@@ -28,7 +28,7 @@ class Pitfall2: public BusExtender {
 
 			switch(address) {
 
-#pragma mark - Reads
+// MARK: - Reads
 
 				// The random number generator
 				case 0x1000: case 0x1001: case 0x1002: case 0x1003: case 0x1004:
@@ -56,7 +56,7 @@ class Pitfall2: public BusExtender {
 					*value = rom_base_[8192 + address_for_counter(address & 7)] & mask_[address & 7];
 				break;
 
-#pragma mark - Writes
+// MARK: - Writes
 
 				case 0x1040: case 0x1041: case 0x1042: case 0x1043: case 0x1044: case 0x1045: case 0x1046: case 0x1047:
 					top_[address & 7] = *value;
@@ -75,12 +75,12 @@ class Pitfall2: public BusExtender {
 					random_number_generator_ = 0;
 				break;
 
-#pragma mark - Paging
+// MARK: - Paging
 
 				case 0x1ff8: rom_ptr_ = rom_base_;			break;
 				case 0x1ff9: rom_ptr_ = rom_base_ + 4096;	break;
 
-#pragma mark - Business as usual
+// MARK: - Business as usual
 
 				default:
 					if(isReadOperation(operation)) {

--- a/Machines/Atari2600/TIA.cpp
+++ b/Machines/Atari2600/TIA.cpp
@@ -529,7 +529,7 @@ void TIA::output_line() {
 	}
 }
 
-#pragma mark - Playfield output
+// MARK: - Playfield output
 
 void TIA::draw_playfield(int start, int end) {
 	// don't do anything if this window ends too early
@@ -549,7 +549,7 @@ void TIA::draw_playfield(int start, int end) {
 	}
 }
 
-#pragma mark - Motion
+// MARK: - Motion
 
 template<class T> void TIA::perform_motion_step(T &object) {
 	if((object.motion_step ^ (object.motion ^ 8)) == 0xf) {
@@ -657,7 +657,7 @@ template<class T> void TIA::draw_object_visible(T &object, const uint8_t collisi
 	}
 }
 
-#pragma mark - Missile drawing
+// MARK: - Missile drawing
 
 void TIA::draw_missile(Missile &missile, Player &player, const uint8_t collision_identity, int start, int end) {
 	if(!missile.locked_to_player || player.latched_pixel4_time < 0) {

--- a/Machines/Commodore/1540/Implementation/C1540.cpp
+++ b/Machines/Commodore/1540/Implementation/C1540.cpp
@@ -108,14 +108,14 @@ void Machine::run_for(const Cycles cycles) {
 		Storage::Disk::Controller::run_for(cycles);
 }
 
-#pragma mark - 6522 delegate
+// MARK: - 6522 delegate
 
 void MachineBase::mos6522_did_change_interrupt_status(void *mos6522) {
 	// both VIAs are connected to the IRQ line
 	m6502_.set_irq_line(serial_port_VIA_.get_interrupt_line() || drive_VIA_.get_interrupt_line());
 }
 
-#pragma mark - Disk drive
+// MARK: - Disk drive
 
 void MachineBase::process_input_bit(int value) {
 	shift_register_ = (shift_register_ << 1) | value;
@@ -149,7 +149,7 @@ void MachineBase::drive_via_did_set_data_density(void *driveVIA, int density) {
 	set_expected_bit_length(Storage::Encodings::CommodoreGCR::length_of_a_bit_in_time_zone(static_cast<unsigned int>(density)));
 }
 
-#pragma mark - SerialPortVIA
+// MARK: - SerialPortVIA
 
 SerialPortVIA::SerialPortVIA(MOS::MOS6522::MOS6522<SerialPortVIA> &via) : via_(via) {}
 
@@ -200,7 +200,7 @@ void SerialPortVIA::update_data_line() {
 	}
 }
 
-#pragma mark - DriveVIA
+// MARK: - DriveVIA
 
 void DriveVIA::set_delegate(Delegate *delegate) {
 	delegate_ = delegate;
@@ -261,7 +261,7 @@ void DriveVIA::set_port_output(MOS::MOS6522::Port port, uint8_t value, uint8_t d
 	}
 }
 
-#pragma mark - SerialPort
+// MARK: - SerialPort
 
 void SerialPort::set_input(::Commodore::Serial::Line line, ::Commodore::Serial::LineLevel level) {
 	std::shared_ptr<SerialPortVIA> serialPortVIA = serial_port_VIA_.lock();

--- a/Machines/Commodore/SerialBus.cpp
+++ b/Machines/Commodore/SerialBus.cpp
@@ -63,7 +63,7 @@ void Bus::set_line_output_did_change(Line line) {
 	}
 }
 
-#pragma mark - The debug port
+// MARK: - The debug port
 
 void DebugPort::set_input(Line line, LineLevel value) {
 	input_levels_[line] = value;

--- a/Machines/Electron/Video.cpp
+++ b/Machines/Electron/Video.cpp
@@ -43,7 +43,7 @@ namespace {
 	};
 }
 
-#pragma mark - Lifecycle
+// MARK: - Lifecycle
 
 VideoOutput::VideoOutput(uint8_t *memory) : ram_(memory) {
 	memset(palette_, 0xf, sizeof(palette_));
@@ -64,13 +64,13 @@ VideoOutput::VideoOutput(uint8_t *memory) : ram_(memory) {
 	crt_->set_visible_area(crt_->get_rect_for_area(first_graphics_line - 3, 256, (first_graphics_cycle+1) * crt_cycles_multiplier, 80 * crt_cycles_multiplier, 4.0f / 3.0f));
 }
 
-#pragma mark - CRT getter
+// MARK: - CRT getter
 
 std::shared_ptr<Outputs::CRT::CRT> VideoOutput::get_crt() {
 	return crt_;
 }
 
-#pragma mark - Display update methods
+// MARK: - Display update methods
 
 void VideoOutput::start_pixel_line() {
 	current_pixel_line_ = (current_pixel_line_+1)&255;
@@ -252,7 +252,7 @@ void VideoOutput::run_for(const Cycles cycles) {
 	}
 }
 
-#pragma mark - Register hub
+// MARK: - Register hub
 
 void VideoOutput::set_register(int address, uint8_t value) {
 	switch(address & 0xf) {
@@ -338,7 +338,7 @@ void VideoOutput::setup_base_address() {
 	}
 }
 
-#pragma mark - Interrupts
+// MARK: - Interrupts
 
 VideoOutput::Interrupt VideoOutput::get_next_interrupt() {
 	VideoOutput::Interrupt interrupt;
@@ -372,7 +372,7 @@ VideoOutput::Interrupt VideoOutput::get_next_interrupt() {
 	return interrupt;
 }
 
-#pragma mark - RAM timing and access information
+// MARK: - RAM timing and access information
 
 unsigned int VideoOutput::get_cycles_until_next_ram_availability(int from_time) {
 	unsigned int result = 0;
@@ -407,7 +407,7 @@ VideoOutput::Range VideoOutput::get_memory_access_range() {
 	return range;
 }
 
-#pragma mark - The screen map
+// MARK: - The screen map
 
 void VideoOutput::setup_screen_map() {
 	/*

--- a/Machines/Utility/Typer.cpp
+++ b/Machines/Utility/Typer.cpp
@@ -80,7 +80,7 @@ Typer::~Typer() {
 	std::free(string_);
 }
 
-#pragma mark - Character mapper
+// MARK: - Character mapper
 
 uint16_t *CharacterMapper::table_lookup_sequence_for_character(KeySequence *sequences, std::size_t length, char character) {
 	std::size_t ucharacter = static_cast<std::size_t>((unsigned char)character);

--- a/Machines/ZX8081/ZX8081.cpp
+++ b/Machines/ZX8081/ZX8081.cpp
@@ -308,7 +308,7 @@ template<bool is_zx81> class ConcreteMachine:
 			return true;
 		}
 
-#pragma mark - Keyboard
+// MARK: - Keyboard
 
 		void set_key_state(uint16_t key, bool isPressed) override final {
 			if(isPressed)
@@ -321,7 +321,7 @@ template<bool is_zx81> class ConcreteMachine:
 			memset(key_states_, 0xff, 8);
 		}
 
-#pragma mark - Tape control
+// MARK: - Tape control
 
 		void set_use_fast_tape_hack(bool activate) override final {
 			use_fast_tape_hack_ = activate;
@@ -337,7 +337,7 @@ template<bool is_zx81> class ConcreteMachine:
 			tape_player_.set_motor_control(is_playing);
 		}
 
-#pragma mark - Typer timing
+// MARK: - Typer timing
 
 		HalfCycles get_typer_delay() override final { return Cycles(7000000); }
 		HalfCycles get_typer_frequency() override final { return Cycles(390000); }
@@ -383,7 +383,7 @@ template<bool is_zx81> class ConcreteMachine:
 		bool use_automatic_tape_motor_control_;
 		HalfCycles tape_advance_delay_ = 0;
 
-#pragma mark - Video
+// MARK: - Video
 
 		inline void set_vsync(bool sync) {
 			vsync_ = sync;

--- a/Outputs/CRT/CRT.cpp
+++ b/Outputs/CRT/CRT.cpp
@@ -110,7 +110,7 @@ CRT::CRT(unsigned int cycles_per_line, unsigned int common_output_divisor, Displ
 	set_new_display_type(cycles_per_line, displayType);
 }
 
-#pragma mark - Sync loop
+// MARK: - Sync loop
 
 Flywheel::SyncEvent CRT::get_next_vertical_sync_event(bool vsync_is_requested, unsigned int cycles_to_run_for, unsigned int *cycles_advanced) {
 	return vertical_flywheel_->get_next_event_in_period(vsync_is_requested, cycles_to_run_for, cycles_advanced);
@@ -272,7 +272,7 @@ void CRT::advance_cycles(unsigned int number_of_cycles, bool hsync_requested, bo
 #undef source_amplitude
 #undef source_phase_time
 
-#pragma mark - stream feeding methods
+// MARK: - stream feeding methods
 
 void CRT::output_scan(const Scan *const scan) {
 	// simplified colour burst logic: if it's within the back porch we'll take it

--- a/Outputs/CRT/Internals/CRTOpenGL.cpp
+++ b/Outputs/CRT/Internals/CRTOpenGL.cpp
@@ -258,7 +258,7 @@ void OpenGLOutputBuilder::set_rgb_sampling_function(const std::string &shader) {
 	reset_all_OpenGL_state();
 }
 
-#pragma mark - Program compilation
+// MARK: - Program compilation
 
 void OpenGLOutputBuilder::prepare_composite_input_shaders() {
 	composite_input_shader_program_ = OpenGL::IntermediateShader::make_source_conversion_shader(composite_shader_, rgb_shader_);
@@ -324,7 +324,7 @@ void OpenGLOutputBuilder::prepare_output_vertex_array() {
 	}
 }
 
-#pragma mark - Public Configuration
+// MARK: - Public Configuration
 
 void OpenGLOutputBuilder::set_output_device(OutputDevice output_device) {
 	if(output_device_ != output_device) {
@@ -348,7 +348,7 @@ void OpenGLOutputBuilder::set_timing(unsigned int input_frequency, unsigned int 
 	set_timing_uniforms();
 }
 
-#pragma mark - Internal Configuration
+// MARK: - Internal Configuration
 
 void OpenGLOutputBuilder::set_colour_space_uniforms() {
 	GLfloat rgbToYUV[] = {0.299f, -0.14713f, 0.615f, 0.587f, -0.28886f, -0.51499f, 0.114f, 0.436f, -0.10001f};

--- a/Processors/6502/Implementation/6502Implementation.hpp
+++ b/Processors/6502/Implementation/6502Implementation.hpp
@@ -84,7 +84,7 @@ if(number_of_cycles <= Cycles(0)) break;
 
 				switch(cycle) {
 
-#pragma mark - Fetch/Decode
+// MARK: - Fetch/Decode
 
 					case CycleFetchOperation: {
 						last_operation_pc_ = pc_;
@@ -156,20 +156,20 @@ if(number_of_cycles <= Cycles(0)) break;
 						throwaway_read(oldPC);
 					} break;
 
-#pragma mark - JAM
+// MARK: - JAM
 
 					case CycleScheduleJam: {
 						is_jammed_ = true;
 						scheduled_program_counter_ = operations[CPU::MOS6502::JamOpcode];
 					} continue;
 
-#pragma mark - Bitwise
+// MARK: - Bitwise
 
 					case OperationORA:	a_ |= operand_;	negative_result_ = zero_result_ = a_;		continue;
 					case OperationAND:	a_ &= operand_;	negative_result_ = zero_result_ = a_;		continue;
 					case OperationEOR:	a_ ^= operand_;	negative_result_ = zero_result_ = a_;		continue;
 
-#pragma mark - Load and Store
+// MARK: - Load and Store
 
 					case OperationLDA:	a_ = negative_result_ = zero_result_ = operand_;			continue;
 					case OperationLDX:	x_ = negative_result_ = zero_result_ = operand_;			continue;
@@ -190,7 +190,7 @@ if(number_of_cycles <= Cycles(0)) break;
 						negative_result_ = zero_result_ = a_;
 					continue;
 
-#pragma mark - Compare
+// MARK: - Compare
 
 					case OperationCMP: {
 						const uint16_t temp16 = a_ - operand_;
@@ -208,7 +208,7 @@ if(number_of_cycles <= Cycles(0)) break;
 						carry_flag_ = ((~temp16) >> 8)&1;
 					} continue;
 
-#pragma mark - BIT
+// MARK: - BIT
 
 					case OperationBIT:
 						zero_result_ = operand_ & a_;
@@ -216,7 +216,7 @@ if(number_of_cycles <= Cycles(0)) break;
 						overflow_flag_ = operand_&Flag::Overflow;
 					continue;
 
-#pragma mark ADC/SBC (and INS)
+// MARK: - ADC/SBC (and INS)
 
 					case OperationINS:
 						operand_++;			// deliberate fallthrough
@@ -270,7 +270,7 @@ if(number_of_cycles <= Cycles(0)) break;
 						if(cycle == OperationINS) operand_ = ~operand_;
 					continue;
 
-#pragma mark - Shifts and Rolls
+// MARK: - Shifts and Rolls
 
 					case OperationASL:
 						carry_flag_ = operand_ >> 7;
@@ -366,7 +366,7 @@ if(number_of_cycles <= Cycles(0)) break;
 						negative_result_ = zero_result_ = a_;
 					continue;
 
-#pragma mark - Addressing Mode Work
+// MARK: - Addressing Mode Work
 
 					case CycleAddXToAddressLow:
 						nextAddress.full = address_.full + x_;
@@ -452,7 +452,7 @@ if(number_of_cycles <= Cycles(0)) break;
 					case OperationCopyOperandFromA:		operand_ = a_;					continue;
 					case OperationCopyOperandToA:		a_ = operand_;					continue;
 
-#pragma mark - Branching
+// MARK: - Branching
 
 #define BRA(condition)	pc_.full++; if(condition) scheduled_program_counter_ = doBranch
 
@@ -478,7 +478,7 @@ if(number_of_cycles <= Cycles(0)) break;
 
 #undef BRA
 
-#pragma mark - Transfers
+// MARK: - Transfers
 
 					case OperationTXA: zero_result_ = negative_result_ = a_ = x_;	continue;
 					case OperationTYA: zero_result_ = negative_result_ = a_ = y_;	continue;

--- a/Processors/Z80/Implementation/Z80Implementation.hpp
+++ b/Processors/Z80/Implementation/Z80Implementation.hpp
@@ -112,7 +112,7 @@ template <	class T,
 					set_flags(temp16_.bytes.low);
 				break;
 
-#pragma mark - Logical
+// MARK: - Logical
 
 #define set_logical_flags(hf)	\
 	sign_result_ = zero_result_ = bit53_result_ = a_;	\
@@ -159,7 +159,7 @@ template <	class T,
 					bit53_result_ = a_;
 				break;
 
-#pragma mark - Flow control
+// MARK: - Flow control
 
 				case MicroOp::DJNZ:
 					bc_.bytes.high--;
@@ -172,7 +172,7 @@ template <	class T,
 					memptr_.full = operation_ & 0x38;
 				break;
 
-#pragma mark - 8-bit arithmetic
+// MARK: - 8-bit arithmetic
 
 #define set_arithmetic_flags(sub, b53)	\
 	sign_result_ = zero_result_ = static_cast<uint8_t>(result);	\
@@ -353,7 +353,7 @@ template <	class T,
 					set_parity(a_);
 				} break;
 
-#pragma mark - 16-bit arithmetic
+// MARK: - 16-bit arithmetic
 
 				case MicroOp::ADD16: {
 					memptr_.full = *static_cast<uint16_t *>(operation->destination);
@@ -416,7 +416,7 @@ template <	class T,
 					memptr_.full++;
 				} break;
 
-#pragma mark - Conditionals
+// MARK: - Conditionals
 
 #define decline_conditional()	\
 	if(operation->source) {		\
@@ -436,7 +436,7 @@ template <	class T,
 
 #undef decline_conditional
 
-#pragma mark - Exchange
+// MARK: - Exchange
 
 #define swap(a, b)	temp = a.full; a.full = b.full; b.full = temp;
 
@@ -463,7 +463,7 @@ template <	class T,
 
 #undef swap
 
-#pragma mark - Repetition
+// MARK: - Repetition
 
 #define REPEAT(test)	\
 	if(test) {	\
@@ -616,7 +616,7 @@ template <	class T,
 
 #undef OUTxR_STEP
 
-#pragma mark - Bit Manipulation
+// MARK: - Bit Manipulation
 
 				case MicroOp::BIT: {
 					uint8_t result = *static_cast<uint8_t *>(operation->source) & (1 << ((operation_ >> 3)&7));
@@ -641,7 +641,7 @@ template <	class T,
 					*static_cast<uint8_t *>(operation->source) |= (1 << ((operation_ >> 3)&7));
 				break;
 
-#pragma mark - Rotation and shifting
+// MARK: - Rotation and shifting
 
 #define set_rotate_flags()	\
 	bit53_result_ = a_;	\
@@ -757,7 +757,7 @@ template <	class T,
 #undef set_decimal_rotate_flags
 
 
-#pragma mark - Interrupt state
+// MARK: - Interrupt state
 
 				case MicroOp::EI:
 					iff1_ = iff2_ = true;
@@ -778,7 +778,7 @@ template <	class T,
 					}
 				break;
 
-#pragma mark - Input
+// MARK: - Input
 
 				case MicroOp::SetInFlags:
 					subtract_flag_ = half_carry_result_ = 0;
@@ -796,7 +796,7 @@ template <	class T,
 					temp8_ = 0;
 				break;
 
-#pragma mark - Special-case Flow
+// MARK: - Special-case Flow
 
 				case MicroOp::BeginIRQMode0:
 					pc_increment_ = 0;			// deliberate fallthrough
@@ -825,7 +825,7 @@ template <	class T,
 					halt_mask_ = 0x00;
 				break;
 
-#pragma mark - Interrupt handling
+// MARK: - Interrupt handling
 
 				case MicroOp::Reset:
 					iff1_ = iff2_ = false;
@@ -837,7 +837,7 @@ template <	class T,
 					ir_.full = 0;
 				break;
 
-#pragma mark - Internal bookkeeping
+// MARK: - Internal bookkeeping
 
 				case MicroOp::SetInstructionPage:
 					current_instruction_page_ = (InstructionPage *)operation->source;

--- a/Storage/Data/ZX8081.cpp
+++ b/Storage/Data/ZX8081.cpp
@@ -94,7 +94,7 @@ std::shared_ptr<File> Storage::Data::ZX8081::FileFromData(const std::vector<uint
 	return ZX80FileFromData(data);
 }
 
-#pragma mark - String conversion
+// MARK: - String conversion
 
 std::wstring Storage::Data::ZX8081::StringFromData(const std::vector<uint8_t> &data, bool is_zx81) {
 	std::wstring string;

--- a/Storage/Disk/Controller/DiskController.cpp
+++ b/Storage/Disk/Controller/DiskController.cpp
@@ -38,7 +38,7 @@ Drive &Controller::get_drive() {
 	return *drive_.get();
 }
 
-#pragma mark - Drive::EventDelegate
+// MARK: - Drive::EventDelegate
 
 void Controller::process_event(const Track::Event &event) {
 	switch(event.type) {
@@ -55,7 +55,7 @@ void Controller::process_write_completed() {
 	// Provided for subclasses to override.
 }
 
-#pragma mark - PLL control and delegate
+// MARK: - PLL control and delegate
 
 void Controller::set_expected_bit_length(Time bit_length) {
 	bit_length_ = bit_length;

--- a/Storage/Disk/Drive.cpp
+++ b/Storage/Disk/Drive.cpp
@@ -140,7 +140,7 @@ void Drive::run_for(const Cycles cycles) {
 	}
 }
 
-#pragma mark - Track timed event loop
+// MARK: - Track timed event loop
 
 void Drive::get_next_event(const Time &duration_already_passed) {
 	// Grab a new track if not already in possession of one. This will recursively call get_next_event,
@@ -181,7 +181,7 @@ void Drive::process_next_event() {
 	get_next_event(Time(0));
 }
 
-#pragma mark - Track management
+// MARK: - Track management
 
 std::shared_ptr<Track> Drive::get_track() {
 	if(disk_) return disk_->get_track_at_position(Track::Address(head_, head_position_));
@@ -217,7 +217,7 @@ void Drive::invalidate_track() {
 	}
 }
 
-#pragma mark - Writing
+// MARK: - Writing
 
 void Drive::begin_writing(Time bit_length, bool clamp_to_index_hole) {
 	is_reading_ = false;

--- a/Storage/Tape/Formats/TZX.cpp
+++ b/Storage/Tape/Formats/TZX.cpp
@@ -267,7 +267,7 @@ void TZX::get_pause() {
 	}
 }
 
-#pragma mark - Output
+// MARK: - Output
 
 void TZX::post_pulse(unsigned int length) {
 	post_pulse(Storage::Time(length, StandardTZXClock));
@@ -288,7 +288,7 @@ void TZX::post_pulse(const Storage::Time &time) {
 	current_level_ ^= true;
 }
 
-#pragma mark - Flow control; currently ignored
+// MARK: - Flow control; currently ignored
 
 void TZX::ignore_group_start() {
 	printf("Ignoring TZX group\n");
@@ -330,7 +330,7 @@ void TZX::ignore_select_block() {
 	printf("Ignoring TZX select block\n");
 }
 
-#pragma mark - Messaging
+// MARK: - Messaging
 
 void TZX::ignore_text_description() {
 	uint8_t length = file_.get8();

--- a/Storage/Tape/Formats/TapeUEF.cpp
+++ b/Storage/Tape/Formats/TapeUEF.cpp
@@ -12,7 +12,7 @@
 #include <cstdlib>
 #include <cmath>
 
-#pragma mark - ZLib extensions
+// MARK: - ZLib extensions
 
 static float gzgetfloat(gzFile file) {
 	uint8_t bytes[4];
@@ -91,7 +91,7 @@ UEF::~UEF() {
 	gzclose(file_);
 }
 
-#pragma mark - Public methods
+// MARK: - Public methods
 
 void UEF::virtual_reset() {
 	gzseek(file_, 12, SEEK_SET);
@@ -99,7 +99,7 @@ void UEF::virtual_reset() {
 	clear();
 }
 
-#pragma mark - Chunk navigator
+// MARK: - Chunk navigator
 
 bool UEF::get_next_chunk(UEF::Chunk &result) {
 	uint16_t chunk_id = static_cast<uint16_t>(gzget16(file_));
@@ -161,7 +161,7 @@ void UEF::get_next_pulses() {
 	}
 }
 
-#pragma mark - Chunk parsers
+// MARK: - Chunk parsers
 
 void UEF::queue_implicit_bit_pattern(uint32_t length) {
 	while(length--) {
@@ -277,7 +277,7 @@ void UEF::queue_defined_data(uint32_t length) {
 	}
 }
 
-#pragma mark - Queuing helpers
+// MARK: - Queuing helpers
 
 void UEF::queue_implicit_byte(uint8_t byte) {
 	queue_bit(0);
@@ -312,7 +312,7 @@ void UEF::queue_bit(int bit) {
 	}
 }
 
-#pragma mark - TypeDistinguisher
+// MARK: - TypeDistinguisher
 
 TargetPlatform::Type UEF::target_platform_type() {
 	return platform_type_;

--- a/Storage/Tape/Tape.cpp
+++ b/Storage/Tape/Tape.cpp
@@ -11,13 +11,13 @@
 
 using namespace Storage::Tape;
 
-#pragma mark - Lifecycle
+// MARK: - Lifecycle
 
 TapePlayer::TapePlayer(unsigned int input_clock_rate) :
 	TimedEventLoop(input_clock_rate)
 {}
 
-#pragma mark - Seeking
+// MARK: - Seeking
 
 void Storage::Tape::Tape::seek(Time &seek_time) {
 	Time next_time(0);
@@ -63,7 +63,7 @@ void Tape::set_offset(uint64_t offset) {
 	while(offset--) get_next_pulse();
 }
 
-#pragma mark - Player
+// MARK: - Player
 
 bool TapePlayer::is_sleeping() {
 	return !tape_ || tape_->is_at_end();
@@ -114,7 +114,7 @@ void TapePlayer::process_next_event() {
 	get_next_pulse();
 }
 
-#pragma mark - Binary Player
+// MARK: - Binary Player
 
 BinaryTapePlayer::BinaryTapePlayer(unsigned int input_clock_rate) :
 	TapePlayer(input_clock_rate)


### PR DESCRIPTION
For the benefit of cross-platform compatibility.