### PR TITLE
Allows 8kb and not-quite-multiple-of-8kb MSX ROMs

### DIFF
--- a/OSBindings/Mac/Clock Signal/AppDelegate.swift
+++ b/OSBindings/Mac/Clock Signal/AppDelegate.swift
@@ -24,4 +24,3 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 		return false
 	}
 }
-

--- a/OSBindings/Mac/Clock Signal/Info.plist
+++ b/OSBindings/Mac/Clock Signal/Info.plist
@@ -16,12 +16,12 @@
 			<string>cartridge</string>
 			<key>CFBundleTypeName</key>
 			<string>Atari 2600 Cartridge</string>
-			<key>CFBundleTypeOSTypes</key>
-			<array>
-				<string>????</string>
-			</array>
 			<key>CFBundleTypeRole</key>
 			<string>Viewer</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.item</string>
+			</array>
 			<key>LSTypeIsPackage</key>
 			<integer>0</integer>
 			<key>NSDocumentClass</key>
@@ -40,8 +40,7 @@
 			<string>Viewer</string>
 			<key>LSItemContentTypes</key>
 			<array>
-				<string>org.akop.cocoamsx.filetype.cartridge</string>
-				<string>com.clocksignal.rom</string>
+				<string>public.item</string>
 			</array>
 			<key>LSTypeIsPackage</key>
 			<integer>0</integer>
@@ -60,6 +59,10 @@
 			<string>Electron/BBC UEF Image</string>
 			<key>CFBundleTypeRole</key>
 			<string>Viewer</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.item</string>
+			</array>
 			<key>LSTypeIsPackage</key>
 			<integer>0</integer>
 			<key>NSDocumentClass</key>
@@ -76,6 +79,10 @@
 			<string>Commodore Program</string>
 			<key>CFBundleTypeRole</key>
 			<string>Viewer</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.item</string>
+			</array>
 			<key>LSTypeIsPackage</key>
 			<integer>0</integer>
 			<key>NSDocumentClass</key>
@@ -92,6 +99,10 @@
 			<string>Tape Image</string>
 			<key>CFBundleTypeRole</key>
 			<string>Viewer</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.item</string>
+			</array>
 			<key>LSTypeIsPackage</key>
 			<integer>0</integer>
 			<key>NSDocumentClass</key>
@@ -108,6 +119,10 @@
 			<string>Commodore Disk</string>
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.item</string>
+			</array>
 			<key>LSTypeIsPackage</key>
 			<integer>0</integer>
 			<key>NSDocumentClass</key>
@@ -124,6 +139,10 @@
 			<string>Commodore 1540/1 Disk</string>
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.item</string>
+			</array>
 			<key>LSTypeIsPackage</key>
 			<integer>0</integer>
 			<key>NSDocumentClass</key>
@@ -144,6 +163,10 @@
 			<string>Electron/BBC Disk Image</string>
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.item</string>
+			</array>
 			<key>LSTypeIsPackage</key>
 			<integer>0</integer>
 			<key>NSDocumentClass</key>
@@ -160,6 +183,10 @@
 			<string>Disk Image</string>
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.item</string>
+			</array>
 			<key>LSTypeIsPackage</key>
 			<integer>0</integer>
 			<key>NSDocumentClass</key>
@@ -177,6 +204,10 @@
 			<string>ZX80 Tape Image</string>
 			<key>CFBundleTypeRole</key>
 			<string>Viewer</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.item</string>
+			</array>
 			<key>LSTypeIsPackage</key>
 			<integer>0</integer>
 			<key>NSDocumentClass</key>
@@ -195,6 +226,10 @@
 			<string>ZX81 Tape Image</string>
 			<key>CFBundleTypeRole</key>
 			<string>Viewer</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.item</string>
+			</array>
 			<key>LSTypeIsPackage</key>
 			<integer>0</integer>
 			<key>NSDocumentClass</key>
@@ -211,6 +246,10 @@
 			<string>Tape Image</string>
 			<key>CFBundleTypeRole</key>
 			<string>Viewer</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.item</string>
+			</array>
 			<key>LSTypeIsPackage</key>
 			<integer>0</integer>
 			<key>NSDocumentClass</key>
@@ -227,6 +266,10 @@
 			<string>Tape Image</string>
 			<key>CFBundleTypeRole</key>
 			<string>Viewer</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.item</string>
+			</array>
 			<key>LSTypeIsPackage</key>
 			<integer>0</integer>
 			<key>NSDocumentClass</key>
@@ -243,6 +286,10 @@
 			<string>Amstrad CPC Tape Image</string>
 			<key>CFBundleTypeRole</key>
 			<string>Viewer</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.item</string>
+			</array>
 			<key>LSTypeIsPackage</key>
 			<integer>0</integer>
 			<key>NSDocumentClass</key>
@@ -259,6 +306,10 @@
 			<string>HxC Disk Image</string>
 			<key>CFBundleTypeRole</key>
 			<string>Viewer</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.item</string>
+			</array>
 			<key>LSTypeIsPackage</key>
 			<integer>0</integer>
 			<key>NSDocumentClass</key>
@@ -277,8 +328,7 @@
 			<string>Viewer</string>
 			<key>LSItemContentTypes</key>
 			<array>
-				<string>org.akop.cocoamsx.filetype.cassette</string>
-				<string>com.clocksignal.cas</string>
+				<string>public.item</string>
 			</array>
 			<key>LSTypeIsPackage</key>
 			<integer>0</integer>
@@ -296,6 +346,10 @@
 			<string>Disk Image</string>
 			<key>CFBundleTypeRole</key>
 			<string>Viewer</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.item</string>
+			</array>
 			<key>LSTypeIsPackage</key>
 			<integer>0</integer>
 		</dict>
