### PR TITLE
Initialize all `const` members.

### DIFF
--- a/Outputs/CRT/Internals/CRTOpenGL.cpp
+++ b/Outputs/CRT/Internals/CRTOpenGL.cpp
@@ -150,14 +150,14 @@ void OpenGLOutputBuilder::draw_frame(unsigned int output_width, unsigned int out
 		{composite_input_shader_program_.get(),					composite_texture_.get(),		{0.0, 0.0, 0.0}},
 		{composite_separation_filter_program_.get(),			separated_texture_.get(),		{0.0, 0.5, 0.5}},
 		{composite_chrominance_filter_shader_program_.get(),	filtered_texture_.get(),		{0.0, 0.0, 0.0}},
-		{nullptr}
+		{nullptr, nullptr}
 	};
 
 	// for RGB video, there's only two steps
 	RenderStage rgb_render_stages[] = {
 		{rgb_input_shader_program_.get(),	composite_texture_.get(),	{0.0, 0.0, 0.0}},
 		{rgb_filter_shader_program_.get(),	filtered_texture_.get(),	{0.0, 0.0, 0.0}},
-		{nullptr}
+		{nullptr, nullptr}
 	};
 
 	RenderStage *active_pipeline = get_is_television_output() ? composite_render_stages : rgb_render_stages;

--- a/Outputs/CRT/Internals/Shaders/IntermediateShader.cpp
+++ b/Outputs/CRT/Internals/Shaders/IntermediateShader.cpp
@@ -21,7 +21,7 @@ namespace {
 		{"outputStart", 1},
 		{"ends", 2},
 		{"phaseTimeAndAmplitude", 3},
-		{nullptr}
+		{nullptr, 0}
 	};
 }
 

--- a/Outputs/CRT/Internals/Shaders/OutputShader.cpp
+++ b/Outputs/CRT/Internals/Shaders/OutputShader.cpp
@@ -17,7 +17,7 @@ namespace {
 	const OpenGL::Shader::AttributeBinding bindings[] = {
 		{"position", 0},
 		{"srcCoordinates", 1},
-		{nullptr}
+		{nullptr, 0}
 	};
 }
 


### PR DESCRIPTION
Without this change, GCC versions >4.8 will error with things like:

```
./CLK/Outputs/CRT/Internals/CRTOpenGL.cpp:154:2:error: uninitialized const member
'Outputs::CRT::OpenGLOutputBuilder::draw_frame(unsigned int, unsigned int, bool)::RenderStage::target'
```