### PR TITLE
Devolves time -> clock rate mapping to machines.

### DIFF
--- a/Analyser/Dynamic/MultiMachine/Implementation/MultiCRTMachine.cpp
+++ b/Analyser/Dynamic/MultiMachine/Implementation/MultiCRTMachine.cpp
@@ -75,41 +75,16 @@ Outputs::Speaker::Speaker *MultiCRTMachine::get_speaker() {
 	return speaker_;
 }
 
-void MultiCRTMachine::run_for(const Cycles cycles) {
+void MultiCRTMachine::run_for(Time::Seconds duration) {
 	perform_parallel([=](::CRTMachine::Machine *machine) {
-		if(machine->get_confidence() >= 0.01f) machine->run_for(cycles);
+		if(machine->get_confidence() >= 0.01f) machine->run_for(duration);
 	});
 
 	if(delegate_) delegate_->multi_crt_did_run_machines();
-}
-
-double MultiCRTMachine::get_clock_rate() {
-	// TODO: something smarter than this? Not all clock rates will necessarily be the same.
-	std::lock_guard<std::mutex> machines_lock(machines_mutex_);
-	CRTMachine::Machine *crt_machine = machines_.front()->crt_machine();
-	return crt_machine ? crt_machine->get_clock_rate() : 0.0;
-}
-
-bool MultiCRTMachine::get_clock_is_unlimited() {
-	std::lock_guard<std::mutex> machines_lock(machines_mutex_);
-	CRTMachine::Machine *crt_machine = machines_.front()->crt_machine();
-	return crt_machine ? crt_machine->get_clock_is_unlimited() : false;
 }
 
 void MultiCRTMachine::did_change_machine_order() {
 	if(speaker_) {
 		speaker_->set_new_front_machine(machines_.front().get());
 	}
-}
-
-void MultiCRTMachine::set_delegate(::CRTMachine::Machine::Delegate *delegate) {
-	// TODO: 
-}
-
-void MultiCRTMachine::machine_did_change_clock_rate(Machine *machine) {
-	// TODO: consider passing along.
-}
-
-void MultiCRTMachine::machine_did_change_clock_is_unlimited(Machine *machine) {
-	// TODO: consider passing along.
 }

--- a/Analyser/Dynamic/MultiMachine/Implementation/MultiCRTMachine.hpp
+++ b/Analyser/Dynamic/MultiMachine/Implementation/MultiCRTMachine.hpp
@@ -29,7 +29,7 @@ namespace Dynamic {
 	acquiring a supplied mutex. The owner should also call did_change_machine_order()
 	if the order of machines changes.
 */
-class MultiCRTMachine: public CRTMachine::Machine, public CRTMachine::Machine::Delegate {
+class MultiCRTMachine: public CRTMachine::Machine {
 	public:
 		MultiCRTMachine(const std::vector<std::unique_ptr<::Machine::DynamicMachine>> &machines, std::mutex &machines_mutex);
 
@@ -57,16 +57,10 @@ class MultiCRTMachine: public CRTMachine::Machine, public CRTMachine::Machine::D
 		void close_output() override;
 		Outputs::CRT::CRT *get_crt() override;
 		Outputs::Speaker::Speaker *get_speaker() override;
-		void run_for(const Cycles cycles) override;
-		double get_clock_rate() override;
-		bool get_clock_is_unlimited() override;
-		void set_delegate(::CRTMachine::Machine::Delegate *delegate) override;
+		void run_for(Time::Seconds duration) override;
 
 	private:
-		// CRTMachine::Machine::Delegate
-		void machine_did_change_clock_rate(Machine *machine) override;
-		void machine_did_change_clock_is_unlimited(Machine *machine) override;
-
+		void run_for(const Cycles cycles) override {}
 		const std::vector<std::unique_ptr<::Machine::DynamicMachine>> &machines_;
 		std::mutex &machines_mutex_;
 		std::vector<Concurrency::AsyncTaskQueue> queues_;

--- a/Analyser/Dynamic/MultiMachine/Implementation/MultiSpeaker.cpp
+++ b/Analyser/Dynamic/MultiMachine/Implementation/MultiSpeaker.cpp
@@ -54,7 +54,17 @@ void MultiSpeaker::speaker_did_complete_samples(Speaker *speaker, const std::vec
 	}
 }
 
+void MultiSpeaker::speaker_did_change_input_clock(Speaker *speaker) {
+	std::lock_guard<std::mutex> lock_guard(front_speaker_mutex_);
+	if(delegate_ && speaker == front_speaker_) {
+		delegate_->speaker_did_change_input_clock(this);
+	}
+}
+
 void MultiSpeaker::set_new_front_machine(::Machine::DynamicMachine *machine) {
 	std::lock_guard<std::mutex> lock_guard(front_speaker_mutex_);
 	front_speaker_ = machine->crt_machine()->get_speaker();
+	if(delegate_) {
+		delegate_->speaker_did_change_input_clock(this);
+	}
 }

--- a/Analyser/Dynamic/MultiMachine/Implementation/MultiSpeaker.hpp
+++ b/Analyser/Dynamic/MultiMachine/Implementation/MultiSpeaker.hpp
@@ -38,12 +38,13 @@ class MultiSpeaker: public Outputs::Speaker::Speaker, Outputs::Speaker::Speaker:
 		void set_new_front_machine(::Machine::DynamicMachine *machine);
 
 		// Below is the standard Outputs::Speaker::Speaker interface; see there for documentation.
-		float get_ideal_clock_rate_in_range(float minimum, float maximum);
-		void set_output_rate(float cycles_per_second, int buffer_size);
-		void set_delegate(Outputs::Speaker::Speaker::Delegate *delegate);
+		float get_ideal_clock_rate_in_range(float minimum, float maximum) override;
+		void set_output_rate(float cycles_per_second, int buffer_size) override;
+		void set_delegate(Outputs::Speaker::Speaker::Delegate *delegate) override;
 
 	private:
-		void speaker_did_complete_samples(Speaker *speaker, const std::vector<int16_t> &buffer);
+		void speaker_did_complete_samples(Speaker *speaker, const std::vector<int16_t> &buffer) override;
+		void speaker_did_change_input_clock(Speaker *speaker) override;
 		MultiSpeaker(const std::vector<Outputs::Speaker::Speaker *> &speakers);
 
 		std::vector<Outputs::Speaker::Speaker *> speakers_;

--- a/ClockReceiver/TimeTypes.hpp
+++ b/ClockReceiver/TimeTypes.hpp
@@ -1,0 +1,18 @@
+//
+//  TimeTypes.hpp
+//  Clock Signal
+//
+//  Created by Thomas Harte on 21/03/2018.
+//  Copyright © 2018 Thomas Harte. All rights reserved.
+//
+
+#ifndef TimeTypes_h
+#define TimeTypes_h
+
+namespace Time {
+
+typedef double Seconds;
+
+}
+
+#endif /* TimeTypes_h */

--- a/Concurrency/BestEffortUpdater.hpp
+++ b/Concurrency/BestEffortUpdater.hpp
@@ -13,6 +13,7 @@
 #include <chrono>
 
 #include "AsyncTaskQueue.hpp"
+#include "TimeTypes.hpp"
 
 namespace Concurrency {
 
@@ -30,14 +31,11 @@ class BestEffortUpdater {
 
 		/// A delegate receives timing cues.
 		struct Delegate {
-			virtual void update(BestEffortUpdater *updater, int cycles, bool did_skip_previous_update) = 0;
+			virtual void update(BestEffortUpdater *updater, Time::Seconds duration, bool did_skip_previous_update) = 0;
 		};
 
 		/// Sets the current delegate.
 		void set_delegate(Delegate *);
-
-		/// Sets the clock rate of the delegate.
-		void set_clock_rate(double clock_rate);
 
 		/*!
 			If the delegate is not currently in the process of an `update` call, calls it now to catch up to the current time.
@@ -54,11 +52,9 @@ class BestEffortUpdater {
 
 		std::chrono::time_point<std::chrono::high_resolution_clock> previous_time_point_;
 		bool has_previous_time_point_ = false;
-		double error_ = 0.0;
 		bool has_skipped_ = false;
 
 		Delegate *delegate_ = nullptr;
-		double clock_rate_ = 1.0;
 };
 
 }

--- a/Machines/CRTMachine.hpp
+++ b/Machines/CRTMachine.hpp
@@ -55,15 +55,14 @@ class Machine: public ROMMachine::Machine {
 			run_for(Cycles(static_cast<int>(cycles)));
 		}
 
-		double get_clock_rate() {
-			return clock_rate_;
-		}
-
 	protected:
 		/// Runs the machine for @c cycles.
 		virtual void run_for(const Cycles cycles) = 0;
 		void set_clock_rate(double clock_rate) {
 			clock_rate_ = clock_rate;
+		}
+		double get_clock_rate() {
+			return clock_rate_;
 		}
 
 	private:

--- a/Machines/CRTMachine.hpp
+++ b/Machines/CRTMachine.hpp
@@ -12,7 +12,10 @@
 #include "../Outputs/CRT/CRT.hpp"
 #include "../Outputs/Speaker/Speaker.hpp"
 #include "../ClockReceiver/ClockReceiver.hpp"
+#include "../ClockReceiver/TimeTypes.hpp"
 #include "ROMMachine.hpp"
+
+#include <cmath>
 
 namespace CRTMachine {
 
@@ -41,45 +44,31 @@ class Machine: public ROMMachine::Machine {
 		/// @returns The speaker that receives this machine's output, or @c nullptr if this machine is mute.
 		virtual Outputs::Speaker::Speaker *get_speaker() = 0;
 
-		/// Runs the machine for @c cycles.
-		virtual void run_for(const Cycles cycles) = 0;
-
 		/// @returns The confidence that this machine is running content it understands.
 		virtual float get_confidence() { return 0.5f; }
 		virtual void print_type() {}
 
-		// TODO: sever the clock-rate stuff.
-		virtual double get_clock_rate() {
+		/// Runs the machine for @c duration seconds.
+		virtual void run_for(Time::Seconds duration) {
+			const double cycles = (duration * clock_rate_) + clock_conversion_error_;
+			clock_conversion_error_ = std::fmod(cycles, 1.0);
+			run_for(Cycles(static_cast<int>(cycles)));
+		}
+
+		double get_clock_rate() {
 			return clock_rate_;
 		}
-		virtual bool get_clock_is_unlimited() {
-			return clock_is_unlimited_;
-		}
-		class Delegate {
-			public:
-				virtual void machine_did_change_clock_rate(Machine *machine) = 0;
-				virtual void machine_did_change_clock_is_unlimited(Machine *machine) = 0;
-		};
-		virtual void set_delegate(Delegate *delegate) { delegate_ = delegate; }
 
 	protected:
+		/// Runs the machine for @c cycles.
+		virtual void run_for(const Cycles cycles) = 0;
 		void set_clock_rate(double clock_rate) {
-			if(clock_rate_ != clock_rate) {
-				clock_rate_ = clock_rate;
-				if(delegate_) delegate_->machine_did_change_clock_rate(this);
-			}
-		}
-		void set_clock_is_unlimited(bool clock_is_unlimited) {
-			if(clock_is_unlimited != clock_is_unlimited_) {
-				clock_is_unlimited_ = clock_is_unlimited;
-				if(delegate_) delegate_->machine_did_change_clock_is_unlimited(this);
-			}
+			clock_rate_ = clock_rate;
 		}
 
 	private:
-		Delegate *delegate_ = nullptr;
 		double clock_rate_ = 1.0;
-		bool clock_is_unlimited_ = false;
+		double clock_conversion_error_ = 0.0;
 };
 
 }

--- a/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
@@ -780,6 +780,7 @@
 		4B448E801F1C45A00009ABD6 /* TZX.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = TZX.hpp; sourceTree = "<group>"; };
 		4B448E821F1C4C480009ABD6 /* PulseQueuedTape.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PulseQueuedTape.cpp; sourceTree = "<group>"; };
 		4B448E831F1C4C480009ABD6 /* PulseQueuedTape.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = PulseQueuedTape.hpp; sourceTree = "<group>"; };
+		4B449C942063389900A095C8 /* TimeTypes.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = TimeTypes.hpp; sourceTree = "<group>"; };
 		4B44EBF41DC987AE00A7820C /* AllSuiteA.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; name = AllSuiteA.bin; path = AllSuiteA/AllSuiteA.bin; sourceTree = "<group>"; };
 		4B44EBF61DC9883B00A7820C /* 6502_functional_test.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; name = 6502_functional_test.bin; path = "Klaus Dormann/6502_functional_test.bin"; sourceTree = "<group>"; };
 		4B44EBF81DC9898E00A7820C /* BCDTEST_beeb */ = {isa = PBXFileReference; lastKnownFileType = file; name = BCDTEST_beeb; path = BCDTest/BCDTEST_beeb; sourceTree = "<group>"; };
@@ -2972,6 +2973,7 @@
 				4BF6606A1F281573002CB053 /* ClockReceiver.hpp */,
 				4BB06B211F316A3F00600C7A /* ForceInline.hpp */,
 				4BB146C61F49D7D700253439 /* Sleeper.hpp */,
+				4B449C942063389900A095C8 /* TimeTypes.hpp */,
 			);
 			name = ClockReceiver;
 			path = ../../ClockReceiver;

--- a/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
+++ b/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
@@ -12,6 +12,7 @@ import AudioToolbox
 class MachineDocument:
 	NSDocument,
 	NSWindowDelegate,
+	CSMachineDelegate,
 	CSOpenGLViewDelegate,
 	CSOpenGLViewResponderDelegate,
 	CSBestEffortUpdaterDelegate,
@@ -55,6 +56,7 @@ class MachineDocument:
 			self.machine.setView(self.openGLView, aspectRatio: Float(displayAspectRatio.width / displayAspectRatio.height))
 		})
 
+		self.machine.delegate = self
 		self.bestEffortUpdater = CSBestEffortUpdater()
 
 		// callbacks from the OpenGL may come on a different thread, immediately following the .delegate set;
@@ -70,6 +72,10 @@ class MachineDocument:
 
 		// start accepting best effort updates
 		self.bestEffortUpdater!.delegate = self
+	}
+
+	func machineSpeakerDidChangeInputClock(_ machine: CSMachine!) {
+		setupClockRate()
 	}
 
 	fileprivate func setupClockRate() {

--- a/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
+++ b/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
@@ -64,7 +64,7 @@ class MachineDocument:
 		self.openGLView.delegate = self
 		self.openGLView.responderDelegate = self
 
-		setupClockRate()
+		setupAudioQueueClockRate()
 		self.optionsPanel?.establishStoredOptions()
 
 		// bring OpenGL view-holding window on top of the options panel
@@ -75,10 +75,10 @@ class MachineDocument:
 	}
 
 	func machineSpeakerDidChangeInputClock(_ machine: CSMachine!) {
-		setupClockRate()
+		setupAudioQueueClockRate()
 	}
 
-	fileprivate func setupClockRate() {
+	fileprivate func setupAudioQueueClockRate() {
 		// establish and provide the audio queue, taking advice as to an appropriate sampling rate
 		let maximumSamplingRate = CSAudioQueue.preferredSamplingRate()
 		let selectedSamplingRate = self.machine.idealSamplingRate(from: NSRange(location: 0, length: NSInteger(maximumSamplingRate)))

--- a/OSBindings/Mac/Clock Signal/Machine/CSMachine.h
+++ b/OSBindings/Mac/Clock Signal/Machine/CSMachine.h
@@ -14,6 +14,9 @@
 #import "CSStaticAnalyser.h"
 
 @class CSMachine;
+@protocol CSMachineDelegate
+- (void)machineSpeakerDidChangeInputClock:(CSMachine *)machine;
+@end
 
 // Deliberately low; to ensure CSMachine has been declared as an @class already.
 #import "CSAtari2600.h"
@@ -42,6 +45,7 @@
 
 @property (nonatomic, strong) CSAudioQueue *audioQueue;
 @property (nonatomic, readonly) CSOpenGLView *view;
+@property (nonatomic, weak) id<CSMachineDelegate> delegate;
 
 @property (nonatomic, readonly) NSString *userDefaultsPrefix;
 

--- a/OSBindings/Mac/Clock Signal/Machine/CSMachine.h
+++ b/OSBindings/Mac/Clock Signal/Machine/CSMachine.h
@@ -43,9 +43,6 @@
 @property (nonatomic, strong) CSAudioQueue *audioQueue;
 @property (nonatomic, readonly) CSOpenGLView *view;
 
-@property (nonatomic, readonly) double clockRate;
-@property (nonatomic, readonly) BOOL clockIsUnlimited;
-
 @property (nonatomic, readonly) NSString *userDefaultsPrefix;
 
 - (void)paste:(NSString *)string;

--- a/OSBindings/Mac/Clock Signal/Machine/CSMachine.h
+++ b/OSBindings/Mac/Clock Signal/Machine/CSMachine.h
@@ -14,10 +14,6 @@
 #import "CSStaticAnalyser.h"
 
 @class CSMachine;
-@protocol CSMachineDelegate
-- (void)machineDidChangeClockRate:(CSMachine *)machine;
-- (void)machineDidChangeClockIsUnlimited:(CSMachine *)machine;
-@end
 
 // Deliberately low; to ensure CSMachine has been declared as an @class already.
 #import "CSAtari2600.h"
@@ -33,7 +29,7 @@
 */
 - (instancetype)initWithAnalyser:(CSStaticAnalyser *)result NS_DESIGNATED_INITIALIZER;
 
-- (void)runForNumberOfCycles:(int)numberOfCycles;
+- (void)runForInterval:(NSTimeInterval)interval;
 
 - (float)idealSamplingRateFromRange:(NSRange)range;
 - (void)setAudioSamplingRate:(float)samplingRate bufferSize:(NSUInteger)bufferSize;
@@ -46,7 +42,6 @@
 
 @property (nonatomic, strong) CSAudioQueue *audioQueue;
 @property (nonatomic, readonly) CSOpenGLView *view;
-@property (nonatomic, weak) id<CSMachineDelegate> delegate;
 
 @property (nonatomic, readonly) double clockRate;
 @property (nonatomic, readonly) BOOL clockIsUnlimited;

--- a/OSBindings/Mac/Clock Signal/Machine/CSMachine.mm
+++ b/OSBindings/Mac/Clock Signal/Machine/CSMachine.mm
@@ -78,7 +78,7 @@ struct SpeakerDelegate: public Outputs::Speaker::Speaker::Delegate, public LockP
 }
 
 - (void)speakerDidChangeInputClock:(Outputs::Speaker::Speaker *)speaker {
-	// TODO: consider changing output audio queue rate.
+	[self.delegate machineSpeakerDidChangeInputClock:self];
 }
 
 - (void)dealloc {

--- a/OSBindings/Mac/Clock Signal/Updater/CSBestEffortUpdater.h
+++ b/OSBindings/Mac/Clock Signal/Updater/CSBestEffortUpdater.h
@@ -13,15 +13,13 @@
 
 @protocol CSBestEffortUpdaterDelegate <NSObject>
 
-- (void)bestEffortUpdater:(CSBestEffortUpdater *)bestEffortUpdater runForCycles:(NSUInteger)cycles didSkipPreviousUpdate:(BOOL)didSkipPreviousUpdate;
+- (void)bestEffortUpdater:(CSBestEffortUpdater *)bestEffortUpdater runForInterval:(NSTimeInterval)interval didSkipPreviousUpdate:(BOOL)didSkipPreviousUpdate;
 
 @end
 
 
 @interface CSBestEffortUpdater : NSObject
 
-@property (nonatomic, assign) double clockRate;
-@property (nonatomic, assign) BOOL runAsUnlimited;
 @property (nonatomic, weak) id<CSBestEffortUpdaterDelegate> delegate;
 
 - (void)update;

--- a/OSBindings/Mac/Clock Signal/Updater/CSBestEffortUpdater.mm
+++ b/OSBindings/Mac/Clock Signal/Updater/CSBestEffortUpdater.mm
@@ -14,12 +14,12 @@ struct UpdaterDelegate: public Concurrency::BestEffortUpdater::Delegate {
 	__weak id<CSBestEffortUpdaterDelegate> delegate;
 	NSLock *delegateLock;
 
-	void update(Concurrency::BestEffortUpdater *updater, int cycles, bool did_skip_previous_update) {
+	void update(Concurrency::BestEffortUpdater *updater, Time::Seconds cycles, bool did_skip_previous_update) {
 		[delegateLock lock];
 		__weak id<CSBestEffortUpdaterDelegate> delegateCopy = delegate;
 		[delegateLock unlock];
 
-		[delegateCopy bestEffortUpdater:nil runForCycles:(NSUInteger)cycles didSkipPreviousUpdate:did_skip_previous_update];
+		[delegateCopy bestEffortUpdater:nil runForInterval:(NSTimeInterval)cycles didSkipPreviousUpdate:did_skip_previous_update];
 	}
 };
 
@@ -49,11 +49,6 @@ struct UpdaterDelegate: public Concurrency::BestEffortUpdater::Delegate {
 
 - (void)flush {
 	_updater.flush();
-}
-
-- (void)setClockRate:(double)clockRate {
-	_clockRate = clockRate;
-	_updater.set_clock_rate(clockRate);
 }
 
 - (void)setDelegate:(id<CSBestEffortUpdaterDelegate>)delegate {

--- a/Outputs/Speaker/Speaker.hpp
+++ b/Outputs/Speaker/Speaker.hpp
@@ -28,6 +28,7 @@ class Speaker {
 
 		struct Delegate {
 			virtual void speaker_did_complete_samples(Speaker *speaker, const std::vector<int16_t> &buffer) = 0;
+			virtual void speaker_did_change_input_clock(Speaker *speaker) {}
 		};
 		virtual void set_delegate(Delegate *delegate) {
 			delegate_ = delegate;


### PR DESCRIPTION
As well as reducing per-target code (albeit just predictable wiring, as the BestEffortUpdater handled this), this simplifies the concept of a multimachine somewhat.