### PR TITLE
Introduces formal setting of the output volume to `SampleSource`.

### DIFF
--- a/Components/6560/6560.cpp
+++ b/Components/6560/6560.cpp
@@ -132,6 +132,9 @@ void AudioGenerator::skip_samples(std::size_t number_of_samples) {
 	}
 }
 
+void AudioGenerator::set_sample_volume_range(std::int16_t range) {
+}
+
 #undef shift
 #undef increment
 #undef update

--- a/Components/6560/6560.hpp
+++ b/Components/6560/6560.hpp
@@ -25,8 +25,10 @@ class AudioGenerator: public ::Outputs::Speaker::SampleSource {
 		void set_volume(uint8_t volume);
 		void set_control(int channel, uint8_t value);
 
+		// For ::SampleSource.
 		void get_samples(std::size_t number_of_samples, int16_t *target);
 		void skip_samples(std::size_t number_of_samples);
+		void set_sample_volume_range(std::int16_t range);
 
 	private:
 		Concurrency::DeferringAsyncTaskQueue &audio_queue_;

--- a/Components/AY38910/AY38910.cpp
+++ b/Components/AY38910/AY38910.cpp
@@ -56,13 +56,18 @@ AY38910::AY38910(Concurrency::DeferringAsyncTaskQueue &task_queue) : task_queue_
 		}
 	}
 
