### PR TITLE
Implements write support for WOZ files

### DIFF
--- a/NumberTheory/CRC.hpp
+++ b/NumberTheory/CRC.hpp
@@ -10,6 +10,7 @@
 #define CRC_hpp
 
 #include <cstdint>
+#include <vector>
 
 namespace CRC {
 
@@ -57,6 +58,19 @@ template <typename T, T reset_value, T xor_output, bool reflect_input, bool refl
 
 		/// Sets the current value of the CRC.
 		inline void set_value(T value) { value_ = value; }
+
+		/*!
+			A compound for:
+
+				reset()
+				[add all data from @c data]
+				get_value()
+		*/
+		T compute_crc(const std::vector<uint8_t> &data) {
+			reset();
+			for(const auto &byte: data) add(byte);
+			return get_value();
+		}
 
 	private:
 		static constexpr int multibyte_shift = (sizeof(T) * 8) - 8;

--- a/NumberTheory/CRC.hpp
+++ b/NumberTheory/CRC.hpp
@@ -11,45 +11,84 @@
 
 #include <cstdint>
 
-namespace NumberTheory {
+namespace CRC {
 
-/*! Provides a class capable of accumulating a CRC16 from source data. */
-class CRC16 {
+/*! Provides a class capable of generating a CRC from source data. */
+template <typename T, T reset_value, T xor_output, bool reflect_input, bool reflect_output> class Generator {
 	public:
 		/*!
 			Instantiates a CRC16 that will compute the CRC16 specified by the supplied
 			@c polynomial and @c reset_value.
 		*/
-		CRC16(uint16_t polynomial, uint16_t reset_value) :
-				reset_value_(reset_value), value_(reset_value) {
+		Generator(T polynomial): value_(reset_value) {
+			const T top_bit = T(~(T(~0) >> 1));
 			for(int c = 0; c < 256; c++) {
-				uint16_t shift_value = static_cast<uint16_t>(c << 8);
+				T shift_value = static_cast<T>(c << multibyte_shift);
 				for(int b = 0; b < 8; b++) {
-					uint16_t exclusive_or = (shift_value&0x8000) ? polynomial : 0x0000;
-					shift_value = static_cast<uint16_t>(shift_value << 1) ^ exclusive_or;
+					T exclusive_or = (shift_value&top_bit) ? polynomial : 0;
+					shift_value = static_cast<T>(shift_value << 1) ^ exclusive_or;
 				}
-				xor_table[c] = static_cast<uint16_t>(shift_value);
+				xor_table[c] = shift_value;
 			}
 		}
 
 		/// Resets the CRC to the reset value.
-		inline void reset() { value_ = reset_value_; }
+		void reset() { value_ = reset_value; }
 
 		/// Updates the CRC to include @c byte.
-		inline void add(uint8_t byte) {
-			value_ = static_cast<uint16_t>((value_ << 8) ^ xor_table[(value_ >> 8) ^ byte]);
+		void add(uint8_t byte) {
+			if(reflect_input) byte = reverse_byte(byte);
+			value_ = static_cast<T>((value_ << 8) ^ xor_table[(value_ >> multibyte_shift) ^ byte]);
 		}
 
 		/// @returns The current value of the CRC.
-		inline uint16_t get_value() const {	return value_; }
+		inline T get_value() const {
+			T result = value_^xor_output;
+			if(reflect_output) {
+				T reflected_output = 0;
+				for(std::size_t c = 0; c < sizeof(T); ++c) {
+					reflected_output = T(reflected_output << 8) | T(reverse_byte(result & 0xff));
+					result >>= 8;
+				}
+				return reflected_output;
+			}
+			return result;
+		}
 
 		/// Sets the current value of the CRC.
-		inline void set_value(uint16_t value) { value_ = value; }
+		inline void set_value(T value) { value_ = value; }
 
 	private:
-		const uint16_t reset_value_;
-		uint16_t xor_table[256];
-		uint16_t value_;
+		static constexpr int multibyte_shift = (sizeof(T) * 8) - 8;
+		T xor_table[256];
+		T value_;
+
+		constexpr uint8_t reverse_byte(uint8_t byte) const {
+			return
+				((byte & 0x80) ? 0x01 : 0x00) |
+				((byte & 0x40) ? 0x02 : 0x00) |
+				((byte & 0x20) ? 0x04 : 0x00) |
+				((byte & 0x10) ? 0x08 : 0x00) |
+				((byte & 0x08) ? 0x10 : 0x00) |
+				((byte & 0x04) ? 0x20 : 0x00) |
+				((byte & 0x02) ? 0x40 : 0x00) |
+				((byte & 0x01) ? 0x80 : 0x00);
+		}
+};
+
+/*!
+	Provides a generator of 16-bit CCITT CRCs, which amongst other uses are
+	those used by the FM and MFM disk encodings.
+*/
+struct CCITT: public Generator<uint16_t, 0xffff, 0x0000, false, false> {
+	CCITT() : Generator(0x1021) {}
+};
+
+/*!
+	Provides a generator of "standard 32-bit" CRCs.
+*/
+struct CRC32: public Generator<uint32_t, 0xffffffff, 0xffffffff, true, true> {
+	CRC32() : Generator(0x04c11db7) {}
 };
 
 }

--- a/OSBindings/Mac/Clock SignalTests/CRCTests.mm
+++ b/OSBindings/Mac/Clock SignalTests/CRCTests.mm
@@ -8,18 +8,14 @@
 
 #import <XCTest/XCTest.h>
 #include "CRC.hpp"
+#include <string>
 
 @interface CRCTests : XCTestCase
 @end
 
 @implementation CRCTests
 
-- (NumberTheory::CRC16)mfmCRCGenerator
-{
-	return NumberTheory::CRC16(0x1021, 0xffff);
-}
-
-- (uint16_t)crcOfData:(uint8_t *)data length:(size_t)length generator:(NumberTheory::CRC16 &)generator
+- (uint16_t)crcOfData:(uint8_t *)data length:(size_t)length generator:(CRC::CCITT &)generator
 {
 	generator.reset();
 	for(size_t c = 0; c < length; c++)
@@ -34,7 +30,7 @@
 		0xa1, 0xa1, 0xa1, 0xfe, 0x00, 0x00, 0x01, 0x01
 	};
 	uint16_t crc = 0xfa0c;
-	NumberTheory::CRC16 crcGenerator = self.mfmCRCGenerator;
+	CRC::CCITT crcGenerator;
 
 	uint16_t computedCRC = [self crcOfData:IDMark length:sizeof(IDMark) generator:crcGenerator];
 	XCTAssert(computedCRC == crc, @"Calculated CRC should have been %04x, was %04x", crc, computedCRC);
@@ -63,10 +59,26 @@
 		0x20, 0x20, 0x20, 0x20
 	};
 	uint16_t crc = 0x4de7;
-	NumberTheory::CRC16 crcGenerator = self.mfmCRCGenerator;
+	CRC::CCITT crcGenerator;
 
 	uint16_t computedCRC = [self crcOfData:sectorData length:sizeof(sectorData) generator:crcGenerator];
 	XCTAssert(computedCRC == crc, @"Calculated CRC should have been %04x, was %04x", crc, computedCRC);
+}
+
+- (void)testCCITTCheck {
+	CRC::CCITT crcGenerator;
+	for(auto c: std::string("123456789")) {
+		crcGenerator.add(c);
+	}
+	XCTAssertEqual(crcGenerator.get_value(), 0x29b1);
+}
+
+- (void)testCRC32Check {
+	CRC::CRC32 crcGenerator;
+	for(auto c: std::string("123456789")) {
+		crcGenerator.add(c);
+	}
+	XCTAssertEqual(crcGenerator.get_value(), 0xcbf43926);
 }
 
 @end

--- a/Storage/Disk/Controller/MFMDiskController.cpp
+++ b/Storage/Disk/Controller/MFMDiskController.cpp
@@ -14,8 +14,7 @@ using namespace Storage::Disk;
 
 MFMController::MFMController(Cycles clock_rate) :
 	Storage::Disk::Controller(clock_rate),
-	shifter_(&crc_generator_),
-	crc_generator_(0x1021, 0xffff) {
+	shifter_(&crc_generator_) {
 }
 
 void MFMController::process_index_hole() {
@@ -49,7 +48,7 @@ MFMController::Token MFMController::get_latest_token() {
 	return latest_token_;
 }
 
-NumberTheory::CRC16 &MFMController::get_crc_generator() {
+CRC::CCITT &MFMController::get_crc_generator() {
 	return crc_generator_;
 }
 

--- a/Storage/Disk/Controller/MFMDiskController.hpp
+++ b/Storage/Disk/Controller/MFMDiskController.hpp
@@ -72,7 +72,7 @@ class MFMController: public Controller {
 		Token get_latest_token();
 
 		/// @returns The controller's CRC generator. This is automatically fed during reading.
-		NumberTheory::CRC16 &get_crc_generator();
+		CRC::CCITT &get_crc_generator();
 
 		// Events
 		enum class Event: int {
@@ -163,7 +163,7 @@ class MFMController: public Controller {
 		int last_bit_;
 
 		// CRC generator
-		NumberTheory::CRC16 crc_generator_;
+		CRC::CCITT crc_generator_;
 };
 
 }

--- a/Storage/Disk/DiskImage/Formats/AppleDSK.cpp
+++ b/Storage/Disk/DiskImage/Formats/AppleDSK.cpp
@@ -111,6 +111,7 @@ void AppleDSK::set_tracks(const std::map<Track::Address, std::shared_ptr<Track>>
 		tracks_by_address[pair.first] = std::move(track_contents);
 	}
 
+	// Grab the file lock and write out the new tracks.
 	std::lock_guard<std::mutex> lock_guard(file_.get_file_access_mutex());
 	for(const auto &pair: tracks_by_address) {
 		file_.seek(file_offset(pair.first), SEEK_SET);

--- a/Storage/Disk/DiskImage/Formats/WOZ.cpp
+++ b/Storage/Disk/DiskImage/Formats/WOZ.cpp
@@ -9,7 +9,7 @@
 #include "WOZ.hpp"
 
 #include "../../Track/PCMTrack.hpp"
-#include "../../../../NumberTheory/CRC.hpp"
+#include "../../Track/TrackSerialiser.hpp"
 
 using namespace Storage::Disk;
 
@@ -22,15 +22,15 @@ WOZ::WOZ(const std::string &file_name) :
 	};
 	if(!file_.check_signature(signature, 8)) throw Error::InvalidFormat;
 
-	// Check the file's CRC32, instead of skipping it.
+	// Get the file's CRC32.
 	const uint32_t crc = file_.get32le();
-	CRC::CRC32 crc_generator;
-	while(true) {
-		uint8_t next = file_.get8();
-		if(file_.eof()) break;
-		crc_generator.add(next);
-	}
-	if(crc != crc_generator.get_value()) {
+
+	// Get the collection of all data that contributes to the CRC.
+	post_crc_contents_ = file_.read(static_cast<std::size_t>(file_.stats().st_size - 12));
+
+	// Test the CRC.
+	const uint32_t computed_crc = crc_generator.compute_crc(post_crc_contents_);
+	if(crc != computed_crc) {
 		 throw Error::InvalidFormat;
 	}
 
@@ -118,4 +118,37 @@ std::shared_ptr<Track> WOZ::get_track_at_position(Track::Address address) {
 	}
 
 	return std::shared_ptr<PCMTrack>(new PCMTrack(track_contents));
+}
+
+void WOZ::set_tracks(const std::map<Track::Address, std::shared_ptr<Track>> &tracks) {
+	for(const auto &pair: tracks) {
+		// Decode the track and store, patching into the post_crc_contents_.
+		auto segment = Storage::Disk::track_serialisation(*pair.second, Storage::Time(1, 50000));
+
+		auto offset = static_cast<std::size_t>(file_offset(pair.first) - 12);
+		memcpy(&post_crc_contents_[offset - 12], segment.data.data(), segment.number_of_bits >> 3);
+
+		// Write number of bytes and number of bits.
+		post_crc_contents_[offset + 6646] = static_cast<uint8_t>(segment.number_of_bits >> 3);
+		post_crc_contents_[offset + 6647] = static_cast<uint8_t>(segment.number_of_bits >> 11);
+		post_crc_contents_[offset + 6648] = static_cast<uint8_t>(segment.number_of_bits);
+		post_crc_contents_[offset + 6649] = static_cast<uint8_t>(segment.number_of_bits >> 8);
+
+		// Set no splice information now provided, since it's been lost if ever it was known.
+		post_crc_contents_[offset + 6650] = 0xff;
+		post_crc_contents_[offset + 6651] = 0xff;
+	}
+
+	// Calculate the new CRC.
+	const uint32_t crc = crc_generator.compute_crc(post_crc_contents_);
+
+	// Grab the file lock, then write the CRC, then just dump the entire file buffer.
+	std::lock_guard<std::mutex> lock_guard(file_.get_file_access_mutex());
+	file_.seek(8, SEEK_SET);
+	file_.put_le(crc);
+	file_.write(post_crc_contents_);
+}
+
+bool WOZ::get_is_read_only() {
+	return file_.get_is_known_read_only();
 }

--- a/Storage/Disk/DiskImage/Formats/WOZ.hpp
+++ b/Storage/Disk/DiskImage/Formats/WOZ.hpp
@@ -34,6 +34,15 @@ class WOZ: public DiskImage {
 		bool is_3_5_disk_ = false;
 		uint8_t track_map_[160];
 		long tracks_offset_ = -1;
+
+		/*!
+			Gets the in-file offset of a track.
+
+			@returns The offset within the file of the track at @c address or @c NoSuchTrack if
+				the track does not exit.
+		*/
+		long file_offset(Track::Address address);
+		constexpr static long NoSuchTrack = 0;	// This is definitely an offset a track can't lie at.
 };
 
 }

--- a/Storage/Disk/DiskImage/Formats/WOZ.hpp
+++ b/Storage/Disk/DiskImage/Formats/WOZ.hpp
@@ -11,6 +11,7 @@
 
 #include "../DiskImage.hpp"
 #include "../../../FileHolder.hpp"
+#include "../../../../NumberTheory/CRC.hpp"
 
 #include <string>
 
@@ -24,9 +25,12 @@ class WOZ: public DiskImage {
 	public:
 		WOZ(const std::string &file_name);
 
+		// Implemented to satisfy @c Disk.
 		HeadPosition get_maximum_head_position() override;
 		int get_head_count() override;
 		std::shared_ptr<Track> get_track_at_position(Track::Address address) override;
+		void set_tracks(const std::map<Track::Address, std::shared_ptr<Track>> &tracks) override;
+		bool get_is_read_only() override;
 
 	private:
 		Storage::FileHolder file_;
@@ -34,6 +38,9 @@ class WOZ: public DiskImage {
 		bool is_3_5_disk_ = false;
 		uint8_t track_map_[160];
 		long tracks_offset_ = -1;
+
+		std::vector<uint8_t> post_crc_contents_;
+		CRC::CRC32 crc_generator;
 
 		/*!
 			Gets the in-file offset of a track.

--- a/Storage/Disk/Encodings/MFM/Encoder.cpp
+++ b/Storage/Disk/Encodings/MFM/Encoder.cpp
@@ -187,7 +187,6 @@ template<class T> std::shared_ptr<Storage::Disk::Track>
 }
 
 Encoder::Encoder(std::vector<uint8_t> &target) :
-	crc_generator_(0x1021, 0xffff),
 	target_(target) {}
 
 void Encoder::output_short(uint16_t value) {

--- a/Storage/Disk/Encodings/MFM/Encoder.hpp
+++ b/Storage/Disk/Encodings/MFM/Encoder.hpp
@@ -56,7 +56,7 @@ class Encoder {
 		void add_crc(bool incorrectly);
 
 	protected:
-		NumberTheory::CRC16 crc_generator_;
+		CRC::CCITT crc_generator_;
 
 	private:
 		std::vector<uint8_t> &target_;

--- a/Storage/Disk/Encodings/MFM/Shifter.cpp
+++ b/Storage/Disk/Encodings/MFM/Shifter.cpp
@@ -11,8 +11,8 @@
 
 using namespace Storage::Encodings::MFM;
 
-Shifter::Shifter() : owned_crc_generator_(new NumberTheory::CRC16(0x1021, 0xffff)), crc_generator_(owned_crc_generator_.get()) {}
-Shifter::Shifter(NumberTheory::CRC16 *crc_generator) : crc_generator_(crc_generator) {}
+Shifter::Shifter() : owned_crc_generator_(new CRC::CCITT()), crc_generator_(owned_crc_generator_.get()) {}
+Shifter::Shifter(CRC::CCITT *crc_generator) : crc_generator_(crc_generator) {}
 
 void Shifter::set_is_double_density(bool is_double_density) {
 	is_double_density_ = is_double_density;

--- a/Storage/Disk/Encodings/MFM/Shifter.hpp
+++ b/Storage/Disk/Encodings/MFM/Shifter.hpp
@@ -44,7 +44,7 @@ namespace MFM {
 class Shifter {
 	public:
 		Shifter();
-		Shifter(NumberTheory::CRC16 *crc_generator);
+		Shifter(CRC::CCITT *crc_generator);
 
 		void set_is_double_density(bool is_double_density);
 		void set_should_obey_syncs(bool should_obey_syncs);
@@ -57,7 +57,7 @@ class Shifter {
 		Token get_token() const {
 			return token_;
 		}
-		NumberTheory::CRC16 &get_crc_generator() {
+		CRC::CCITT &get_crc_generator() {
 			return *crc_generator_;
 		}
 
@@ -72,8 +72,8 @@ class Shifter {
 		// input configuration
 		bool is_double_density_ = false;
 
-		std::unique_ptr<NumberTheory::CRC16> owned_crc_generator_;
-		NumberTheory::CRC16 *crc_generator_;
+		std::unique_ptr<CRC::CCITT> owned_crc_generator_;
+		CRC::CCITT *crc_generator_;
 };
 
 }

--- a/Storage/FileHolder.hpp
+++ b/Storage/FileHolder.hpp
@@ -53,6 +53,28 @@ class FileHolder final {
 		uint32_t get32le();
 
 		/*!
+			Writes @c value using successive @c put8s, in little endian order.
+		*/
+		template <typename T> void put_le(T value) {
+			auto bytes = sizeof(T);
+			while(bytes--) {
+				put8(value&0xff);
+				value >>= 8;
+			}
+		}
+
+		/*!
+			Writes @c value using successive @c put8s, in big endian order.
+		*/
+		template <typename T> void put_be(T value) {
+			auto shift = sizeof(T) * 8;
+			while(shift) {
+				shift -= 8;
+				put8((value >> shift)&0xff);
+			}
+		}
+
+		/*!
 			Performs @c get8 four times on @c file, casting each result to a @c uint32_t
 			and returning the four assembled in big endian order.
 		*/

--- a/Storage/Tape/Parsers/Acorn.cpp
+++ b/Storage/Tape/Parsers/Acorn.cpp
@@ -14,7 +14,7 @@ namespace {
 const int PLLClockRate = 1920000;
 }
 
-Parser::Parser() : crc_(0x1021, 0x0000) {
+Parser::Parser() {
 	shifter_.set_delegate(this);
 }
 

--- a/Storage/Tape/Parsers/Acorn.hpp
+++ b/Storage/Tape/Parsers/Acorn.hpp
@@ -63,7 +63,7 @@ class Parser: public Storage::Tape::Parser<SymbolType>, public Shifter::Delegate
 
 	private:
 		bool did_update_shifter(int new_value, int length);
-		NumberTheory::CRC16 crc_;
+		CRC::CCITT crc_;
 		Shifter shifter_;
 };
 


### PR DESCRIPTION
Since WOZ files include a CRC32 to verify file contents, this also generalises what was `CRC16` into a generic templated `CRC::Generator` from which both the 16-bit CCITT generator used by FM/MFM disks and Acorn tapes, and the CRC32 used for WOZ file verification can be instantiated.