### PR TITLE
Makes an attempt at implementing all missing TZX 1.20 blocks.

### DIFF
--- a/Storage/Tape/Formats/CSW.cpp
+++ b/Storage/Tape/Formats/CSW.cpp
@@ -13,21 +13,21 @@
 using namespace Storage::Tape;
 
 CSW::CSW(const char *file_name) :
-	file_(file_name),
 	source_data_pointer_(0) {
-	if(file_.stats().st_size < 0x20) throw ErrorNotCSW;
+	Storage::FileHolder file(file_name);
+	if(file.stats().st_size < 0x20) throw ErrorNotCSW;
 
 	// Check signature.
-	if(!file_.check_signature("Compressed Square Wave")) {
+	if(!file.check_signature("Compressed Square Wave")) {
 		throw ErrorNotCSW;
 	}
 
 	// Check terminating byte.
-	if(file_.get8() != 0x1a) throw ErrorNotCSW;
+	if(file.get8() != 0x1a) throw ErrorNotCSW;
 
 	// Get version file number.
-	uint8_t major_version = file_.get8();
-	uint8_t minor_version = file_.get8();
+	uint8_t major_version = file.get8();
+	uint8_t minor_version = file.get8();
 
 	// Reject if this is an unknown version.
 	if(major_version > 2 || !major_version || minor_version > 1) throw ErrorNotCSW;
@@ -35,40 +35,41 @@ CSW::CSW(const char *file_name) :
 	// The header now diverges based on version.
 	uint32_t number_of_waves = 0;
 	if(major_version == 1) {
-		pulse_.length.clock_rate = file_.get16le();
+		pulse_.length.clock_rate = file.get16le();
 
-		if(file_.get8() != 1) throw ErrorNotCSW;
+		if(file.get8() != 1) throw ErrorNotCSW;
 		compression_type_ = CompressionType::RLE;
 
-		pulse_.type = (file_.get8() & 1) ? Pulse::High : Pulse::Low;
+		pulse_.type = (file.get8() & 1) ? Pulse::High : Pulse::Low;
 
-		file_.seek(0x20, SEEK_SET);
+		file.seek(0x20, SEEK_SET);
 	} else {
-		pulse_.length.clock_rate = file_.get32le();
-		number_of_waves = file_.get32le();
-		switch(file_.get8()) {
+		pulse_.length.clock_rate = file.get32le();
+		number_of_waves = file.get32le();
+		switch(file.get8()) {
 			case 1: compression_type_ = CompressionType::RLE;	break;
 			case 2: compression_type_ = CompressionType::ZRLE;	break;
 			default: throw ErrorNotCSW;
 		}
 
-		pulse_.type = (file_.get8() & 1) ? Pulse::High : Pulse::Low;
-		uint8_t extension_length = file_.get8();
+		pulse_.type = (file.get8() & 1) ? Pulse::High : Pulse::Low;
+		uint8_t extension_length = file.get8();
 
-		if(file_.stats().st_size < 0x34 + extension_length) throw ErrorNotCSW;
-		file_.seek(0x34 + extension_length, SEEK_SET);
+		if(file.stats().st_size < 0x34 + extension_length) throw ErrorNotCSW;
+		file.seek(0x34 + extension_length, SEEK_SET);
 	}
+
+	// Grab all data remaining in the file.
+	std::vector<uint8_t> file_data;
+	std::size_t remaining_data = static_cast<std::size_t>(file.stats().st_size) - static_cast<std::size_t>(file.tell());
+	file_data.resize(remaining_data);
+	file.read(file_data.data(), remaining_data);
 
 	if(compression_type_ == CompressionType::ZRLE) {
 		// The only clue given by CSW as to the output size in bytes is that there will be
 		// number_of_waves waves. Waves are usually one byte, but may be five. So this code
 		// is pessimistic.
 		source_data_.resize(static_cast<std::size_t>(number_of_waves) * 5);
-
-		std::vector<uint8_t> file_data;
-		std::size_t remaining_data = static_cast<std::size_t>(file_.stats().st_size) - static_cast<std::size_t>(file_.tell());
-		file_data.resize(remaining_data);
-		file_.read(file_data.data(), remaining_data);
 
 		// uncompress will tell how many compressed bytes there actually were, so use its
 		// modification of output_length to throw away all the memory that isn't actually
@@ -77,42 +78,34 @@ CSW::CSW(const char *file_name) :
 		uncompress(source_data_.data(), &output_length, file_data.data(), file_data.size());
 		source_data_.resize(static_cast<std::size_t>(output_length));
 	} else {
-		rle_start_ = file_.tell();
+		source_data_ = std::move(file_data);
 	}
 
 	invert_pulse();
 }
 
-uint8_t CSW::get_next_byte() {
-	switch(compression_type_) {
-		case CompressionType::RLE: return file_.get8();
-		case CompressionType::ZRLE: {
-			if(source_data_pointer_ == source_data_.size()) return 0xff;
-			uint8_t result = source_data_[source_data_pointer_];
-			source_data_pointer_++;
-			return result;
-		}
+CSW::CSW(const std::vector<uint8_t> &&data, CompressionType compression_type, bool initial_level, uint32_t sampling_rate) {
+	pulse_.length.clock_rate = sampling_rate;
+	pulse_.type = initial_level ? Pulse::High : Pulse::Low;
+	source_data_ = std::move(data);
+}
 
-		default: assert(false);	break;
-	}
+uint8_t CSW::get_next_byte() {
+	if(source_data_pointer_ == source_data_.size()) return 0xff;
+	uint8_t result = source_data_[source_data_pointer_];
+	source_data_pointer_++;
+	return result;
 }
 
 uint32_t CSW::get_next_int32le() {
-	switch(compression_type_) {
-		case CompressionType::RLE: return file_.get32le();
-		case CompressionType::ZRLE: {
-			if(source_data_pointer_ > source_data_.size() - 4) return 0xffff;
-			uint32_t result = (uint32_t)(
-				(source_data_[source_data_pointer_ + 0] << 0) |
-				(source_data_[source_data_pointer_ + 1] << 8) |
-				(source_data_[source_data_pointer_ + 2] << 16) |
-				(source_data_[source_data_pointer_ + 3] << 24));
-			source_data_pointer_ += 4;
-			return result;
-		}
-
-		default: assert(false);	break;
-	}
+	if(source_data_pointer_ > source_data_.size() - 4) return 0xffff;
+	uint32_t result = (uint32_t)(
+		(source_data_[source_data_pointer_ + 0] << 0) |
+		(source_data_[source_data_pointer_ + 1] << 8) |
+		(source_data_[source_data_pointer_ + 2] << 16) |
+		(source_data_[source_data_pointer_ + 3] << 24));
+	source_data_pointer_ += 4;
+	return result;
 }
 
 void CSW::invert_pulse() {
@@ -120,21 +113,11 @@ void CSW::invert_pulse() {
 }
 
 bool CSW::is_at_end() {
-	switch(compression_type_) {
-		case CompressionType::RLE: return file_.eof();
-		case CompressionType::ZRLE: return source_data_pointer_ == source_data_.size();
-
-		default: assert(false);	break;
-	}
+	return source_data_pointer_ == source_data_.size();
 }
 
 void CSW::virtual_reset() {
-	switch(compression_type_) {
-		case CompressionType::RLE:	file_.seek(rle_start_, SEEK_SET);	break;
-		case CompressionType::ZRLE:	source_data_pointer_ = 0;			break;
-
-		default: assert(false);	break;
-	}
+	source_data_pointer_ = 0;
 }
 
 Tape::Pulse CSW::virtual_get_next_pulse() {

--- a/Storage/Tape/Formats/CSW.hpp
+++ b/Storage/Tape/Formats/CSW.hpp
@@ -30,6 +30,16 @@ class CSW: public Tape {
 		*/
 		CSW(const char *file_name);
 
+		enum class CompressionType {
+			RLE,
+			ZRLE
+		};
+
+		/*!
+			Constructs a @c CSW containing content as specified. Does not throw.
+		*/
+		CSW(const std::vector<uint8_t> &&data, CompressionType compression_type, bool initial_level, uint32_t sampling_rate);
+
 		enum {
 			ErrorNotCSW
 		};
@@ -38,16 +48,11 @@ class CSW: public Tape {
 		bool is_at_end();
 
 	private:
-		Storage::FileHolder file_;
-
 		void virtual_reset();
 		Pulse virtual_get_next_pulse();
 
 		Pulse pulse_;
-		enum class CompressionType {
-			RLE,
-			ZRLE
-		} compression_type_;
+		CompressionType compression_type_;
 
 		uint8_t get_next_byte();
 		uint32_t get_next_int32le();
@@ -55,8 +60,6 @@ class CSW: public Tape {
 
 		std::vector<uint8_t> source_data_;
 		std::size_t source_data_pointer_;
-
-		long rle_start_;
 };
 
 }

--- a/Storage/Tape/Formats/TZX.hpp
+++ b/Storage/Tape/Formats/TZX.hpp
@@ -44,11 +44,10 @@ class TZX: public PulseQueuedTape {
 		void get_pure_tone_data_block();
 		void get_pulse_sequence();
 		void get_pure_data_block();
+		void get_direct_recording_block();
+		void get_csw_recording_block();
 		void get_generalised_data_block();
 		void get_pause();
-		void get_kansas_city_block();
-
-		void get_hardware_type();
 
 		void ignore_group_start();
 		void ignore_group_end();
@@ -58,8 +57,18 @@ class TZX: public PulseQueuedTape {
 		void ignore_call_sequence();
 		void ignore_return_from_sequence();
 		void ignore_select_block();
+		void ignore_stop_tape_if_in_48kb_mode();
+
+		void get_set_signal_level();
+
 		void ignore_text_description();
 		void ignore_message_block();
+		void ignore_archive_info();
+		void get_hardware_type();
+		void ignore_custom_info_block();
+
+		void get_kansas_city_block();
+		void ignore_glue_block();
 
 		struct Data {
 			unsigned int length_of_zero_bit_pulse;

--- a/Storage/Tape/PulseQueuedTape.cpp
+++ b/Storage/Tape/PulseQueuedTape.cpp
@@ -33,6 +33,10 @@ void PulseQueuedTape::emplace_back(Tape::Pulse::Type type, Time length) {
 	queued_pulses_.emplace_back(type, length);
 }
 
+void PulseQueuedTape::emplace_back(const Tape::Pulse &&pulse) {
+	queued_pulses_.emplace_back(pulse);
+}
+
 Tape::Pulse PulseQueuedTape::silence() {
 	Pulse silence;
 	silence.type = Pulse::Zero;

--- a/Storage/Tape/PulseQueuedTape.hpp
+++ b/Storage/Tape/PulseQueuedTape.hpp
@@ -32,6 +32,7 @@ class PulseQueuedTape: public Tape {
 
 	protected:
 		void emplace_back(Tape::Pulse::Type type, Time length);
+		void emplace_back(const Tape::Pulse &&pulse);
 		void clear();
 		bool empty();
 


### PR DESCRIPTION
Towards that aim, simplifies CSW handling so that even regular RLE compression uses a static grab of file contents.

Deals with https://github.com/TomHarte/CLK/issues/342