### PR TITLE
Substantially improves Disk II emulation, including write support

### DIFF
--- a/Components/DiskII/DiskII.cpp
+++ b/Components/DiskII/DiskII.cpp
@@ -25,6 +25,7 @@ DiskII::DiskII() :
 {
 	drives_[0].set_sleep_observer(this);
 	drives_[1].set_sleep_observer(this);
+	drives_[active_drive_].set_event_delegate(this);
 }
 
 void DiskII::set_control(Control control, bool on) {
@@ -138,6 +139,7 @@ void DiskII::set_controller_can_sleep() {
 }
 
 bool DiskII::is_write_protected() {
+return true;
 	return !!(stepper_mask_ & 2) | drives_[active_drive_].get_is_read_only();
 }
 

--- a/Components/DiskII/DiskII.cpp
+++ b/Components/DiskII/DiskII.cpp
@@ -75,9 +75,8 @@ void DiskII::select_drive(int drive) {
 void DiskII::run_for(const Cycles cycles) {
 	if(is_sleeping()) return;
 
-	int integer_cycles = cycles.as_int();
-
 	if(!controller_can_sleep_) {
+		int integer_cycles = cycles.as_int();
 		while(integer_cycles--) {
 			const int address = (state_ & 0xf0) | inputs_ | ((shift_register_&0x80) >> 6);
 			inputs_ |= input_flux;

--- a/Components/DiskII/DiskII.cpp
+++ b/Components/DiskII/DiskII.cpp
@@ -247,15 +247,19 @@ uint8_t DiskII::trigger_address(int address, uint8_t value) {
 		case 0xa:	select_drive(0);					break;
 		case 0xb:	select_drive(1);					break;
 
-		case 0xc:	return get_shift_register();
+		case 0xc:
+			inputs_ &= ~input_command;
+		break;
 		case 0xd:	set_data_register(value);			break;
 
 		case 0xe:
 			set_mode(Mode::Read);
-			return shift_register_;
+		break;
+//			return shift_register_;
 		case 0xf:	set_mode(Mode::Write);				break;
 	}
-	return 0xff;
+	set_controller_can_sleep();
+	return (address & 1) ? 0xff : shift_register_;
 }
 
 void DiskII::set_activity_observer(Activity::Observer *observer) {

--- a/Components/DiskII/DiskII.cpp
+++ b/Components/DiskII/DiskII.cpp
@@ -126,10 +126,19 @@ void DiskII::run_for(const Cycles cycles) {
 void DiskII::set_controller_can_sleep() {
 	// Permit the controller to sleep if it's in sense write protect mode, and the shift register
 	// has already filled with the result of shifting eight times.
+	bool controller_could_sleep = controller_can_sleep_;
 	controller_can_sleep_ =
-		(inputs_ == (input_command | input_flux)) &&
-		(shift_register_ == (is_write_protected() ? 0xff : 0x00));
-	if(is_sleeping()) update_sleep_observer();
+		(
+			(inputs_ == input_flux) &&
+			!motor_is_enabled_ &&
+			!shift_register_
+		) ||
+		(
+			(inputs_ == (input_command | input_flux)) &&
+			(shift_register_ == (is_write_protected() ? 0xff : 0x00))
+		);
+	if(controller_could_sleep != controller_can_sleep_)
+		update_sleep_observer();
 }
 
 bool DiskII::is_write_protected() {

--- a/Components/DiskII/DiskII.hpp
+++ b/Components/DiskII/DiskII.hpp
@@ -76,6 +76,7 @@ class DiskII:
 		bool drive_is_sleeping_[2];
 		bool controller_can_sleep_ = false;
 		int active_drive_ = 0;
+		bool motor_is_enabled_ = false;
 
 		void set_controller_can_sleep();
 };

--- a/Components/DiskII/DiskII.hpp
+++ b/Components/DiskII/DiskII.hpp
@@ -61,10 +61,14 @@ class DiskII:
 			the implementation as to the content of this ROM.
 			Including:
 
-				If Q6 is set and Q7 is reset, the controller is testing
+			*	If Q6 is set and Q7 is reset, the controller is testing
 				for write protect. If and when the shift register has
 				become full with the state of the write protect value,
 				no further processing is required.
+
+			*	If both Q6 and Q7 are reset, the drive motor is disabled,
+				and the shift register is all zeroes, no further processing
+				is required.
 		*/
 		void set_state_machine(const std::vector<uint8_t> &);
 

--- a/Components/DiskII/DiskII.hpp
+++ b/Components/DiskII/DiskII.hpp
@@ -65,7 +65,6 @@ class DiskII:
 		uint8_t state_ = 0;
 		uint8_t inputs_ = 0;
 		uint8_t shift_register_ = 0;
-		uint8_t data_register_ = 0;
 
 		int stepper_mask_ = 0;
 		int stepper_position_ = 0;

--- a/Components/DiskII/DiskII.hpp
+++ b/Components/DiskII/DiskII.hpp
@@ -33,15 +33,48 @@ class DiskII:
 	public:
 		DiskII();
 
-		void set_register(int address, uint8_t value);
-		uint8_t get_register(int address);
+		/// Sets the current external value of the data bus.
+		void set_data_input(uint8_t input);
 
+		/*!
+			Submits an access to address @c address.
+
+			@returns The 8-bit value loaded to the data bus by the DiskII if any;
+				@c DidNotLoad otherwise.
+		*/
+		int read_address(int address);
+
+		/*!
+			The value returned by @c read_address if accessing that address
+			didn't cause the disk II to place anything onto the bus.
+		*/
+		const int DidNotLoad = -1;
+
+		/// Advances the controller by @c cycles.
 		void run_for(const Cycles cycles);
+
+		/*!
+		 	Supplies the image of the state machine (i.e. P6) ROM,
+			which dictates how the Disk II will respond to input.
+
+			To reduce processing costs, some assumptions are made by
+			the implementation as to the content of this ROM.
+			Including:
+
+				If Q6 is set and Q7 is reset, the controller is testing
+				for write protect. If and when the shift register has
+				become full with the state of the write protect value,
+				no further processing is required.
+		*/
 		void set_state_machine(const std::vector<uint8_t> &);
 
+		/// Inserts @c disk into the drive @c drive.
 		void set_disk(const std::shared_ptr<Storage::Disk::Disk> &disk, int drive);
+
+		// As per Sleeper.
 		bool is_sleeping() override;
 
+		// The Disk II functions as a potential target for @c Activity::Sources.
 		void set_activity_observer(Activity::Observer *observer);
 
 	private:
@@ -55,8 +88,6 @@ class DiskII:
 		void set_control(Control control, bool on);
 		void set_mode(Mode mode);
 		void select_drive(int drive);
-		void set_data_register(uint8_t value);
-		uint8_t get_shift_register();
 
 		uint8_t trigger_address(int address, uint8_t value);
 		void process_event(const Storage::Disk::Track::Event &event) override;
@@ -78,6 +109,8 @@ class DiskII:
 		bool motor_is_enabled_ = false;
 
 		void set_controller_can_sleep();
+
+		uint8_t data_input_ = 0;
 };
 
 }

--- a/Concurrency/BestEffortUpdater.cpp
+++ b/Concurrency/BestEffortUpdater.cpp
@@ -39,7 +39,9 @@ void BestEffortUpdater::update() {
 				const int64_t integer_duration = std::chrono::duration_cast<std::chrono::nanoseconds>(elapsed).count();
 				if(integer_duration > 0) {
 					if(delegate_) {
-						const double duration = static_cast<double>(integer_duration) / 1e9;
+						// Cap running at 1/5th of a second, to avoid doing a huge amount of work after any
+						// brief system interruption.
+						const double duration = std::min(static_cast<double>(integer_duration) / 1e9, 0.2);
 						delegate_->update(this, duration, has_skipped_);
 					}
 					has_skipped_ = false;

--- a/Machines/AppleII/AppleII.cpp
+++ b/Machines/AppleII/AppleII.cpp
@@ -286,25 +286,29 @@ class ConcreteMachine:
 					break;
 				}
 
-				if(address >= 0xc100 && address < 0xc800) {
-					/*
-						Decode the area conventionally used by cards for ROMs:
-							0xCn00 to 0xCnff: card n.
-					*/
-					const size_t card_number = (address - 0xc100) >> 8;
-					if(cards_[card_number]) {
-						update_cards();
-						cards_[card_number]->perform_bus_operation(operation, address & 0xff, value);
+				if(address >= 0xc090 && address < 0xc800) {
+					size_t card_number = 0;
+					AppleII::Card::Select select = AppleII::Card::None;
+
+					if(address >= 0xc100) {
+						/*
+							Decode the area conventionally used by cards for ROMs:
+								0xCn00 to 0xCnff: card n.
+						*/
+						card_number = (address - 0xc100) >> 8;
+						select = AppleII::Card::Device;
+					} else {
+						/*
+							Decode the area conventionally used by cards for registers:
+								C0n0 to C0nF: card n - 8.
+						*/
+						card_number = (address - 0xc090) >> 4;
+						select = AppleII::Card::IO;
 					}
-				} else if(address >= 0xc090 && address < 0xc100) {
-					/*
-						Decode the area conventionally used by cards for registers:
-							C0n0 to C0nF: card n - 8.
-					*/
-					const size_t card_number = (address - 0xc090) >> 4;
+
 					if(cards_[card_number]) {
 						update_cards();
-						cards_[card_number]->perform_bus_operation(operation, 0x100 | (address&0xf), value);
+						cards_[card_number]->perform_bus_operation(select, isReadOperation(operation), address, value);
 					}
 				}
 			}

--- a/Machines/AppleII/Card.hpp
+++ b/Machines/AppleII/Card.hpp
@@ -15,16 +15,97 @@
 
 namespace AppleII {
 
+/*!
+	This provides a small subset of the interface offered to cards installed in
+	an Apple II, oriented pragmatically around the cards that are implemented.
+
+	The main underlying rule is as it is elsewhere in the emulator: no
+	_inaccurate_ simplifications — no provision of information that shouldn't
+	actually commute, no interfaces that say they do one thing but which by both
+	both sides are coupled through an unwritten understanding of abuse.
+
+	Special notes:
+
+		Devices that announce a select constraint, being interested in acting only
+		when their IO or Device select is active will receive just-in-time @c run_for
+		notifications, as well as being updated at the end of each of the Apple's
+		@c run_for periods, prior to a @c flush.
+
+		Devices that do not announce a select constraint will prima facie receive a
+		@c perform_bus_operation every cycle. They'll also receive a @c flush.
+		It is **highly** recomended that such devices also implement @c Sleeper
+		as they otherwise prima facie require a virtual method call every
+		single cycle.
+*/
 class Card {
 	public:
-		/*! Advances time by @c cycles, of which @c stretches were stretched. */
+		enum Select: int {
+			None	= 0,		// No select line is active
+			IO		= 1 << 0,	// IO select is active
+			Device	= 1 << 1,	// Device select is active
+		};
+
+		/*!
+			Advances time by @c cycles, of which @c stretches were stretched.
+
+			This is posted only to cards that announced a select constraint. Cards with
+			no constraints, that want to be informed of every machine cycle, will receive
+			a call to perform_bus_operation every cycle and should use that for time keeping.
+		*/
 		virtual void run_for(Cycles half_cycles, int stretches) {}
 
-		/*! Performs a bus operation; the card is implicitly selected. */
-		virtual void perform_bus_operation(CPU::MOS6502::BusOperation operation, uint16_t address, uint8_t *value) = 0;
+		/// Requests a flush of any pending audio or video output.
+		virtual void flush() {}
 
-		/*! Supplies a target for observers. */
+		/*!
+			Performs a bus operation.
+
+			@param select The state of the card's select lines: indicates whether the Apple II
+				thinks this card should respond as though this were an IO access, a Device access,
+				or it thinks that the card shouldn't respond.
+			@param is_read @c true if this is a read cycle; @c false otherwise.
+			@param address The current value of the address bus.
+			@param value A pointer to the value of the data bus, not accounting input from cards.
+				If this is a read cycle, the card is permitted to replace this value with the value
+				output by the card, if any. If this is a write cycle, the card should only read
+				this value.
+		*/
+		virtual void perform_bus_operation(Select select, bool is_read, uint16_t address, uint8_t *value) = 0;
+
+		/*!
+			Returns the type of bus selects this card is actually interested in.
+			As specified, the default is that cards will ask to receive perform_bus_operation
+			only when their select lines are active.
+
+			There's a substantial caveat here: cards that register to receive @c None
+			will receive a perform_bus_operation every cycle. To reduce the number of
+			virtual method calls, they **will not** receive run_for. run_for will propagate
+			only to cards that register for IO and/or Device accesses only.
+
+
+		*/
+		int get_select_constraints() {
+			return select_constraints_;
+		}
+
+		/*! Cards may supply a target for activity observation if desired. */
 		virtual void set_activity_observer(Activity::Observer *observer) {}
+
+		struct Delegate {
+			virtual void card_did_change_select_constraints(Card *card) = 0;
+		};
+		void set_delegate(Delegate *delegate) {
+			delegate_ = delegate;
+		}
+
+	protected:
+		int select_constraints_ = IO | Device;
+		Delegate *delegate_ = nullptr;
+		void set_select_constraints(int constraints) {
+			if(constraints == select_constraints_) return;
+			select_constraints_ = constraints;
+			if(delegate_) delegate_->card_did_change_select_constraints(this);
+		}
 };
 
 }

--- a/Machines/AppleII/DiskIICard.cpp
+++ b/Machines/AppleII/DiskIICard.cpp
@@ -20,6 +20,7 @@ DiskIICard::DiskIICard(const ROMMachine::ROMFetcher &rom_fetcher, bool is_16_sec
 	boot_ = std::move(*roms[0]);
 	diskii_.set_state_machine(*roms[1]);
 	set_select_constraints(None);
+	diskii_.set_sleep_observer(this);
 }
 
 void DiskIICard::perform_bus_operation(Select select, bool is_read, uint16_t address, uint8_t *value) {
@@ -40,6 +41,7 @@ void DiskIICard::perform_bus_operation(Select select, bool is_read, uint16_t add
 }
 
 void DiskIICard::run_for(Cycles cycles, int stretches) {
+	if(diskii_is_sleeping_) return;
 	diskii_.run_for(Cycles(cycles.as_int() * 2));
 }
 
@@ -49,4 +51,9 @@ void DiskIICard::set_disk(const std::shared_ptr<Storage::Disk::Disk> &disk, int 
 
 void DiskIICard::set_activity_observer(Activity::Observer *observer) {
 	diskii_.set_activity_observer(observer);
+}
+
+void DiskIICard::set_component_is_sleeping(Sleeper *component, bool is_sleeping) {
+	diskii_is_sleeping_ = is_sleeping;
+	set_select_constraints(is_sleeping ? (IO | Device) : 0);
 }

--- a/Machines/AppleII/DiskIICard.cpp
+++ b/Machines/AppleII/DiskIICard.cpp
@@ -25,10 +25,12 @@ void DiskIICard::perform_bus_operation(CPU::MOS6502::BusOperation operation, uin
 	if(address < 0x100) {
 		if(isReadOperation(operation)) *value = boot_[address];
 	} else {
+		// TODO: data input really shouldn't happen only upon a write.
+		diskii_.set_data_input(*value);
+		const int disk_value = diskii_.read_address(address);
 		if(isReadOperation(operation)) {
-			*value = diskii_.get_register(address);
-		} else {
-			diskii_.set_register(address, *value);
+			if(disk_value != diskii_.DidNotLoad)
+				*value = static_cast<uint8_t>(disk_value);
 		}
 	}
 }

--- a/Machines/AppleII/DiskIICard.hpp
+++ b/Machines/AppleII/DiskIICard.hpp
@@ -14,6 +14,7 @@
 
 #include "../../Components/DiskII/DiskII.hpp"
 #include "../../Storage/Disk/Disk.hpp"
+#include "../../ClockReceiver/Sleeper.hpp"
 
 #include <cstdint>
 #include <memory>
@@ -25,8 +26,9 @@ class DiskIICard: public Card {
 	public:
 		DiskIICard(const ROMMachine::ROMFetcher &rom_fetcher, bool is_16_sector);
 
-		void perform_bus_operation(CPU::MOS6502::BusOperation operation, uint16_t address, uint8_t *value) override;
+		void perform_bus_operation(Select select, bool is_read, uint16_t address, uint8_t *value) override;
 		void run_for(Cycles cycles, int stretches) override;
+
 		void set_activity_observer(Activity::Observer *observer) override;
 
 		void set_disk(const std::shared_ptr<Storage::Disk::Disk> &disk, int drive);

--- a/Machines/AppleII/DiskIICard.hpp
+++ b/Machines/AppleII/DiskIICard.hpp
@@ -22,7 +22,7 @@
 
 namespace AppleII {
 
-class DiskIICard: public Card {
+class DiskIICard: public Card, public Sleeper::SleepObserver {
 	public:
 		DiskIICard(const ROMMachine::ROMFetcher &rom_fetcher, bool is_16_sector);
 
@@ -34,8 +34,10 @@ class DiskIICard: public Card {
 		void set_disk(const std::shared_ptr<Storage::Disk::Disk> &disk, int drive);
 
 	private:
+		void set_component_is_sleeping(Sleeper *component, bool is_sleeping) override;
 		std::vector<uint8_t> boot_;
 		Apple::DiskII diskii_;
+		bool diskii_is_sleeping_ = false;
 };
 
 }

--- a/Storage/Disk/DiskImage/Formats/AppleDSK.cpp
+++ b/Storage/Disk/DiskImage/Formats/AppleDSK.cpp
@@ -102,7 +102,7 @@ void AppleDSK::set_tracks(const std::map<Track::Address, std::shared_ptr<Track>>
 		for(const auto &sector_pair: sector_map) {
 			size_t target_address = sector_pair.second.address.sector;
 			if(target_address != 15) {
-				target_address = (target_address * (is_prodos_ ? 2 : 13)) % 15;
+				target_address = (target_address * (is_prodos_ ? 8 : 7)) % 15;
 			}
 			memcpy(&track_contents[target_address*256], sector_pair.second.data.data(), bytes_per_sector);
 		}

--- a/Storage/Disk/DiskImage/Formats/AppleDSK.hpp
+++ b/Storage/Disk/DiskImage/Formats/AppleDSK.hpp
@@ -35,6 +35,9 @@ class AppleDSK: public DiskImage {
 		HeadPosition get_maximum_head_position() override;
 		std::shared_ptr<Track> get_track_at_position(Track::Address address) override;
 
+		// TEST!
+		bool get_is_read_only() override { return false; }
+
 	private:
 		Storage::FileHolder file_;
 		int sectors_per_track_ = 16;

--- a/Storage/Disk/DiskImage/Formats/AppleDSK.hpp
+++ b/Storage/Disk/DiskImage/Formats/AppleDSK.hpp
@@ -34,14 +34,15 @@ class AppleDSK: public DiskImage {
 		// implemented to satisfy @c Disk
 		HeadPosition get_maximum_head_position() override;
 		std::shared_ptr<Track> get_track_at_position(Track::Address address) override;
-
-		// TEST!
-		bool get_is_read_only() override { return false; }
+		void set_tracks(const std::map<Track::Address, std::shared_ptr<Track>> &tracks) override;
+		bool get_is_read_only() override;
 
 	private:
 		Storage::FileHolder file_;
 		int sectors_per_track_ = 16;
 		bool is_prodos_ = false;
+
+		long file_offset(Track::Address address);
 };
 
 }

--- a/Storage/Disk/DiskImage/Formats/AppleDSK.hpp
+++ b/Storage/Disk/DiskImage/Formats/AppleDSK.hpp
@@ -31,7 +31,7 @@ class AppleDSK: public DiskImage {
 		*/
 		AppleDSK(const std::string &file_name);
 
-		// implemented to satisfy @c Disk
+		// Implemented to satisfy @c Disk.
 		HeadPosition get_maximum_head_position() override;
 		std::shared_ptr<Track> get_track_at_position(Track::Address address) override;
 		void set_tracks(const std::map<Track::Address, std::shared_ptr<Track>> &tracks) override;
@@ -43,6 +43,7 @@ class AppleDSK: public DiskImage {
 		bool is_prodos_ = false;
 
 		long file_offset(Track::Address address);
+		size_t logical_sector_for_physical_sector(size_t physical);
 };
 
 }

--- a/Storage/Disk/Track/PCMPatchedTrack.cpp
+++ b/Storage/Disk/Track/PCMPatchedTrack.cpp
@@ -202,7 +202,8 @@ Storage::Time PCMPatchedTrack::seek_to(const Time &time_since_index_hole) {
 	else
 		current_time_ = underlying_track_->seek_to(time_since_index_hole);
 
-	assert(current_time_ <= time_since_index_hole);
+	// The assert below is disabled as it assumes too much about total precision.
+//	assert(current_time_ <= time_since_index_hole);
 	return current_time_;
 }
 

--- a/Storage/Disk/Track/PCMPatchedTrack.cpp
+++ b/Storage/Disk/Track/PCMPatchedTrack.cpp
@@ -27,7 +27,7 @@ PCMPatchedTrack::PCMPatchedTrack(const PCMPatchedTrack &original) {
 	active_period_ = periods_.begin();
 }
 
-Track *PCMPatchedTrack::clone() {
+Track *PCMPatchedTrack::clone() const {
 	return new PCMPatchedTrack(*this);
 }
 

--- a/Storage/Disk/Track/PCMPatchedTrack.hpp
+++ b/Storage/Disk/Track/PCMPatchedTrack.hpp
@@ -43,9 +43,9 @@ class PCMPatchedTrack: public Track {
 		void add_segment(const Time &start_time, const PCMSegment &segment, bool clamp_to_index_hole);
 
 		// To satisfy Storage::Disk::Track
-		Event get_next_event();
-		Time seek_to(const Time &time_since_index_hole);
-		Track *clone();
+		Event get_next_event() override;
+		Time seek_to(const Time &time_since_index_hole) override;
+		Track *clone() const override;
 
 	private:
 		std::shared_ptr<Track> underlying_track_;

--- a/Storage/Disk/Track/PCMTrack.cpp
+++ b/Storage/Disk/Track/PCMTrack.cpp
@@ -46,7 +46,7 @@ PCMTrack::PCMTrack(const PCMTrack &original) : PCMTrack() {
 	segment_event_sources_ = original.segment_event_sources_;
 }
 
-Track *PCMTrack::clone() {
+Track *PCMTrack::clone() const {
 	return new PCMTrack(*this);
 }
 

--- a/Storage/Disk/Track/PCMTrack.hpp
+++ b/Storage/Disk/Track/PCMTrack.hpp
@@ -42,9 +42,9 @@ class PCMTrack: public Track {
 		PCMTrack(const PCMTrack &);
 
 		// as per @c Track
-		Event get_next_event();
-		Time seek_to(const Time &time_since_index_hole);
-		Track *clone();
+		Event get_next_event() override;
+		Time seek_to(const Time &time_since_index_hole) override;
+		Track *clone() const override;
 
 	private:
 		// storage for the segments that describe this track

--- a/Storage/Disk/Track/Track.hpp
+++ b/Storage/Disk/Track/Track.hpp
@@ -114,7 +114,7 @@ class Track {
 		/*!
 			The virtual copy constructor pattern; returns a copy of the Track.
 		*/
-		virtual Track *clone() = 0;
+		virtual Track *clone() const = 0;
 };
 
 }

--- a/Storage/Disk/Track/TrackSerialiser.cpp
+++ b/Storage/Disk/Track/TrackSerialiser.cpp
@@ -8,11 +8,14 @@
 
 #include "TrackSerialiser.hpp"
 
+#include <memory>
+
 // TODO: if this is a PCMTrack with only one segment and that segment's bit rate is within tolerance,
 // just return a copy of that segment.
-Storage::Disk::PCMSegment Storage::Disk::track_serialisation(Track &track, Time length_of_a_bit) {
+Storage::Disk::PCMSegment Storage::Disk::track_serialisation(const Track &track, Time length_of_a_bit) {
 	unsigned int history_size = 16;
 	DigitalPhaseLockedLoop pll(100, history_size);
+	std::unique_ptr<Track> track_copy(track.clone());
 
 	struct ResultAccumulator: public DigitalPhaseLockedLoop::Delegate {
 		PCMSegment result;
@@ -29,12 +32,12 @@ Storage::Disk::PCMSegment Storage::Disk::track_serialisation(Track &track, Time 
 	length_multiplier.simplify();
 
 	// start at the index hole
-	track.seek_to(Time(0));
+	track_copy->seek_to(Time(0));
 
 	// grab events until the next index hole
 	Time time_error = Time(0);
 	while(true) {
-		Track::Event next_event = track.get_next_event();
+		Track::Event next_event = track_copy->get_next_event();
 		if(next_event.type == Track::Event::IndexHole) break;
 
 		Time extended_length = next_event.length * length_multiplier + time_error;
@@ -47,7 +50,7 @@ Storage::Disk::PCMSegment Storage::Disk::track_serialisation(Track &track, Time 
 		if(history_size) {
 			history_size--;
 			if(!history_size) {
-				track.seek_to(Time(0));
+				track_copy->seek_to(Time(0));
 				time_error.set_zero();
 				pll.set_delegate(&result_accumulator);
 			}

--- a/Storage/Disk/Track/TrackSerialiser.cpp
+++ b/Storage/Disk/Track/TrackSerialiser.cpp
@@ -43,7 +43,7 @@ Storage::Disk::PCMSegment Storage::Disk::track_serialisation(const Track &track,
 		Time extended_length = next_event.length * length_multiplier + time_error;
 		time_error.clock_rate = extended_length.clock_rate;
 		time_error.length = extended_length.length % extended_length.clock_rate;
-		pll.run_for(Cycles(extended_length.get<int>()));
+		pll.run_for(Cycles(static_cast<int>(extended_length.get<int64_t>())));
 		pll.add_pulse();
 
 		// If the PLL is now sufficiently primed, restart, and start recording bits this time.

--- a/Storage/Disk/Track/TrackSerialiser.hpp
+++ b/Storage/Disk/Track/TrackSerialiser.hpp
@@ -30,7 +30,7 @@ namespace Disk {
 	@param length_of_a_bit The expected length of a single bit, as a proportion of the
 	track length.
 */
-PCMSegment track_serialisation(Track &track, Time length_of_a_bit);
+PCMSegment track_serialisation(const Track &track, Time length_of_a_bit);
 
 }
 }

--- a/Storage/Disk/Track/UnformattedTrack.cpp
+++ b/Storage/Disk/Track/UnformattedTrack.cpp
@@ -21,6 +21,6 @@ Storage::Time UnformattedTrack::seek_to(const Time &time_since_index_hole) {
 	return Time(0);
 }
 
-Track *UnformattedTrack::clone() {
+Track *UnformattedTrack::clone() const {
 	return new UnformattedTrack;
 }

--- a/Storage/Disk/Track/UnformattedTrack.hpp
+++ b/Storage/Disk/Track/UnformattedTrack.hpp
@@ -19,9 +19,9 @@ namespace Disk {
 */
 class UnformattedTrack: public Track {
 	public:
-		Event get_next_event();
-		Time seek_to(const Time &time_since_index_hole);
-		Track *clone();
+		Event get_next_event() override;
+		Time seek_to(const Time &time_since_index_hole) override;
+		Track *clone() const override;
 };
 
 }


### PR DESCRIPTION
In particular:
* lowers the level of bus communications to allow the Disk II to read the data bus at any time and not load the bus at all even on a read cycle;
* fleshes out and corrects the state machine re: unused commands, the single shift register, the proper computation of is-read-only;
* implements some of the more subtle effects of various soft switches; and
* ensures only one drive is powered at a time.

As a side effect, it also enhances the Apple II's internal slot system.