@@ -310,6 +364,10 @@
 			<string>MSX Tape Image</string>
 			<key>CFBundleTypeRole</key>
 			<string>Viewer</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.item</string>
+			</array>
 			<key>LSTypeIsPackage</key>
 			<integer>0</integer>
 			<key>NSDocumentClass</key>

--- a/StaticAnalyser/Acorn/StaticAnalyser.cpp
+++ b/StaticAnalyser/Acorn/StaticAnalyser.cpp
@@ -24,7 +24,7 @@ static std::list<std::shared_ptr<Storage::Cartridge::Cartridge>>
 		if(segments.size() != 1) continue;
 
 		// which must be 8 or 16 kb in size
-		Storage::Cartridge::Cartridge::Segment segment = segments.front();
+		const Storage::Cartridge::Cartridge::Segment &segment = segments.front();
 		if(segment.data.size() != 0x4000 && segment.data.size() != 0x2000) continue;
 
 		// is a copyright string present?

--- a/StaticAnalyser/MSX/StaticAnalyser.cpp
+++ b/StaticAnalyser/MSX/StaticAnalyser.cpp
@@ -188,7 +188,7 @@ static std::list<std::shared_ptr<Storage::Cartridge::Cartridge>>
 		std::vector<Storage::Cartridge::Cartridge::Segment> output_segments;
 		if(segment.data.size() & 0x1fff) {
 			std::vector<uint8_t> truncated_data;
-			std::vector<uint8_t>::difference_type truncated_size = static_cast<std::vector<uint8_t>::difference_type>(segment.data.size() & ~0x1fff);
+			std::vector<uint8_t>::difference_type truncated_size = static_cast<std::vector<uint8_t>::difference_type>(segment.data.size()) & ~0x1fff;
 			truncated_data.insert(truncated_data.begin(), segment.data.begin(), segment.data.begin() + truncated_size);
 			output_segments.emplace_back(start_address, truncated_data);
 		} else {

--- a/StaticAnalyser/MSX/StaticAnalyser.cpp
+++ b/StaticAnalyser/MSX/StaticAnalyser.cpp
@@ -34,10 +34,10 @@ static std::list<std::shared_ptr<Storage::Cartridge::Cartridge>>
 		// Only one mapped item is allowed.
 		if(segments.size() != 1) continue;
 
-		// Which must be a multiple of 16 kb in size.
+		// Which must be no more than 63 bytes larger than a multiple of 8 kb in size.
 		Storage::Cartridge::Cartridge::Segment segment = segments.front();
 		const size_t data_size = segment.data.size();
-		if(data_size < 0x2000 || data_size & 0x3fff) continue;
+		if(data_size < 0x2000 || (data_size & 0x1fff) > 64) continue;
 
 		// Check for a ROM header at address 0; if it's not found then try 0x4000
 		// and adjust the start address;
@@ -184,10 +184,17 @@ static std::list<std::shared_ptr<Storage::Cartridge::Cartridge>>
 			}
 		}
 
-		// Apply the standard MSX start address.
-		msx_cartridges.emplace_back(new Storage::Cartridge::Cartridge({
-			Storage::Cartridge::Cartridge::Segment(start_address, segment.data)
-		}));
+		// Size down to a multiple of 8kb in size and apply the start address.
+		std::vector<Storage::Cartridge::Cartridge::Segment> output_segments;
+		if(segment.data.size() & 0x1fff) {
+			std::vector<uint8_t> truncated_data;
+			std::vector<uint8_t>::difference_type truncated_size = static_cast<std::vector<uint8_t>::difference_type>(segment.data.size() & ~0x1fff);
+			truncated_data.insert(truncated_data.begin(), segment.data.begin(), segment.data.begin() + truncated_size);
+			output_segments.emplace_back(start_address, truncated_data);
+		} else {
+			output_segments.emplace_back(start_address, segment.data);
+		}
+		msx_cartridges.emplace_back(new Storage::Cartridge::Cartridge(output_segments));
 	}
 
 	return msx_cartridges;

--- a/Storage/Cartridge/Cartridge.hpp
+++ b/Storage/Cartridge/Cartridge.hpp
@@ -28,11 +28,27 @@ namespace Cartridge {
 class Cartridge {
 	public:
 		struct Segment {
-			Segment(size_t start_address, size_t end_address, std::vector<uint8_t> data) :
-				start_address(start_address), end_address(end_address), data(std::move(data)) {}
+			Segment(size_t start_address, size_t end_address, std::vector<uint8_t> &&data) :
+				start_address(start_address), end_address(end_address), data(data) {}
 
-			Segment(size_t start_address, std::vector<uint8_t> data) :
+			Segment(size_t start_address, size_t end_address, const std::vector<uint8_t> &data) :
+				start_address(start_address), end_address(end_address), data(data) {}
+
+			Segment(size_t start_address, std::vector<uint8_t> &&data) :
 				Segment(start_address, start_address + data.size(), data) {}
+
+			Segment(size_t start_address, const std::vector<uint8_t> &data) :
+				Segment(start_address, start_address + data.size(), data) {}
+
+			Segment(Segment &&segment) :
+				start_address(segment.start_address),
+				end_address(segment.end_address),
+				data(std::move(segment.data)) {}
+
+			Segment(const Segment &segment) :
+				start_address(segment.start_address),
+				end_address(segment.end_address),
+				data(segment.data) {}
 
 			/// Indicates that an address is unknown.
 			static const size_t UnknownAddress;


### PR DESCRIPTION
Also corrects UTI declarations so that File->Open..., etc, work for files named .rom on the Mac (hopefully) regardless of any other applications you might have installed that accept things called .rom.