+	set_sample_volume_range(0);
+}
+
+void AY38910::set_sample_volume_range(std::int16_t range) {
 	// set up volume lookup table
-	float max_volume = 8192;
-	float root_two = sqrtf(2.0f);
+	const float max_volume = static_cast<float>(range) / 3.0f;	// As there are three channels.
+	const float root_two = sqrtf(2.0f);
 	for(int v = 0; v < 16; v++) {
 		volumes_[v] = static_cast<int>(max_volume / powf(root_two, static_cast<float>(v ^ 0xf)));
 	}
 	volumes_[0] = 0;
+	evaluate_output_volume();
 }
 
 void AY38910::get_samples(std::size_t number_of_samples, int16_t *target) {

--- a/Components/AY38910/AY38910.hpp
+++ b/Components/AY38910/AY38910.hpp
@@ -86,6 +86,7 @@ class AY38910: public ::Outputs::Speaker::SampleSource {
 		// to satisfy ::Outputs::Speaker (included via ::Outputs::Filter; not for public consumption
 		void get_samples(std::size_t number_of_samples, int16_t *target);
 		bool is_zero_level();
+		void set_sample_volume_range(std::int16_t range);
 
 	private:
 		Concurrency::DeferringAsyncTaskQueue &task_queue_;

--- a/Components/KonamiSCC/KonamiSCC.hpp
+++ b/Components/KonamiSCC/KonamiSCC.hpp
@@ -31,6 +31,7 @@ class SCC: public ::Outputs::Speaker::SampleSource {
 
 		/// As per ::SampleSource; provides audio output.
 		void get_samples(std::size_t number_of_samples, std::int16_t *target);
+		void set_sample_volume_range(std::int16_t range);
 
 		/// Writes to the SCC.
 		void write(uint16_t address, uint8_t value);
@@ -43,7 +44,8 @@ class SCC: public ::Outputs::Speaker::SampleSource {
 
 		// State from here on down is accessed ony from the audio thread.
 		int master_divider_ = 0;
-		int16_t output_volume_ = 0;
+		std::int16_t master_volume_ = 0;
+		int16_t transient_output_level_ = 0;
 
 		struct Channel {
 			int period = 0;

--- a/Components/SN76489/SN76489.cpp
+++ b/Components/SN76489/SN76489.cpp
@@ -14,15 +14,7 @@
 using namespace TI;
 
 SN76489::SN76489(Personality personality, Concurrency::DeferringAsyncTaskQueue &task_queue, int additional_divider) : task_queue_(task_queue) {
-	// Build a volume table.
-	double multiplier = pow(10.0, -0.1);
-	double volume = 8191.0f;
-	for(int c = 0; c < 16; ++c) {
-		volumes_[c] = (int)round(volume);
-		volume *= multiplier;
-	}
-	volumes_[15] = 0;
-	evaluate_output_volume();
+	set_sample_volume_range(0);
 
 	switch(personality) {
 		case Personality::SN76494:
@@ -42,6 +34,18 @@ SN76489::SN76489(Personality personality, Concurrency::DeferringAsyncTaskQueue &
 	assert((master_divider_period_ % additional_divider) == 0);
 	assert(additional_divider < master_divider_period_);
 	master_divider_period_ /= additional_divider;
+}
+
+void SN76489::set_sample_volume_range(std::int16_t range) {
+	// Build a volume table.
+	double multiplier = pow(10.0, -0.1);
+	double volume = static_cast<float>(range) / 4.0f;	// As there are four channels.
+	for(int c = 0; c < 16; ++c) {
+		volumes_[c] = (int)round(volume);
+		volume *= multiplier;
+	}
+	volumes_[15] = 0;
+	evaluate_output_volume();
 }
 
 void SN76489::set_register(uint8_t value) {

--- a/Components/SN76489/SN76489.hpp
+++ b/Components/SN76489/SN76489.hpp
@@ -31,6 +31,7 @@ class SN76489: public Outputs::Speaker::SampleSource {
 		// As per SampleSource.
 		void get_samples(std::size_t number_of_samples, std::int16_t *target);
 		bool is_zero_level();
+		void set_sample_volume_range(std::int16_t range);
 
 	private:
 		int master_divider_ = 0;

--- a/Machines/Atari2600/TIASound.cpp
+++ b/Machines/Atari2600/TIASound.cpp
@@ -119,7 +119,11 @@ void Atari2600::TIASound::get_samples(std::size_t number_of_samples, int16_t *ta
 				break;
 			}
 
-			target[c] += volume_[channel] * 1024 * level;
+			target[c] += (volume_[channel] * per_channel_volume_ * level) >> 4;
 		}
 	}
+}
+
+void Atari2600::TIASound::set_sample_volume_range(std::int16_t range) {
+	per_channel_volume_ = range / 2;
 }

--- a/Machines/Atari2600/TIASound.hpp
+++ b/Machines/Atari2600/TIASound.hpp
@@ -26,7 +26,9 @@ class TIASound: public Outputs::Speaker::SampleSource {
 		void set_divider(int channel, uint8_t divider);
 		void set_control(int channel, uint8_t control);
 
+		// To satisfy ::SampleSource.
 		void get_samples(std::size_t number_of_samples, int16_t *target);
+		void set_sample_volume_range(std::int16_t range);
 
 	private:
 		Concurrency::DeferringAsyncTaskQueue &audio_queue_;
@@ -41,6 +43,7 @@ class TIASound: public Outputs::Speaker::SampleSource {
 		int output_state_[2];
 
 		int divider_counter_[2];
+		int16_t per_channel_volume_ = 0;
 };
 
 }

--- a/Machines/Electron/SoundGenerator.cpp
+++ b/Machines/Electron/SoundGenerator.cpp
@@ -15,10 +15,14 @@ using namespace Electron;
 SoundGenerator::SoundGenerator(Concurrency::DeferringAsyncTaskQueue &audio_queue) :
 	audio_queue_(audio_queue) {}
 
+void SoundGenerator::set_sample_volume_range(std::int16_t range) {
+	volume_ = static_cast<unsigned int>(range / 2);
+}
+
 void SoundGenerator::get_samples(std::size_t number_of_samples, int16_t *target) {
 	if(is_enabled_) {
 		while(number_of_samples--) {
-			*target = static_cast<int16_t>((counter_ / (divider_+1)) * 8192);
+			*target = static_cast<int16_t>((counter_ / (divider_+1)) * volume_);
 			target++;
 			counter_ = (counter_ + 1) % ((divider_+1) * 2);
 		}

--- a/Machines/Electron/SoundGenerator.hpp
+++ b/Machines/Electron/SoundGenerator.hpp
@@ -22,16 +22,19 @@ class SoundGenerator: public ::Outputs::Speaker::SampleSource {
 
 		void set_is_enabled(bool is_enabled);
 
+		static const unsigned int clock_rate_divider = 8;
+
+		// To satisfy ::SampleSource.
 		void get_samples(std::size_t number_of_samples, int16_t *target);
 		void skip_samples(std::size_t number_of_samples);
-
-		static const unsigned int clock_rate_divider = 8;
+		void set_sample_volume_range(std::int16_t range);
 
 	private:
 		Concurrency::DeferringAsyncTaskQueue &audio_queue_;
 		unsigned int counter_ = 0;
 		unsigned int divider_ = 0;
 		bool is_enabled_ = false;
+		unsigned int volume_ = 0;
 };
 
 }

--- a/Machines/MSX/MSX.cpp
+++ b/Machines/MSX/MSX.cpp
@@ -62,13 +62,17 @@ class AudioToggle: public Outputs::Speaker::SampleSource {
 			}
 		}
 
+		void set_sample_volume_range(std::int16_t range) {
+			volume_ = range;
+		}
+
 		void skip_samples(const std::size_t number_of_samples) {}
 
 		void set_output(bool enabled) {
 			if(is_enabled_ == enabled) return;
 			is_enabled_ = enabled;
 			audio_queue_.defer([=] {
-				level_ = enabled ? 4096 : 0;
+				level_ = enabled ? volume_ : 0;
 			});
 		}
 
@@ -78,7 +82,7 @@ class AudioToggle: public Outputs::Speaker::SampleSource {
 
 	private:
 		bool is_enabled_ = false;
-		int16_t level_ = 0;
+		int16_t level_ = 0, volume_ = 0;
 		Concurrency::DeferringAsyncTaskQueue &audio_queue_;
 };
 

--- a/Outputs/Speaker/Implementation/CompoundSource.hpp
+++ b/Outputs/Speaker/Implementation/CompoundSource.hpp
@@ -25,6 +25,12 @@ template <typename... T> class CompoundSource: public Outputs::Speaker::SampleSo
 		void get_samples(std::size_t number_of_samples, std::int16_t *target) {
 			std::memset(target, 0, sizeof(std::int16_t) * number_of_samples);
 		}
+
+		void set_scaled_volume_range(int16_t range) {}
+
+		int size() {
+			return 0;
+		}
 };
 
 /*!
@@ -53,6 +59,19 @@ template <typename T, typename... R> class CompoundSource<T, R...>:
 		void skip_samples(const std::size_t number_of_samples) {
 			source_.skip_samples(number_of_samples);
 			next_source_.skip_samples(number_of_samples);
+		}
+
+		void set_sample_volume_range(int16_t range) {
+			set_scaled_volume_range(range / size());
+		}
+
+		void set_scaled_volume_range(int16_t range) {
+			source_.set_sample_volume_range(range);
+			next_source_.set_scaled_volume_range(range);
+		}
+
+		int size() {
+			return 1+next_source_.size();
 		}
 
 	private:

--- a/Outputs/Speaker/Implementation/LowpassSpeaker.hpp
+++ b/Outputs/Speaker/Implementation/LowpassSpeaker.hpp
@@ -28,7 +28,9 @@ namespace Speaker {
 */
 template <typename T> class LowpassSpeaker: public Speaker {
 	public:
-		LowpassSpeaker(T &sample_source) : sample_source_(sample_source) {}
+		LowpassSpeaker(T &sample_source) : sample_source_(sample_source) {
+			sample_source.set_sample_volume_range(32767);
+		}
 
 		// Implemented as per Speaker.
 		float get_ideal_clock_rate_in_range(float minimum, float maximum) {

--- a/Outputs/Speaker/Implementation/SampleSource.hpp
+++ b/Outputs/Speaker/Implementation/SampleSource.hpp
@@ -46,6 +46,13 @@ class SampleSource {
 		bool is_zero_level() {
 			return false;
 		}
+
+		/*!
+			Sets the proper output range for this sample source; it should write values
+			between 0 and volume.
+		*/
+		void set_sample_volume_range(std::int16_t volume) {
+		}
 };
 
 }


### PR DESCRIPTION
Previously every output device was making its own decision. Which is increasingly less sustainable due to the CompoundSource.