### PR TITLE
Eliminates diamond inheritance of KeyboardMachine::Machine by typers.

### DIFF
--- a/Machines/AmstradCPC/AmstradCPC.cpp
+++ b/Machines/AmstradCPC/AmstradCPC.cpp
@@ -20,6 +20,10 @@
 #include "../Utility/MemoryFuzzer.hpp"
 #include "../Utility/Typer.hpp"
 
+#include "../ConfigurationTarget.hpp"
+#include "../CRTMachine.hpp"
+#include "../KeyboardMachine.hpp"
+
 #include "../../Storage/Tape/Tape.hpp"
 
 #include "../../ClockReceiver/ForceInline.hpp"
@@ -674,6 +678,9 @@ class i8255PortHandler : public Intel::i8255::PortHandler {
 	The actual Amstrad CPC implementation; tying the 8255, 6845 and AY to the Z80.
 */
 class ConcreteMachine:
+	public CRTMachine::Machine,
+	public ConfigurationTarget::Machine,
+	public KeyboardMachine::Machine,
 	public Utility::TypeRecipient,
 	public CPU::Z80::BusHandler,
 	public Sleeper::SleepObserver,

--- a/Machines/AmstradCPC/AmstradCPC.hpp
+++ b/Machines/AmstradCPC/AmstradCPC.hpp
@@ -9,19 +9,12 @@
 #ifndef AmstradCPC_hpp
 #define AmstradCPC_hpp
 
-#include "../ConfigurationTarget.hpp"
-#include "../CRTMachine.hpp"
-#include "../KeyboardMachine.hpp"
-
 namespace AmstradCPC {
 
 /*!
 	Models an Amstrad CPC.
 */
-class Machine:
-	public CRTMachine::Machine,
-	public ConfigurationTarget::Machine,
-	public KeyboardMachine::Machine {
+class Machine {
 	public:
 		virtual ~Machine();
 

--- a/Machines/Atari2600/Atari2600.cpp
+++ b/Machines/Atari2600/Atari2600.cpp
@@ -11,6 +11,10 @@
 #include <algorithm>
 #include <cstdio>
 
+#include "../ConfigurationTarget.hpp"
+#include "../CRTMachine.hpp"
+#include "../JoystickMachine.hpp"
+
 #include "Cartridges/Atari8k.hpp"
 #include "Cartridges/Atari16k.hpp"
 #include "Cartridges/Atari32k.hpp"
@@ -72,6 +76,9 @@ class Joystick: public Inputs::Joystick {
 
 class ConcreteMachine:
 	public Machine,
+	public CRTMachine::Machine,
+	public ConfigurationTarget::Machine,
+	public JoystickMachine::Machine,
 	public Outputs::CRT::Delegate {
 	public:
 		ConcreteMachine() {

--- a/Machines/Atari2600/Atari2600.hpp
+++ b/Machines/Atari2600/Atari2600.hpp
@@ -9,10 +9,6 @@
 #ifndef Atari2600_cpp
 #define Atari2600_cpp
 
-#include "../ConfigurationTarget.hpp"
-#include "../CRTMachine.hpp"
-#include "../JoystickMachine.hpp"
-
 #include "Atari2600Inputs.h"
 
 namespace Atari2600 {
@@ -20,10 +16,7 @@ namespace Atari2600 {
 /*!
 	Models an Atari 2600.
 */
-class Machine:
-	public CRTMachine::Machine,
-	public ConfigurationTarget::Machine,
-	public JoystickMachine::Machine {
+class Machine {
 	public:
 		virtual ~Machine();
 

--- a/Machines/Commodore/Vic-20/Vic20.cpp
+++ b/Machines/Commodore/Vic-20/Vic20.cpp
@@ -10,6 +10,11 @@
 
 #include "Keyboard.hpp"
 
+#include "../../ConfigurationTarget.hpp"
+#include "../../CRTMachine.hpp"
+#include "../../KeyboardMachine.hpp"
+#include "../../JoystickMachine.hpp"
+
 #include "../../../Processors/6502/6502.hpp"
 #include "../../../Components/6560/6560.hpp"
 #include "../../../Components/6522/6522.hpp"
@@ -283,6 +288,11 @@ class Joystick: public Inputs::Joystick {
 };
 
 class ConcreteMachine:
+	public CRTMachine::Machine,
+	public ConfigurationTarget::Machine,
+	public KeyboardMachine::Machine,
+	public JoystickMachine::Machine,
+	public Configurable::Device,
 	public CPU::MOS6502::BusHandler,
 	public MOS::MOS6522::IRQDelegatePortHandler::Delegate,
 	public Utility::TypeRecipient,

--- a/Machines/Commodore/Vic-20/Vic20.hpp
+++ b/Machines/Commodore/Vic-20/Vic20.hpp
@@ -10,10 +10,6 @@
 #define Vic20_hpp
 
 #include "../../../Configurable/Configurable.hpp"
-#include "../../ConfigurationTarget.hpp"
-#include "../../CRTMachine.hpp"
-#include "../../KeyboardMachine.hpp"
-#include "../../JoystickMachine.hpp"
 
 namespace Commodore {
 namespace Vic20 {
@@ -35,12 +31,7 @@ enum Region {
 /// @returns The options available for a Vic-20.
 std::vector<std::unique_ptr<Configurable::Option>> get_options();
 
-class Machine:
-	public CRTMachine::Machine,
-	public ConfigurationTarget::Machine,
-	public KeyboardMachine::Machine,
-	public JoystickMachine::Machine,
-	public Configurable::Device {
+class Machine {
 	public:
 		virtual ~Machine();
 

--- a/Machines/Electron/Electron.cpp
+++ b/Machines/Electron/Electron.cpp
@@ -8,6 +8,10 @@
 
 #include "Electron.hpp"
 
+#include "../ConfigurationTarget.hpp"
+#include "../CRTMachine.hpp"
+#include "../KeyboardMachine.hpp"
+
 #include "../../ClockReceiver/ClockReceiver.hpp"
 #include "../../ClockReceiver/ForceInline.hpp"
 #include "../../Configurable/StandardOptions.hpp"
@@ -34,6 +38,10 @@ std::vector<std::unique_ptr<Configurable::Option>> get_options() {
 
 class ConcreteMachine:
 	public Machine,
+	public CRTMachine::Machine,
+	public ConfigurationTarget::Machine,
+	public KeyboardMachine::Machine,
+	public Configurable::Device,
 	public CPU::MOS6502::BusHandler,
 	public Tape::Delegate,
 	public Utility::TypeRecipient {

--- a/Machines/Electron/Electron.hpp
+++ b/Machines/Electron/Electron.hpp
@@ -10,9 +10,6 @@
 #define Electron_hpp
 
 #include "../../Configurable/Configurable.hpp"
-#include "../ConfigurationTarget.hpp"
-#include "../CRTMachine.hpp"
-#include "../KeyboardMachine.hpp"
 
 #include <cstdint>
 #include <vector>
@@ -42,11 +39,7 @@ std::vector<std::unique_ptr<Configurable::Option>> get_options();
 	@discussion An instance of Electron::Machine represents the current state of an
 	Acorn Electron.
 */
-class Machine:
-	public CRTMachine::Machine,
-	public ConfigurationTarget::Machine,
-	public KeyboardMachine::Machine,
-	public Configurable::Device {
+class Machine {
 	public:
 		virtual ~Machine();
 

--- a/Machines/KeyboardMachine.hpp
+++ b/Machines/KeyboardMachine.hpp
@@ -16,20 +16,29 @@
 
 namespace KeyboardMachine {
 
-class Machine: public Inputs::Keyboard::Delegate {
+/*!
+	Covers just the actions necessary to communicate keyboard state, as a purely abstract class.
+*/
+struct KeyActions {
+	/*!
+		Indicates that the key @c key has been either pressed or released, according to
+		the state of @c isPressed.
+	*/
+	virtual void set_key_state(uint16_t key, bool is_pressed) = 0;
+
+	/*!
+		Instructs that all keys should now be treated as released.
+	*/
+	virtual void clear_all_keys() = 0;
+};
+
+/*!
+	Describes the full functionality of being an emulated machine with a keyboard: not just being
+	able to receive key actions, but being able to vend a generic keyboard and a keyboard mapper.
+*/
+class Machine: public Inputs::Keyboard::Delegate, public KeyActions {
 	public:
 		Machine();
-
-		/*!
-			Indicates that the key @c key has been either pressed or released, according to
-			the state of @c isPressed.
-		*/
-		virtual void set_key_state(uint16_t key, bool is_pressed) = 0;
-
-		/*!
-			Instructs that all keys should now be treated as released.
-		*/
-		virtual void clear_all_keys() = 0;
 
 		/*!
 			Causes the machine to attempt to type the supplied string.

--- a/Machines/Oric/Oric.cpp
+++ b/Machines/Oric/Oric.cpp
@@ -12,6 +12,10 @@
 #include "Microdisc.hpp"
 #include "Video.hpp"
 
+#include "../ConfigurationTarget.hpp"
+#include "../CRTMachine.hpp"
+#include "../KeyboardMachine.hpp"
+
 #include "../Utility/MemoryFuzzer.hpp"
 #include "../Utility/Typer.hpp"
 
@@ -184,6 +188,10 @@ class VIAPortHandler: public MOS::MOS6522::IRQDelegatePortHandler {
 };
 
 class ConcreteMachine:
+	public CRTMachine::Machine,
+	public ConfigurationTarget::Machine,
+	public KeyboardMachine::Machine,
+	public Configurable::Device,
 	public CPU::MOS6502::BusHandler,
 	public MOS::MOS6522::IRQDelegatePortHandler::Delegate,
 	public Utility::TypeRecipient,

--- a/Machines/Oric/Oric.hpp
+++ b/Machines/Oric/Oric.hpp
@@ -10,9 +10,6 @@
 #define Oric_hpp
 
 #include "../../Configurable/Configurable.hpp"
-#include "../ConfigurationTarget.hpp"
-#include "../CRTMachine.hpp"
-#include "../KeyboardMachine.hpp"
 
 namespace Oric {
 
@@ -22,11 +19,7 @@ std::vector<std::unique_ptr<Configurable::Option>> get_options();
 /*!
 	Models an Oric 1/Atmos with or without a Microdisc.
 */
-class Machine:
-	public CRTMachine::Machine,
-	public ConfigurationTarget::Machine,
-	public KeyboardMachine::Machine,
-	public Configurable::Device {
+class Machine {
 	public:
 		virtual ~Machine();
 

--- a/Machines/Utility/Typer.hpp
+++ b/Machines/Utility/Typer.hpp
@@ -47,7 +47,7 @@ class CharacterMapper {
 */
 class Typer {
 	public:
-		class Delegate: public KeyboardMachine::Machine {
+		class Delegate: public KeyboardMachine::KeyActions {
 			public:
 				virtual void typer_reset(Typer *typer) = 0;
 		};
@@ -56,7 +56,6 @@ class Typer {
 
 		void run_for(const HalfCycles duration);
 		bool type_next_character();
-
 		bool is_completed();
 
 		const char BeginString = 0x02;	// i.e. ASCII start of text
@@ -81,7 +80,7 @@ class Typer {
 	which may or may not want to nominate an initial delay and typing frequency.
 */
 class TypeRecipient: public Typer::Delegate {
-	public:
+	protected:
 		/// Attaches a typer to this class that will type @c string using @c character_mapper as a source.
 		void add_typer(const std::string &string, std::unique_ptr<CharacterMapper> character_mapper) {
 			typer_.reset(new Typer(string, get_typer_delay(), get_typer_frequency(), std::move(character_mapper), this));
@@ -101,7 +100,6 @@ class TypeRecipient: public Typer::Delegate {
 			typer_ = nullptr;
 		}
 
-	protected:
 		virtual HalfCycles get_typer_delay() { return HalfCycles(0); }
 		virtual HalfCycles get_typer_frequency() { return HalfCycles(0); }
 		std::unique_ptr<Typer> typer_;

--- a/Machines/ZX8081/ZX8081.cpp
+++ b/Machines/ZX8081/ZX8081.cpp
@@ -8,6 +8,10 @@
 
 #include "ZX8081.hpp"
 
+#include "../ConfigurationTarget.hpp"
+#include "../CRTMachine.hpp"
+#include "../KeyboardMachine.hpp"
+
 #include "../../Components/AY38910/AY38910.hpp"
 #include "../../Processors/Z80/Z80.hpp"
 #include "../../Storage/Tape/Tape.hpp"
@@ -52,6 +56,10 @@ std::vector<std::unique_ptr<Configurable::Option>> get_options() {
 }
 
 template<bool is_zx81> class ConcreteMachine:
+	public CRTMachine::Machine,
+	public ConfigurationTarget::Machine,
+	public KeyboardMachine::Machine,
+	public Configurable::Device,
 	public Utility::TypeRecipient,
 	public CPU::Z80::BusHandler,
 	public Machine {

--- a/Machines/ZX8081/ZX8081.hpp
+++ b/Machines/ZX8081/ZX8081.hpp
@@ -10,20 +10,14 @@
 #define ZX8081_hpp
 
 #include "../../Configurable/Configurable.hpp"
-#include "../ConfigurationTarget.hpp"
-#include "../CRTMachine.hpp"
-#include "../KeyboardMachine.hpp"
+#include "../../Analyser/Static/StaticAnalyser.hpp"
 
 namespace ZX8081 {
 
 /// @returns The options available for a ZX80 or ZX81.
 std::vector<std::unique_ptr<Configurable::Option>> get_options();
 
-class Machine:
-	public CRTMachine::Machine,
-	public ConfigurationTarget::Machine,
-	public KeyboardMachine::Machine,
-	public Configurable::Device {
+class Machine {
 	public:
 		virtual ~Machine();
 


### PR DESCRIPTION
Specifically by pulling the key action stuff into a purely abstract class [/interface]. Takes the opportunity to unpublish a bunch of machine details.

Thereby resolves https://github.com/TomHarte/CLK/issues/308