### PR TITLE
Corrects left-border handling on the CPC

### DIFF
--- a/Machines/AmstradCPC/AmstradCPC.hpp
+++ b/Machines/AmstradCPC/AmstradCPC.hpp
@@ -9,7 +9,16 @@
 #ifndef AmstradCPC_hpp
 #define AmstradCPC_hpp
 
+#include "../../Configurable/Configurable.hpp"
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
 namespace AmstradCPC {
+
+/// @returns The options available for an Amstrad CPC.
+std::vector<std::unique_ptr<Configurable::Option>> get_options();
 
 /*!
 	Models an Amstrad CPC.

--- a/Machines/Electron/Electron.cpp
+++ b/Machines/Electron/Electron.cpp
@@ -480,6 +480,7 @@ class ConcreteMachine:
 			return selection_set;
 		}
 
+		// MARK: - Activity Source
 		void set_activity_observer(Activity::Observer *observer) override {
 			activity_observer_ = observer;
 			if(activity_observer_) {

--- a/Machines/Utility/MachineForTarget.cpp
+++ b/Machines/Utility/MachineForTarget.cpp
@@ -129,6 +129,7 @@ std::string Machine::LongNameForTargetMachine(Analyser::Machine machine) {
 std::map<std::string, std::vector<std::unique_ptr<Configurable::Option>>> Machine::AllOptionsByMachineName() {
 	std::map<std::string, std::vector<std::unique_ptr<Configurable::Option>>> options;
 
+	options.emplace(std::make_pair(LongNameForTargetMachine(Analyser::Machine::AmstradCPC), AmstradCPC::get_options()));
 	options.emplace(std::make_pair(LongNameForTargetMachine(Analyser::Machine::AppleII), AppleII::get_options()));
 	options.emplace(std::make_pair(LongNameForTargetMachine(Analyser::Machine::Electron), Electron::get_options()));
 	options.emplace(std::make_pair(LongNameForTargetMachine(Analyser::Machine::MSX), MSX::get_options()));

--- a/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
@@ -646,6 +646,7 @@
 		4BEBFB522002DB30000708CC /* DiskROM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4BEBFB4F2002DB30000708CC /* DiskROM.cpp */; };
 		4BEE0A6F1D72496600532C7B /* Cartridge.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4BEE0A6A1D72496600532C7B /* Cartridge.cpp */; };
 		4BEE0A701D72496600532C7B /* PRG.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4BEE0A6D1D72496600532C7B /* PRG.cpp */; };
+		4BEEE6BD20DC72EB003723BF /* CompositeOptions.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4BEEE6BB20DC72EA003723BF /* CompositeOptions.xib */; };
 		4BEF6AAA1D35CE9E00E73575 /* DigitalPhaseLockedLoopBridge.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4BEF6AA91D35CE9E00E73575 /* DigitalPhaseLockedLoopBridge.mm */; };
 		4BEF6AAC1D35D1C400E73575 /* DPLLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BEF6AAB1D35D1C400E73575 /* DPLLTests.swift */; };
 		4BF437EE209D0F7E008CBD6B /* SegmentParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4BF437EC209D0F7E008CBD6B /* SegmentParser.cpp */; };
@@ -1430,6 +1431,7 @@
 		4BEE0A6B1D72496600532C7B /* Cartridge.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = Cartridge.hpp; sourceTree = "<group>"; };
 		4BEE0A6D1D72496600532C7B /* PRG.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PRG.cpp; sourceTree = "<group>"; };
 		4BEE0A6E1D72496600532C7B /* PRG.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = PRG.hpp; sourceTree = "<group>"; };
+		4BEEE6BC20DC72EA003723BF /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = "Clock Signal/Base.lproj/CompositeOptions.xib"; sourceTree = SOURCE_ROOT; };
 		4BEF6AA81D35CE9E00E73575 /* DigitalPhaseLockedLoopBridge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DigitalPhaseLockedLoopBridge.h; sourceTree = "<group>"; };
 		4BEF6AA91D35CE9E00E73575 /* DigitalPhaseLockedLoopBridge.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = DigitalPhaseLockedLoopBridge.mm; sourceTree = "<group>"; };
 		4BEF6AAB1D35D1C400E73575 /* DPLLTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DPLLTests.swift; sourceTree = "<group>"; };
@@ -1995,6 +1997,7 @@
 				4B08A56720D72BEF0016CE5A /* Activity.xib */,
 				4BC5FC2E20CDDDEE00410AA0 /* AppleIIOptions.xib */,
 				4B8FE2131DA19D5F0090D3CE /* Atari2600Options.xib */,
+				4BEEE6BB20DC72EA003723BF /* CompositeOptions.xib */,
 				4B8FE2151DA19D5F0090D3CE /* MachineDocument.xib */,
 				4B2A332B1DB86821002876E3 /* OricOptions.xib */,
 				4B8FE2171DA19D5F0090D3CE /* QuickLoadCompositeOptions.xib */,
