### PR TITLE
Corrects NTSC Q phase

### DIFF
--- a/Components/6560/6560.hpp
+++ b/Components/6560/6560.hpp
@@ -69,7 +69,7 @@ template <class BusHandler> class MOS6560 {
 				speaker_(audio_generator_)
 		{
 			crt_->set_svideo_sampling_function(
-				"vec2 svideo_sample(usampler2D texID, vec2 coordinate, vec2 iCoordinate, float phase)"
+				"vec2 svideo_sample(usampler2D texID, vec2 coordinate, vec2 iCoordinate, float phase, float amplitude)"
 				"{"
 					"vec2 yc = texture(texID, coordinate).rg / vec2(255.0);"
 
@@ -125,10 +125,10 @@ template <class BusHandler> class MOS6560 {
 				19,		86,		123,	59,
 			};
 			const uint8_t ntsc_chrominances[16] = {
-				255,	255,	7,		71,
-				25,		86,		48,		112,
-				0,		119,	7,		71,
-				25,		86,		48,		112,
+				255,	255,	121,	57,
+				103,	42,		80,		16,
+				0,		9,		121,	57,
+				103,	42,		80,		16,
 			};
 			const uint8_t *chrominances;
 			Outputs::CRT::DisplayType display_type;

--- a/Components/AY38910/AY38910.hpp
+++ b/Components/AY38910/AY38910.hpp
@@ -92,7 +92,7 @@ class AY38910: public ::Outputs::Speaker::SampleSource {
 		Concurrency::DeferringAsyncTaskQueue &task_queue_;
 
 		int selected_register_ = 0;
-		uint8_t registers_[16];
+		uint8_t registers_[16] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 		uint8_t output_registers_[16] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 		uint8_t port_inputs_[2];
 

--- a/Components/DiskII/DiskII.cpp
+++ b/Components/DiskII/DiskII.cpp
@@ -124,9 +124,9 @@ void DiskII::decide_clocking_preference() {
 	// If in read mode, clocking is either:
 	//
 	//	just-in-time, if drives are running or the shift register has any 1s in it or a flux event hasn't yet passed; or
-	//	none, given that drives are not running, the shift register has already emptied and there's no flux about to fire.
+	//	none, given that drives are not running, the shift register has already emptied and there's no flux about to be received.
 	if(!(inputs_ & ~input_flux)) {
-		clocking_preference_ = (!motor_is_enabled_ && !shift_register_ && !(inputs_&input_flux)) ? ClockingHint::Preference::None : ClockingHint::Preference::JustInTime;
+		clocking_preference_ = (!motor_is_enabled_ && !shift_register_ && (inputs_&input_flux)) ? ClockingHint::Preference::None : ClockingHint::Preference::JustInTime;
 	}
 
 	// If in writing mode, clocking is real time.

--- a/Machines/AppleII/Video.cpp
+++ b/Machines/AppleII/Video.cpp
@@ -57,19 +57,4 @@ void VideoBase::set_high_resolution() {
 
 void VideoBase::set_character_rom(const std::vector<uint8_t> &character_rom) {
 	character_rom_ = character_rom;
-
-	// Bytes in the character ROM are stored in reverse bit order. Reverse them
-	// ahead of time so as to be able to use the same scaling table as for
-	// high-resolution graphics.
-	for(auto &byte : character_rom_) {
-		byte =
-			((byte & 0x40) ? 0x01 : 0x00) |
-			((byte & 0x20) ? 0x02 : 0x00) |
-			((byte & 0x10) ? 0x04 : 0x00) |
-			((byte & 0x08) ? 0x08 : 0x00) |
-			((byte & 0x04) ? 0x10 : 0x00) |
-			((byte & 0x02) ? 0x20 : 0x00) |
-			((byte & 0x01) ? 0x40 : 0x00) |
-			(byte & 0x80);
-	}
 }

--- a/Machines/AppleII/Video.cpp
+++ b/Machines/AppleII/Video.cpp
@@ -27,7 +27,7 @@ VideoBase::VideoBase() :
 	crt_->set_composite_sampling_function(
 		"float composite_sample(usampler2D sampler, vec2 coordinate, vec2 icoordinate, float phase, float amplitude)"
 		"{"
-			"uint texValue = texture(sampler, coordinate).r;"
+			"uint texValue = texture(sampler, vec2(icoordinate.x / (7*textureSize(sampler, 0).x), coordinate.y)).r;"
 			"texValue >>= int(icoordinate.x) % 7;"
 			"return float(texValue & 1u);"
 		"}");

--- a/Machines/AppleII/Video.hpp
+++ b/Machines/AppleII/Video.hpp
@@ -27,7 +27,6 @@ class BusHandler {
 class VideoBase {
 	public:
 		VideoBase();
-		static void setup_tables();
 
 		/// @returns The CRT this video feed is feeding.
 		Outputs::CRT::CRT *get_crt();
@@ -46,9 +45,12 @@ class VideoBase {
 	protected:
 		std::unique_ptr<Outputs::CRT::CRT> crt_;
 
+		uint8_t *pixel_pointer_ = nullptr;
+		int pixel_pointer_column_ = 0;
+		bool pixels_are_high_density_ = false;
+
 		int video_page_ = 0;
 		int row_ = 0, column_ = 0, flash_ = 0;
-		uint16_t *pixel_pointer_ = nullptr;
 		std::vector<uint8_t> character_rom_;
 
 		enum class GraphicsMode {
@@ -58,10 +60,7 @@ class VideoBase {
 		} graphics_mode_ = GraphicsMode::LowRes;
 		bool use_graphics_mode_ = false;
 		bool mixed_mode_ = false;
-		uint16_t graphics_carry_ = 0;
-
-		static uint16_t scaled_byte[256];
-		static uint16_t low_resolution_patterns[2][16];
+		uint8_t graphics_carry_ = 0;
 };
 
 template <class BusHandler> class Video: public VideoBase {
@@ -91,7 +90,7 @@ template <class BusHandler> class Video: public VideoBase {
 				const int cycles_this_line = std::min(65 - column_, int_cycles);
 
 				if(row_ >= first_sync_line && row_ < first_sync_line + 3) {
-					crt_->output_sync(static_cast<unsigned int>(cycles_this_line) * 7);
+					crt_->output_sync(static_cast<unsigned int>(cycles_this_line) * 14);
 				} else {
 					const int ending_column = column_ + cycles_this_line;
 					const GraphicsMode line_mode = use_graphics_mode_ ? graphics_mode_ : GraphicsMode::Text;
@@ -101,8 +100,13 @@ template <class BusHandler> class Video: public VideoBase {
 					// of line 192.
 					if(column_ < 40) {
 						if(row_ < 192) {
-							if(!column_) {
-								pixel_pointer_ = reinterpret_cast<uint16_t *>(crt_->allocate_write_area(80, 2));
+							GraphicsMode pixel_mode = (!mixed_mode_ || row_ < 160) ? line_mode : GraphicsMode::Text;
+							bool requires_high_density = pixel_mode != GraphicsMode::Text;
+							if(!column_ || requires_high_density != pixels_are_high_density_) {
+								if(column_) output_data_to_column(column_);
+								pixel_pointer_ = crt_->allocate_write_area(561);
+								pixel_pointer_column_ = column_;
+								pixels_are_high_density_ = requires_high_density;
 								graphics_carry_ = 0;
 							}
 
@@ -111,10 +115,7 @@ template <class BusHandler> class Video: public VideoBase {
 							const int pixel_row = row_ & 7;
 							const uint16_t row_address = static_cast<uint16_t>((character_row >> 3) * 40 + ((character_row&7) << 7));
 							const uint16_t text_address = static_cast<uint16_t>(((video_page_+1) * 0x400) + row_address);
-							const uint16_t graphics_address = static_cast<uint16_t>(((video_page_+1) * 0x2000) + row_address + ((pixel_row&7) << 10));
-							const int row_shift = (row_&4);
 
-							GraphicsMode pixel_mode = (!mixed_mode_ || row_ < 160) ? line_mode : GraphicsMode::Text;
 							switch(pixel_mode) {
 								case GraphicsMode::Text: {
 									const uint8_t inverses[] = {
@@ -128,35 +129,71 @@ template <class BusHandler> class Video: public VideoBase {
 										const std::size_t character_address = static_cast<std::size_t>(((character & 0x3f) << 3) + pixel_row);
 
 										const uint8_t character_pattern = character_rom_[character_address] ^ inverses[character >> 6];
-										pixel_pointer_[c] = scaled_byte[character_pattern & 0x7f];
+
+										int mask = 0x01;
+										for(int p = 0; p < 7; ++p) {
+											pixel_pointer_[p] = character_pattern & mask;
+											mask <<= 1;
+										}
+										graphics_carry_ = character_pattern & 0x40;
+										pixel_pointer_ += 7;
 									}
 								} break;
 
-								case GraphicsMode::LowRes:
+								case GraphicsMode::LowRes: {
+									const int row_shift = (row_&4);
 									for(int c = column_; c < pixel_end; ++c) {
-										const uint8_t character = bus_handler_.perform_read(static_cast<uint16_t>(text_address + c));
-										pixel_pointer_[c] = low_resolution_patterns[c&1][(character >> row_shift)&0xf];
-									}
-								break;
+										const uint8_t nibble = (bus_handler_.perform_read(static_cast<uint16_t>(text_address + c)) >> row_shift) & 0x0f;
 
-								case GraphicsMode::HighRes:
+										if(c&1) {
+											pixel_pointer_[0] = pixel_pointer_[4] = pixel_pointer_[8] = pixel_pointer_[12] = nibble & 4;
+											pixel_pointer_[1] = pixel_pointer_[5] = pixel_pointer_[9] = pixel_pointer_[13] = nibble & 8;
+											pixel_pointer_[2] = pixel_pointer_[6] = pixel_pointer_[10] = nibble & 1;
+											pixel_pointer_[3] = pixel_pointer_[7] = pixel_pointer_[11] = nibble & 2;
+											graphics_carry_ = nibble & 8;
+										} else {
+											pixel_pointer_[0] = pixel_pointer_[4] = pixel_pointer_[8] = pixel_pointer_[12] = nibble & 1;
+											pixel_pointer_[1] = pixel_pointer_[5] = pixel_pointer_[9] = pixel_pointer_[13] = nibble & 2;
+											pixel_pointer_[2] = pixel_pointer_[6] = pixel_pointer_[10] = nibble & 4;
+											pixel_pointer_[3] = pixel_pointer_[7] = pixel_pointer_[11] = nibble & 8;
+											graphics_carry_ = nibble & 2;
+										}
+										pixel_pointer_ += 14;
+									}
+								} break;
+
+								case GraphicsMode::HighRes: {
+									const uint16_t graphics_address = static_cast<uint16_t>(((video_page_+1) * 0x2000) + row_address + ((pixel_row&7) << 10));
 									for(int c = column_; c < pixel_end; ++c) {
 										const uint8_t graphic = bus_handler_.perform_read(static_cast<uint16_t>(graphics_address + c));
-										pixel_pointer_[c] = scaled_byte[graphic];
+
 										if(graphic & 0x80) {
-											reinterpret_cast<uint8_t *>(&pixel_pointer_[c])[0] |= (graphics_carry_&1);
+											pixel_pointer_[0] = graphics_carry_;
+											pixel_pointer_++;
 										}
-										graphics_carry_ = graphic >> 6;
+										int mask = 0x01;
+										for(int p = 0; p < 12; p += 2) {
+											pixel_pointer_[p] = graphic & mask;
+											pixel_pointer_[p+1] = graphic & mask;
+											mask <<= 1;
+										}
+										pixel_pointer_[12] = graphic & 0x40;
+										pixel_pointer_ += 13;
+										if(!(graphic & 0x80)) {
+											pixel_pointer_[0] = graphic & 0x40;
+											pixel_pointer_++;
+										}
+										graphics_carry_ = graphic & 0x40;
 									}
-								break;
+								} break;
 							}
 
 							if(ending_column >= 40) {
-								output_data(80);
+								output_data_to_column(40);
 							}
 						} else {
 							if(ending_column >= 40) {
-								crt_->output_blank(280);
+								crt_->output_blank(560);
 							}
 						}
 					}
@@ -169,13 +206,13 @@ template <class BusHandler> class Video: public VideoBase {
 					const int first_blank_start = std::max(40, column_);
 					const int first_blank_end = std::min(first_sync_column, ending_column);
 					if(first_blank_end > first_blank_start) {
-						crt_->output_blank(static_cast<unsigned int>(first_blank_end - first_blank_start) * 7);
+						crt_->output_blank(static_cast<unsigned int>(first_blank_end - first_blank_start) * 14);
 					}
 
 					const int sync_start = std::max(first_sync_column, column_);
 					const int sync_end = std::min(first_sync_column + 4, ending_column);
 					if(sync_end > sync_start) {
-						crt_->output_sync(static_cast<unsigned int>(sync_end - sync_start) * 7);
+						crt_->output_sync(static_cast<unsigned int>(sync_end - sync_start) * 14);
 					}
 
 					int second_blank_start;
@@ -183,7 +220,7 @@ template <class BusHandler> class Video: public VideoBase {
 						const int colour_burst_start = std::max(first_sync_column + 4, column_);
 						const int colour_burst_end = std::min(first_sync_column + 7, ending_column);
 						if(colour_burst_end > colour_burst_start) {
-							crt_->output_default_colour_burst(static_cast<unsigned int>(colour_burst_end - colour_burst_start) * 7);
+							crt_->output_default_colour_burst(static_cast<unsigned int>(colour_burst_end - colour_burst_start) * 14);
 						}
 
 						second_blank_start = std::max(first_sync_column + 7, column_);
@@ -192,7 +229,7 @@ template <class BusHandler> class Video: public VideoBase {
 					}
 
 					if(ending_column > second_blank_start) {
-						crt_->output_blank(static_cast<unsigned int>(ending_column - second_blank_start) * 7);
+						crt_->output_blank(static_cast<unsigned int>(ending_column - second_blank_start) * 14);
 					}
 				}
 
@@ -204,7 +241,7 @@ template <class BusHandler> class Video: public VideoBase {
 
 					// Add an extra half a colour cycle of blank; this isn't counted in the run_for
 					// count explicitly but is promised.
-					crt_->output_blank(1);
+					crt_->output_blank(2);
 				}
 			}
 		}
@@ -261,8 +298,10 @@ template <class BusHandler> class Video: public VideoBase {
 
 		const int flash_length = 8406;
 		BusHandler &bus_handler_;
-		void output_data(unsigned int length) {
-			crt_->output_data((length*7)/2, length);
+		void output_data_to_column(int column) {
+			int length = column - pixel_pointer_column_;
+			crt_->output_data(static_cast<unsigned int>(length*14), static_cast<unsigned int>(length * (pixels_are_high_density_ ? 14 : 7)));
+			pixel_pointer_ = nullptr;
 		}
 };
 

--- a/Machines/AppleII/Video.hpp
+++ b/Machines/AppleII/Video.hpp
@@ -144,15 +144,15 @@ template <class BusHandler> class Video: public VideoBase {
 										const uint8_t graphic = bus_handler_.perform_read(static_cast<uint16_t>(graphics_address + c));
 										pixel_pointer_[c] = scaled_byte[graphic];
 										if(graphic & 0x80) {
-											reinterpret_cast<uint8_t *>(&pixel_pointer_[c])[0] |= graphics_carry_;
+											reinterpret_cast<uint8_t *>(&pixel_pointer_[c])[0] |= (graphics_carry_&1);
 										}
-										graphics_carry_ = (graphic >> 6) & 1;
+										graphics_carry_ = graphic >> 6;
 									}
 								break;
 							}
 
 							if(ending_column >= 40) {
-								crt_->output_data(280, 80);
+								output_data(80);
 							}
 						} else {
 							if(ending_column >= 40) {
@@ -261,6 +261,9 @@ template <class BusHandler> class Video: public VideoBase {
 
 		const int flash_length = 8406;
 		BusHandler &bus_handler_;
+		void output_data(unsigned int length) {
+			crt_->output_data((length*7)/2, length);
+		}
 };
 
 }

--- a/Machines/Atari2600/TIA.cpp
+++ b/Machines/Atari2600/TIA.cpp
@@ -124,19 +124,19 @@ void TIA::set_output_mode(Atari2600::TIA::OutputMode output_mode) {
 
 	if(output_mode == OutputMode::NTSC) {
 		crt_->set_svideo_sampling_function(
-			"vec2 svideo_sample(usampler2D texID, vec2 coordinate, vec2 iCoordinate, float phase)"
+			"vec2 svideo_sample(usampler2D texID, vec2 coordinate, vec2 iCoordinate, float phase, float amplitude)"
 			"{"
 				"uint c = texture(texID, coordinate).r;"
 				"uint y = c & 14u;"
 				"uint iPhase = (c >> 4);"
 
 				"float phaseOffset = 6.283185308 * float(iPhase) / 13.0 + 5.074880441076923;"
-				"return vec2(float(y) / 14.0, step(1, iPhase) * cos(phase + phaseOffset));"
+				"return vec2(float(y) / 14.0, step(1, iPhase) * cos(phase - phaseOffset));"
 			"}");
 		display_type = Outputs::CRT::DisplayType::NTSC60;
 	} else {
 		crt_->set_svideo_sampling_function(
-			"vec2 svideo_sample(usampler2D texID, vec2 coordinate, vec2 iCoordinate, float phase)"
+			"vec2 svideo_sample(usampler2D texID, vec2 coordinate, vec2 iCoordinate, float phase, float amplitude)"
 			"{"
 				"uint c = texture(texID, coordinate).r;"
 				"uint y = c & 14u;"

--- a/Machines/ZX8081/Video.hpp
+++ b/Machines/ZX8081/Video.hpp
@@ -45,7 +45,7 @@ class Video {
 		bool sync_ = false;
 		uint8_t *line_data_ = nullptr;
 		uint8_t *line_data_pointer_ = nullptr;
-		unsigned int cycles_since_update_ = 0;
+		HalfCycles time_since_update_ = 0;
 		std::unique_ptr<Outputs::CRT::CRT> crt_;
 
 		void flush(bool next_sync);

--- a/Machines/ZX8081/ZX8081.cpp
+++ b/Machines/ZX8081/ZX8081.cpp
@@ -157,7 +157,7 @@ template<bool is_zx81> class ConcreteMachine:
 
 					// The below emulates the ZonX AY expansion device.
 					if(is_zx81) {
-						if((address&0xef) == 0x0f) {
+						if((address&0xef) == 0xcf) {
 							value &= ay_read_data();
 						}
 					}

--- a/Outputs/CRT/CRT.cpp
+++ b/Outputs/CRT/CRT.cpp
@@ -170,7 +170,9 @@ void CRT::advance_cycles(unsigned int number_of_cycles, bool hsync_requested, bo
 			// outside of the locked region
 			source_output_position_x1() = static_cast<uint16_t>(horizontal_flywheel_->get_current_output_position());
 			source_phase() = colour_burst_phase_;
-			source_amplitude() = colour_burst_amplitude_;
+
+			// TODO: determine what the PAL phase-shift machines actually do re: the swinging burst.
+			source_amplitude() = phase_alternates_ ? 128 - colour_burst_amplitude_ : 128 + colour_burst_amplitude_;
 		}
 
 		// decrement the number of cycles left to run for and increment the
@@ -368,7 +370,7 @@ void CRT::output_colour_burst(unsigned int number_of_cycles, uint8_t phase, uint
 	scan.type = Scan::Type::ColourBurst;
 	scan.number_of_cycles = number_of_cycles;
 	scan.phase = phase;
-	scan.amplitude = amplitude;
+	scan.amplitude = amplitude >> 1;
 	output_scan(&scan);
 }
 

--- a/Outputs/CRT/CRT.hpp
+++ b/Outputs/CRT/CRT.hpp
@@ -332,10 +332,10 @@ class CRT {
 			output mode will be applied.
 
 			@param shader A GLSL fragment including a function with the signature
-			`vec2 svideo_sample(usampler2D texID, vec2 coordinate, vec2 iCoordinate, float phase)`
+			`vec2 svideo_sample(usampler2D texID, vec2 coordinate, vec2 iCoordinate, float phase, float amplitude)`
 			that evaluates to the s-video signal level, luminance as the first component and chrominance
 			as the second, as a function of a source buffer, sampling location and colour
-			carrier phase.
+			carrier phase; amplitude is supplied for its sign.
 		*/
 		inline void set_svideo_sampling_function(const std::string &shader) {
 			enqueue_openGL_function([shader, this] {


### PR DESCRIPTION
As per #399 the Apple II was originally selected as a candidate for addition because it produces a direct, fully-defined PCM video stream. In many other machines the exact manner of colour signal generation is either undefined or implicitly dependent upon analogue components. I therefore hoped it would confirm or deny my NTSC implementation.

Despite initially believing it confirmed my implementation based on low-resolution mode, it turns out I had still made coupled errors on both sides of the NTSC chasm. My low-resolution mode was shifting colour values in reverse.

High-resolution mode shifts correctly, but had acquired an odd effect: two out of four colours (not counting black and white) were the wrong way around. I should have noticed, but didn't.

Regardless, diagnosing that revealed the latent error that I was treating the Q component of NTSC colour as having the opposite phase. Think of the way that PAL advances on NTSC by alternates phases: my NTSC was using the alternate rather than the plain.

This pull request resolves that, plus the coupled errors in encoding.

It also addresses precision dependencies in the GLSL byte decoders for the Apple II and the ZX80/81. A better job could probably be done, but this'll do for now.

Therefore it resolves #457 and the graphical component of #454. It actually entirely resolves #454 as the input issue was a one-line fix that became clear while I was testing the graphical side.