### PR TITLE
Tweaks the Mac UI

### DIFF
--- a/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
+++ b/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
@@ -301,6 +301,7 @@ class MachineDocument:
 			switch item.action {
 				case #selector(self.useKeyboardAsKeyboard):
 					if machine == nil || !machine.hasKeyboard {
+						menuItem.state = .off
 						return false
 					}
 
@@ -309,6 +310,7 @@ class MachineDocument:
 
 				case #selector(self.useKeyboardAsJoystick):
 					if machine == nil || !machine.hasJoystick {
+						menuItem.state = .off
 						return false
 					}
 
@@ -317,6 +319,9 @@ class MachineDocument:
 
 				case #selector(self.showActivity(_:)):
 					return self.activityPanel != nil
+
+				case #selector(self.insertMedia(_:)):
+					return self.machine != nil && self.machine.canInsertMedia
 
 				default: break
 			}

--- a/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
+++ b/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
@@ -222,6 +222,7 @@ class MachineDocument:
 
 	@IBAction final func insertMedia(_ sender: AnyObject!) {
 		let openPanel = NSOpenPanel()
+		openPanel.message = "Hint: you can also insert media by dragging and dropping it onto the machine's window."
 		openPanel.beginSheetModal(for: self.windowControllers[0].window!) { (response) in
 			if response == .OK {
 				for url in openPanel.urls {

--- a/OSBindings/Mac/Clock Signal/Info.plist
+++ b/OSBindings/Mac/Clock Signal/Info.plist
@@ -13,7 +13,7 @@
 				<string>bin</string>
 			</array>
 			<key>CFBundleTypeIconFile</key>
-			<string>cartridge</string>
+			<string>cartridge.png</string>
 			<key>CFBundleTypeName</key>
 			<string>Atari 2600 Cartridge</string>
 			<key>CFBundleTypeRole</key>
@@ -33,7 +33,7 @@
 				<string>rom</string>
 			</array>
 			<key>CFBundleTypeIconFile</key>
-			<string>chip</string>
+			<string>chip.png</string>
 			<key>CFBundleTypeName</key>
 			<string>ROM Image</string>
 			<key>CFBundleTypeRole</key>
@@ -54,7 +54,7 @@
 				<string>uef.gz</string>
 			</array>
 			<key>CFBundleTypeIconFile</key>
-			<string>cassette</string>
+			<string>cassette.png</string>
 			<key>CFBundleTypeName</key>
 			<string>Electron/BBC UEF Image</string>
 			<key>CFBundleTypeRole</key>
@@ -74,7 +74,7 @@
 				<string>prg</string>
 			</array>
 			<key>CFBundleTypeIconFile</key>
-			<string>floppy525</string>
+			<string>floppy525.png</string>
 			<key>CFBundleTypeName</key>
 			<string>Commodore Program</string>
 			<key>CFBundleTypeRole</key>
@@ -94,7 +94,7 @@
 				<string>tap</string>
 			</array>
 			<key>CFBundleTypeIconFile</key>
-			<string>cassette</string>
+			<string>cassette.png</string>
 			<key>CFBundleTypeName</key>
 			<string>Tape Image</string>
 			<key>CFBundleTypeRole</key>
@@ -114,7 +114,7 @@
 				<string>g64</string>
 			</array>
 			<key>CFBundleTypeIconFile</key>
-			<string>floppy525</string>
+			<string>floppy525.png</string>
 			<key>CFBundleTypeName</key>
 			<string>Commodore Disk</string>
 			<key>CFBundleTypeRole</key>
@@ -134,7 +134,7 @@
 				<string>d64</string>
 			</array>
 			<key>CFBundleTypeIconFile</key>
-			<string>floppy525</string>
+			<string>floppy525.png</string>
 			<key>CFBundleTypeName</key>
 			<string>Commodore 1540/1 Disk</string>
 			<key>CFBundleTypeRole</key>
@@ -158,7 +158,7 @@
 				<string>adm</string>
 			</array>
 			<key>CFBundleTypeIconFile</key>
-			<string>floppy35</string>
+			<string>floppy35.png</string>
 			<key>CFBundleTypeName</key>
 			<string>Electron/BBC Disk Image</string>
 			<key>CFBundleTypeRole</key>
@@ -178,7 +178,7 @@
 				<string>dsk</string>
 			</array>
 			<key>CFBundleTypeIconFile</key>
-			<string>floppy35</string>
+			<string>floppy35.png</string>
 			<key>CFBundleTypeName</key>
 			<string>Disk Image</string>
 			<key>CFBundleTypeRole</key>
@@ -199,7 +199,7 @@
 				<string>80</string>
 			</array>
 			<key>CFBundleTypeIconFile</key>
-			<string>cassette</string>
+			<string>cassette.png</string>
 			<key>CFBundleTypeName</key>
 			<string>ZX80 Tape Image</string>
 			<key>CFBundleTypeRole</key>
@@ -221,7 +221,7 @@
 				<string>p81</string>
 			</array>
 			<key>CFBundleTypeIconFile</key>
-			<string>cassette</string>
+			<string>cassette.png</string>
 			<key>CFBundleTypeName</key>
 			<string>ZX81 Tape Image</string>
 			<key>CFBundleTypeRole</key>
@@ -241,7 +241,7 @@
 				<string>csw</string>
 			</array>
 			<key>CFBundleTypeIconFile</key>
-			<string>cassette</string>
+			<string>cassette.png</string>
 			<key>CFBundleTypeName</key>
 			<string>Tape Image</string>
 			<key>CFBundleTypeRole</key>
@@ -261,7 +261,7 @@
 				<string>tzx</string>
 			</array>
 			<key>CFBundleTypeIconFile</key>
-			<string>cassette</string>
+			<string>cassette.png</string>
 			<key>CFBundleTypeName</key>
 			<string>Tape Image</string>
 			<key>CFBundleTypeRole</key>
@@ -281,7 +281,7 @@
 				<string>cdt</string>
 			</array>
 			<key>CFBundleTypeIconFile</key>
-			<string>cassette</string>
+			<string>cassette.png</string>
 			<key>CFBundleTypeName</key>
 			<string>Amstrad CPC Tape Image</string>
 			<key>CFBundleTypeRole</key>
@@ -301,7 +301,7 @@
 				<string>hfe</string>
 			</array>
 			<key>CFBundleTypeIconFile</key>
-			<string>floppy35</string>
+			<string>floppy35.png</string>
 			<key>CFBundleTypeName</key>
 			<string>HxC Disk Image</string>
 			<key>CFBundleTypeRole</key>
@@ -321,7 +321,7 @@
 				<string>cas</string>
 			</array>
 			<key>CFBundleTypeIconFile</key>
-			<string>cassette</string>
+			<string>cassette.png</string>
 			<key>CFBundleTypeName</key>
 			<string>MSX Tape Image</string>
 			<key>CFBundleTypeRole</key>
@@ -341,7 +341,7 @@
 				<string>dmk</string>
 			</array>
 			<key>CFBundleTypeIconFile</key>
-			<string>floppy35</string>
+			<string>floppy35.png</string>
 			<key>CFBundleTypeName</key>
 			<string>Disk Image</string>
 			<key>CFBundleTypeRole</key>
@@ -359,7 +359,7 @@
 				<string>tsx</string>
 			</array>
 			<key>CFBundleTypeIconFile</key>
-			<string>cassette</string>
+			<string>cassette.png</string>
 			<key>CFBundleTypeName</key>
 			<string>MSX Tape Image</string>
 			<key>CFBundleTypeRole</key>
@@ -379,7 +379,7 @@
 				<string>col</string>
 			</array>
 			<key>CFBundleTypeIconFile</key>
-			<string>cartridge</string>
+			<string>cartridge.png</string>
 			<key>CFBundleTypeName</key>
 			<string>ColecoVision Cartridge</string>
 			<key>CFBundleTypeRole</key>
@@ -402,7 +402,7 @@
 				<string>po</string>
 			</array>
 			<key>CFBundleTypeIconFile</key>
-			<string>floppy525</string>
+			<string>floppy525.png</string>
 			<key>CFBundleTypeName</key>
 			<string>Apple II Disk Image</string>
 			<key>CFBundleTypeRole</key>

--- a/OSBindings/Mac/Clock Signal/Machine/CSMachine.h
+++ b/OSBindings/Mac/Clock Signal/Machine/CSMachine.h
@@ -39,6 +39,7 @@ typedef NS_ENUM(NSInteger, CSMachineKeyboardInputMode) {
 @interface CSMachine : NSObject
 
 - (nonnull instancetype)init NS_UNAVAILABLE;
+
 /*!
 	Initialises an instance of CSMachine.
 
@@ -69,6 +70,8 @@ typedef NS_ENUM(NSInteger, CSMachineKeyboardInputMode) {
 @property (nonatomic, assign) BOOL useFastLoadingHack;
 @property (nonatomic, assign) CSMachineVideoSignal videoSignal;
 @property (nonatomic, assign) BOOL useAutomaticTapeMotorControl;
+
+@property (nonatomic, readonly) BOOL canInsertMedia;
 
 - (bool)supportsVideoSignal:(CSMachineVideoSignal)videoSignal;
 

--- a/OSBindings/Mac/Clock Signal/Machine/CSMachine.mm
+++ b/OSBindings/Mac/Clock Signal/Machine/CSMachine.mm
@@ -516,6 +516,10 @@ struct ActivityObserver: public Activity::Observer {
 	return [[NSString stringWithUTF8String:name.c_str()] lowercaseString];
 }
 
+- (BOOL)canInsertMedia {
+	return !!_machine->media_target();
+}
+
 #pragma mark - Special machines
 
 - (CSAtari2600 *)atari2600 {


### PR DESCRIPTION
Specifically to:
* ensure that 'Insert...' isn't offered for machines that don't accept new media while running;
* provide a hint that the inert dialogue need not be used;
* make sure 'keyboard as keyboard' isn't ticked for machines without keyboards; and
* to try again to make the file type icons work.