@@ -3298,6 +3301,7 @@
 				4B8FE21D1DA19D5F0090D3CE /* QuickLoadCompositeOptions.xib in Resources */,
 				4B79E4461E3AF38600141F11 /* floppy525.png in Resources */,
 				4BC9DF451D044FCA00F44158 /* ROMImages in Resources */,
+				4BEEE6BD20DC72EB003723BF /* CompositeOptions.xib in Resources */,
 				4B1497981EE4B97F00CE2596 /* ZX8081Options.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -4068,6 +4072,14 @@
 				4BD61663206B2AC700236112 /* Base */,
 			);
 			name = QuickLoadOptions.xib;
+			sourceTree = "<group>";
+		};
+		4BEEE6BB20DC72EA003723BF /* CompositeOptions.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				4BEEE6BC20DC72EA003723BF /* Base */,
+			);
+			name = CompositeOptions.xib;
 			sourceTree = "<group>";
 		};
 /* End PBXVariantGroup section */

--- a/OSBindings/Mac/Clock Signal/Base.lproj/CompositeOptions.xib
+++ b/OSBindings/Mac/Clock Signal/Base.lproj/CompositeOptions.xib
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14113" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14113"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="MachineDocument" customModule="Clock_Signal" customModuleProvider="target">
+            <connections>
+                <outlet property="optionsPanel" destination="ZW7-Bw-4RP" id="JpE-wG-zRR"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <window title="Options" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" hidesOnDeactivate="YES" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="ZW7-Bw-4RP" customClass="MachinePanel" customModule="Clock_Signal" customModuleProvider="target">
+            <windowStyleMask key="styleMask" titled="YES" closable="YES" utility="YES" nonactivatingPanel="YES" HUD="YES"/>
+            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+            <rect key="contentRect" x="83" y="102" width="200" height="61"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="900"/>
+            <view key="contentView" id="tpZ-0B-QQu">
+                <rect key="frame" x="0.0" y="0.0" width="200" height="61"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="rh8-km-57n">
+                        <rect key="frame" x="18" y="17" width="165" height="26"/>
+                        <popUpButtonCell key="cell" type="push" title="RGB Monitor" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="tJM-kX-gaK" id="8SX-c5-ud1">
+                            <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="menu"/>
+                            <menu key="menu" id="L06-TO-EF0">
+                                <items>
+                                    <menuItem title="RGB Monitor" state="on" id="tJM-kX-gaK"/>
+                                    <menuItem title="S-Video" tag="2" id="Mtc-Ht-iY8"/>
+                                    <menuItem title="Television" tag="1" id="fFm-fS-rWG"/>
+                                </items>
+                            </menu>
+                        </popUpButtonCell>
+                        <connections>
+                            <action selector="setDisplayType:" target="ZW7-Bw-4RP" id="PAH-CZ-zlk"/>
+                        </connections>
+                    </popUpButton>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="rh8-km-57n" firstAttribute="top" secondItem="tpZ-0B-QQu" secondAttribute="top" constant="20" id="B6L-VS-2cN"/>
+                    <constraint firstItem="rh8-km-57n" firstAttribute="leading" secondItem="tpZ-0B-QQu" secondAttribute="leading" constant="20" id="VRo-6R-IKd"/>
+                    <constraint firstAttribute="bottom" secondItem="rh8-km-57n" secondAttribute="bottom" constant="20" id="jHA-lf-e7V"/>
+                    <constraint firstAttribute="trailing" secondItem="rh8-km-57n" secondAttribute="trailing" constant="20" id="urO-Ac-aqK"/>
+                </constraints>
+            </view>
+            <connections>
+                <outlet property="displayTypeButton" destination="rh8-km-57n" id="FB2-Zg-VKq"/>
+            </connections>
+            <point key="canvasLocation" x="175" y="33.5"/>
+        </window>
+    </objects>
+</document>

--- a/OSBindings/Mac/Clock Signal/Machine/StaticAnalyser/CSStaticAnalyser.mm
+++ b/OSBindings/Mac/Clock Signal/Machine/StaticAnalyser/CSStaticAnalyser.mm
@@ -183,6 +183,7 @@ static Analyser::Static::ZX8081::Target::MemoryModel ZX8081MemoryModelFromSize(K
 
 - (NSString *)optionsPanelNibName {
 	switch(_targets.front()->machine) {
+		case Analyser::Machine::AmstradCPC:	return @"CompositeOptions";
 		case Analyser::Machine::AppleII:	return @"AppleIIOptions";
 		case Analyser::Machine::Atari2600:	return @"Atari2600Options";
 		case Analyser::Machine::Electron:	return @"QuickLoadCompositeOptions";


### PR DESCRIPTION
Specifically:
* sync sent to the monitor is still triggered by but independent of the hsync signal from the CRTC;
* however neither pixels nor border are output while CRTC hsync is active;
* a colour burst is posted after the sync level, then the blank level is adopted until hsync falls.

Since there is now a colour burst, composite video is enabled for the CPC.

This addresses the oversized left border of #473.