### PR TITLE
Corrects NTSC VIC raster register timing.

### DIFF
--- a/Analyser/Static/Commodore/StaticAnalyser.cpp
+++ b/Analyser/Static/Commodore/StaticAnalyser.cpp
@@ -149,6 +149,9 @@ void Analyser::Static::Commodore::AddTargets(const Media &media, std::vector<std
 			target->region = Analyser::Static::Commodore::Target::Region::American;
 		}
 
+		// Attach a 1540 if there are any disks here.
+		target->has_c1540 = !target->media.disks.empty();
+
 		destination.push_back(std::move(target));
 	}
 }

--- a/Components/6560/6560.cpp
+++ b/Components/6560/6560.cpp
@@ -106,7 +106,7 @@ static uint8_t noise_pattern[] = {
 // means every second cycle, etc.
 
 void AudioGenerator::get_samples(std::size_t number_of_samples, int16_t *target) {
-	for(unsigned int c = 0; c < number_of_samples; c++) {
+	for(unsigned int c = 0; c < number_of_samples; ++c) {
 		update(0, 2, shift);
 		update(1, 1, shift);
 		update(2, 0, shift);
@@ -124,7 +124,7 @@ void AudioGenerator::get_samples(std::size_t number_of_samples, int16_t *target)
 }
 
 void AudioGenerator::skip_samples(std::size_t number_of_samples) {
-	for(unsigned int c = 0; c < number_of_samples; c++) {
+	for(unsigned int c = 0; c < number_of_samples; ++c) {
 		update(0, 2, shift);
 		update(1, 1, shift);
 		update(2, 0, shift);

--- a/Machines/Commodore/Vic-20/Vic20.cpp
+++ b/Machines/Commodore/Vic-20/Vic20.cpp
@@ -374,7 +374,7 @@ class ConcreteMachine:
 				type_string(target->loading_command);
 			}
 
-			if(target->media.disks.size()) {
+			if(commodore_target_.has_c1540) {
 				// construct the 1540
 				c1540_.reset(new ::Commodore::C1540::Machine(Commodore::C1540::Machine::C1540));
 

--- a/Machines/Commodore/Vic-20/Vic20.cpp
+++ b/Machines/Commodore/Vic-20/Vic20.cpp
@@ -546,12 +546,12 @@ class ConcreteMachine:
 			if(isReadOperation(operation)) {
 				uint8_t result = processor_read_memory_map_[address >> 10] ? processor_read_memory_map_[address >> 10][address & 0x3ff] : 0xff;
 				if((address&0xfc00) == 0x9000) {
-					if((address&0xff00) == 0x9000) {
+					if(!(address&0x100)) {
 						update_video();
 						result &= mos6560_->get_register(address);
 					}
-					if((address&0xfc10) == 0x9010)	result &= user_port_via_.get_register(address);
-					if((address&0xfc20) == 0x9020)	result &= keyboard_via_.get_register(address);
+					if(address & 0x10) result &= user_port_via_.get_register(address);
+					if(address & 0x20) result &= keyboard_via_.get_register(address);
 				}
 				*value = result;
 
@@ -630,13 +630,17 @@ class ConcreteMachine:
 					update_video();
 					ram[address & 0x3ff] = *value;
 				}
+				// Anything between 0x9000 and 0x9400 is the IO area.
 				if((address&0xfc00) == 0x9000) {
-					if((address&0xff00) == 0x9000) {
+					// The VIC is selected by bit 8 = 0
+					if(!(address&0x100)) {
 						update_video();
 						mos6560_->set_register(address, *value);
 					}
-					if((address&0xfc10) == 0x9010)	user_port_via_.set_register(address, *value);
-					if((address&0xfc20) == 0x9020)	keyboard_via_.set_register(address, *value);
+					// The first VIA is selected by bit 4 = 1.
+					if(address & 0x10) user_port_via_.set_register(address, *value);
+					// The second VIA is selected by bit 5 = 1.
+					if(address & 0x20) keyboard_via_.set_register(address, *value);
 				}
 			}
 

--- a/OSBindings/Mac/Clock Signal/New Group/Base.lproj/MachinePicker.xib
+++ b/OSBindings/Mac/Clock Signal/New Group/Base.lproj/MachinePicker.xib
@@ -20,11 +20,11 @@
             <rect key="contentRect" x="196" y="240" width="600" height="165"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1366" height="768"/>
             <view key="contentView" wantsLayer="YES" id="EiT-Mj-1SZ">
-                <rect key="frame" x="0.0" y="0.0" width="600" height="205"/>
-                <autoresizingMask key="autoresizingMask"/>
+                <rect key="frame" x="0.0" y="0.0" width="600" height="165"/>
+                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                 <subviews>
                     <tabView translatesAutoresizingMaskIntoConstraints="NO" id="VUb-QG-x7c">
-                        <rect key="frame" x="13" y="51" width="574" height="140"/>
+                        <rect key="frame" x="13" y="51" width="574" height="100"/>
                         <font key="font" metaFont="system"/>
                         <tabViewItems>
                             <tabViewItem label="Acorn Electron" identifier="electron" id="muc-z9-Vqc">
@@ -334,6 +334,9 @@
                         <buttonCell key="cell" type="push" title="Choose" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="MnM-xo-4Qa">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
+                            <string key="keyEquivalent" base64-UTF8="YES">
+DQ
+</string>
                         </buttonCell>
                         <connections>
                             <action selector="createMachine:" target="-2" id="2wo-Zv-H4f"/>


### PR DESCRIPTION
Also ensures that pressing 'enter' can confirm the machine selector, and that the 'has C1540' box works for a Vic-20.

This deals with the "splits ... happen at the wrong place" part of #411 though "that changes of the colour registers on real h/w take effect one hires pixel" remains dangling.

As issues tangentially arising it also:
- reduces the diversity of luminances in the VIC; and
- makes the Mac's new machine dialogue respond to enter, and makes sure that the user's selection as to inclusion of a C1540 is honoured.