### PR TITLE
Further corrects 65C02 behaviour

### DIFF
--- a/Machines/AppleII/AppleII.cpp
+++ b/Machines/AppleII/AppleII.cpp
@@ -63,7 +63,7 @@ template <Analyser::Static::AppleII::Target::Model model> class ConcreteMachine:
 				uint8_t *ram_, *aux_ram_;
 		};
 
-		CPU::MOS6502::Processor<ConcreteMachine, false> m6502_;
+		CPU::MOS6502::Processor<(model == Analyser::Static::AppleII::Target::Model::EnhancedIIe) ? CPU::MOS6502::Personality::PSynertek65C02 : CPU::MOS6502::Personality::P6502, ConcreteMachine, false> m6502_;
 		VideoBusHandler video_bus_handler_;
 		std::unique_ptr<AppleII::Video::Video<VideoBusHandler, is_iie()>> video_;
 		int cycles_into_current_line_ = 0;
@@ -301,7 +301,7 @@ template <Analyser::Static::AppleII::Target::Model model> class ConcreteMachine:
 
 	public:
 		ConcreteMachine(const Analyser::Static::AppleII::Target &target, const ROMMachine::ROMFetcher &rom_fetcher):
-			m6502_((model == Analyser::Static::AppleII::Target::Model::EnhancedIIe) ? CPU::MOS6502::Personality::P65C02 : CPU::MOS6502::Personality::P6502, *this),
+			m6502_(*this),
 		 	video_bus_handler_(ram_, aux_ram_),
 		 	audio_toggle_(audio_queue_),
 		 	speaker_(audio_toggle_) {

--- a/Machines/Atari2600/Cartridges/Cartridge.hpp
+++ b/Machines/Atari2600/Cartridges/Cartridge.hpp
@@ -32,7 +32,7 @@ template<class T> class Cartridge:
 
 	public:
 		Cartridge(const std::vector<uint8_t> &rom) :
-			m6502_(CPU::MOS6502::Personality::P6502, *this),
+			m6502_(*this),
 			rom_(rom),
 			bus_extender_(rom_.data(), rom.size()) {
 			// The above works because bus_extender_ is declared after rom_ in the instance storage list;
@@ -204,7 +204,7 @@ template<class T> class Cartridge:
 		}
 
 	protected:
-		CPU::MOS6502::Processor<Cartridge<T>, true> m6502_;
+		CPU::MOS6502::Processor<CPU::MOS6502::Personality::P6502, Cartridge<T>, true> m6502_;
 		std::vector<uint8_t> rom_;
 
 	private:

--- a/Machines/Commodore/1540/Implementation/C1540.cpp
+++ b/Machines/Commodore/1540/Implementation/C1540.cpp
@@ -18,7 +18,7 @@ using namespace Commodore::C1540;
 
 MachineBase::MachineBase(Personality personality, const ROMMachine::ROMFetcher &rom_fetcher) :
 		Storage::Disk::Controller(1000000),
-		m6502_(CPU::MOS6502::Personality::P6502, *this),
+		m6502_(*this),
 		drive_(new Storage::Disk::Drive(1000000, 300, 2)),
 		serial_port_VIA_port_handler_(new SerialPortVIA(serial_port_VIA_)),
 		serial_port_(new SerialPort),

--- a/Machines/Commodore/1540/Implementation/C1540Base.hpp
+++ b/Machines/Commodore/1540/Implementation/C1540Base.hpp
@@ -143,7 +143,7 @@ class MachineBase:
 		void set_activity_observer(Activity::Observer *observer);
 
 	protected:
-		CPU::MOS6502::Processor<MachineBase, false> m6502_;
+		CPU::MOS6502::Processor<CPU::MOS6502::Personality::P6502, MachineBase, false> m6502_;
 		std::shared_ptr<Storage::Disk::Drive> drive_;
 
 		uint8_t ram_[0x800];

--- a/Machines/Commodore/Vic-20/Vic20.cpp
+++ b/Machines/Commodore/Vic-20/Vic20.cpp
@@ -293,7 +293,7 @@ class ConcreteMachine:
 	public Activity::Source {
 	public:
 		ConcreteMachine(const Analyser::Static::Commodore::Target &target, const ROMMachine::ROMFetcher &rom_fetcher) :
-				m6502_(CPU::MOS6502::Personality::P6502, *this),
+				m6502_(*this),
 				user_port_via_port_handler_(new UserPortVIA),
 				keyboard_via_port_handler_(new KeyboardVIA),
 				serial_port_(new SerialPort),
@@ -703,7 +703,7 @@ class ConcreteMachine:
 		void update_video() {
 			mos6560_->run_for(cycles_since_mos6560_update_.flush());
 		}
-		CPU::MOS6502::Processor<ConcreteMachine, false> m6502_;
+		CPU::MOS6502::Processor<CPU::MOS6502::Personality::P6502, ConcreteMachine, false> m6502_;
 
 		std::vector<uint8_t>  character_rom_;
 		std::vector<uint8_t>  basic_rom_;

--- a/Machines/Electron/Electron.cpp
+++ b/Machines/Electron/Electron.cpp
@@ -50,7 +50,7 @@ class ConcreteMachine:
 	public Activity::Source {
 	public:
 		ConcreteMachine(const Analyser::Static::Acorn::Target &target, const ROMMachine::ROMFetcher &rom_fetcher) :
-				m6502_(CPU::MOS6502::Personality::P6502, *this),
+				m6502_(*this),
 				sound_generator_(audio_queue_),
 				speaker_(sound_generator_) {
 			memset(key_states_, 0, sizeof(key_states_));
@@ -541,7 +541,7 @@ class ConcreteMachine:
 			m6502_.set_irq_line(interrupt_status_ & 1);
 		}
 
-		CPU::MOS6502::Processor<ConcreteMachine, false> m6502_;
+		CPU::MOS6502::Processor<CPU::MOS6502::Personality::P6502, ConcreteMachine, false> m6502_;
 
 		// Things that directly constitute the memory map.
 		uint8_t roms_[16][16384];

--- a/Machines/Oric/Oric.cpp
+++ b/Machines/Oric/Oric.cpp
@@ -207,7 +207,7 @@ template <Analyser::Static::Oric::Target::DiskInterface disk_interface> class Co
 
 	public:
 		ConcreteMachine(const Analyser::Static::Oric::Target &target, const ROMMachine::ROMFetcher &rom_fetcher) :
-				m6502_(CPU::MOS6502::Personality::P6502, *this),
+				m6502_(*this),
 				ay8910_(audio_queue_),
 				speaker_(ay8910_),
 				via_port_handler_(audio_queue_, ay8910_, speaker_, tape_player_, keyboard_),
@@ -575,7 +575,7 @@ template <Analyser::Static::Oric::Target::DiskInterface disk_interface> class Co
 		const uint16_t basic_invisible_ram_top_ = 0xffff;
 		const uint16_t basic_visible_ram_top_ = 0xbfff;
 
-		CPU::MOS6502::Processor<ConcreteMachine, false> m6502_;
+		CPU::MOS6502::Processor<CPU::MOS6502::Personality::P6502, ConcreteMachine, false> m6502_;
 
 		// RAM and ROM
 		std::vector<uint8_t> rom_, microdisc_rom_, colour_rom_;

--- a/OSBindings/Mac/Clock SignalTests/Bridges/TestMachine6502.mm
+++ b/OSBindings/Mac/Clock SignalTests/Bridges/TestMachine6502.mm
@@ -40,7 +40,7 @@ static CPU::MOS6502::Register registerForRegister(CSTestMachine6502Register reg)
 
 	if(self) {
 		_processor = CPU::MOS6502::AllRAMProcessor::Processor(
-			is65C02 ? CPU::MOS6502::Personality::P65C02 : CPU::MOS6502::Personality::P6502);
+			is65C02 ? CPU::MOS6502::Personality::PWDC65C02 : CPU::MOS6502::Personality::P6502);
 	}
 
 	return self;

--- a/Processors/6502/AllRAM/6502AllRAM.cpp
+++ b/Processors/6502/AllRAM/6502AllRAM.cpp
@@ -15,10 +15,10 @@ using namespace CPU::MOS6502;
 
 namespace {
 
-class ConcreteAllRAMProcessor: public AllRAMProcessor, public BusHandler {
+template <Personality personality> class ConcreteAllRAMProcessor: public AllRAMProcessor, public BusHandler {
 	public:
-		ConcreteAllRAMProcessor(Personality personality) :
-			mos6502_(personality, *this) {
+		ConcreteAllRAMProcessor() :
+			mos6502_(*this) {
 			mos6502_.set_power_on(false);
 		}
 
@@ -63,11 +63,20 @@ class ConcreteAllRAMProcessor: public AllRAMProcessor, public BusHandler {
 		}
 
 	private:
-		CPU::MOS6502::Processor<ConcreteAllRAMProcessor, false> mos6502_;
+		CPU::MOS6502::Processor<personality, ConcreteAllRAMProcessor, false> mos6502_;
 };
 
 }
 
 AllRAMProcessor *AllRAMProcessor::Processor(Personality personality) {
-	return new ConcreteAllRAMProcessor(personality);
+#define Bind(p) case p: return new ConcreteAllRAMProcessor<p>();
+	switch(personality) {
+		default:
+		Bind(Personality::P6502)
+		Bind(Personality::PNES6502)
+		Bind(Personality::PSynertek65C02)
+		Bind(Personality::PWDC65C02)
+		Bind(Personality::PRockwell65C02)
+	}
+#undef Bind
 }

--- a/Processors/6502/Implementation/6502Implementation.hpp
+++ b/Processors/6502/Implementation/6502Implementation.hpp
@@ -533,7 +533,13 @@ if(number_of_cycles <= Cycles(0)) break;
 
 // MARK: - Branching
 
-#define BRA(condition)	pc_.full++; if(condition) scheduled_program_counter_ = do_branch
+#define BRA(condition)	\
+	pc_.full++; \
+	if(condition) {	\
+		scheduled_program_counter_ = do_branch;	\
+	} else if(is_65c02(personality)) {	\
+		scheduled_program_counter_ = fetch_decode_execute;	\
+	}
 
 					case OperationBPL: BRA(!(negative_result_&0x80));				continue;
 					case OperationBMI: BRA(negative_result_&0x80);					continue;

--- a/Processors/6502/Implementation/6502Implementation.hpp
+++ b/Processors/6502/Implementation/6502Implementation.hpp
@@ -104,6 +104,9 @@ if(number_of_cycles <= Cycles(0)) break;
 							operation_ == 0xdb
 						) {
 							read_mem(operand_, pc_.full);
+							break;
+						} else {
+							continue;
 						}
 					break;
 
@@ -173,11 +176,11 @@ if(number_of_cycles <= Cycles(0)) break;
 					case OperationSetFlagsFromX:		zero_result_ = negative_result_ = x_;								continue;
 					case OperationSetFlagsFromY:		zero_result_ = negative_result_ = y_;								continue;
 
-					case CycleIncrementPCAndReadStack:	pc_.full++; throwaway_read(s_ | 0x100);															break;
-					case CycleReadPCLFromAddress:			read_mem(pc_.bytes.low, address_.full);														break;
-					case CycleReadPCHFromAddressLowInc:		address_.bytes.low++; read_mem(pc_.bytes.high, address_.full);								break;
-					case CycleReadPCHFromAddressFixed:		if(!address_.bytes.low) address_.bytes.high++; read_mem(pc_.bytes.high, address_.full);		break;
-					case CycleReadPCHFromAddressInc:		address_.full++; read_mem(pc_.bytes.high, address_.full);									break;
+					case CycleIncrementPCAndReadStack:	pc_.full++; throwaway_read(s_ | 0x100);													break;
+					case CycleReadPCLFromAddress:		read_mem(pc_.bytes.low, address_.full);													break;
+					case CycleReadPCHFromAddressLowInc:	address_.bytes.low++; read_mem(pc_.bytes.high, address_.full);							break;
+					case CycleReadPCHFromAddressFixed:	if(!address_.bytes.low) address_.bytes.high++; read_mem(pc_.bytes.high, address_.full);	break;
+					case CycleReadPCHFromAddressInc:	address_.full++; read_mem(pc_.bytes.high, address_.full);								break;
 
 					case CycleReadAndIncrementPC: {
 						uint16_t oldPC = pc_.full;
@@ -204,6 +207,7 @@ if(number_of_cycles <= Cycles(0)) break;
 					case OperationLDX:	x_ = negative_result_ = zero_result_ = operand_;			continue;
 					case OperationLDY:	y_ = negative_result_ = zero_result_ = operand_;			continue;
 					case OperationLAX:	a_ = x_ = negative_result_ = zero_result_ = operand_;		continue;
+					case OperationCopyOperandToA:		a_ = operand_;								continue;
 
 					case OperationSTA:	operand_ = a_;											continue;
 					case OperationSTX:	operand_ = x_;											continue;
@@ -516,8 +520,6 @@ if(number_of_cycles <= Cycles(0)) break;
 					case OperationIncrementPC:			pc_.full++;						continue;
 					case CycleFetchOperandFromAddress:	read_mem(operand_, address_.full);	break;
 					case CycleWriteOperandToAddress:	write_mem(operand_, address_.full);	break;
-					case OperationCopyOperandFromA:		operand_ = a_;					continue;
-					case OperationCopyOperandToA:		a_ = operand_;					continue;
 
 // MARK: - Branching
 

--- a/Processors/6502/Implementation/6502Implementation.hpp
+++ b/Processors/6502/Implementation/6502Implementation.hpp
@@ -140,9 +140,13 @@ if(number_of_cycles <= Cycles(0)) break;
 					case CycleReadFromPC:				throwaway_read(pc_.full);										break;
 
 					case OperationBRKPickVector:
-						// NMI can usurp BRK-vector operations
-						nextAddress.full = (interrupt_requests_ & InterruptRequestFlags::NMI) ? 0xfffa : 0xfffe;
-						interrupt_requests_ &= ~InterruptRequestFlags::NMI;	// TODO: this probably doesn't happen now?
+						if(is_65c02(personality)) {
+							nextAddress.full = 0xfffe;
+						} else {
+							// NMI can usurp BRK-vector operations on the pre-C 6502s.
+							nextAddress.full = (interrupt_requests_ & InterruptRequestFlags::NMI) ? 0xfffa : 0xfffe;
+							interrupt_requests_ &= ~InterruptRequestFlags::NMI;
+						}
 					continue;
 					case OperationNMIPickVector:		nextAddress.full = 0xfffa;											continue;
 					case OperationRSTPickVector:		nextAddress.full = 0xfffc;											continue;

--- a/Processors/6502/Implementation/6502Implementation.hpp
+++ b/Processors/6502/Implementation/6502Implementation.hpp
@@ -98,7 +98,7 @@ if(number_of_cycles <= Cycles(0)) break;
 						// governs everything else on the 6502: that two bytes will always
 						// be fetched.
 						if(
-							is_65c02(personality) ||
+							!is_65c02(personality) ||
 							(operation_&7) != 3 ||
 							operation_ == 0xcb ||
 							operation_ == 0xdb

--- a/Processors/6502/Implementation/6502Implementation.hpp
+++ b/Processors/6502/Implementation/6502Implementation.hpp
@@ -436,32 +436,42 @@ if(number_of_cycles <= Cycles(0)) break;
 
 // MARK: - Addressing Mode Work
 
+#define page_crossing_stall_read()	\
+	if(is_65c02(personality)) {	\
+		throwaway_read(pc_.full - 1);	\
+	} else {	\
+		throwaway_read(address_.full);	\
+	}
+
 					case CycleAddXToAddressLow:
 						nextAddress.full = address_.full + x_;
 						address_.bytes.low = nextAddress.bytes.low;
-						if(address_.bytes.high != nextAddress.bytes.high) {
-							throwaway_read(address_.full);
+						if(address_.bytes.high != nextAddress.bytes.high) {		
+							page_crossing_stall_read();
 							break;
 						}
 					continue;
 					case CycleAddXToAddressLowRead:
 						nextAddress.full = address_.full + x_;
 						address_.bytes.low = nextAddress.bytes.low;
-						throwaway_read(address_.full);
+						page_crossing_stall_read();
 					break;
 					case CycleAddYToAddressLow:
 						nextAddress.full = address_.full + y_;
 						address_.bytes.low = nextAddress.bytes.low;
 						if(address_.bytes.high != nextAddress.bytes.high) {
-							throwaway_read(address_.full);
+							page_crossing_stall_read();
 							break;
 						}
 					continue;
 					case CycleAddYToAddressLowRead:
 						nextAddress.full = address_.full + y_;
 						address_.bytes.low = nextAddress.bytes.low;
-						throwaway_read(address_.full);
+						page_crossing_stall_read();
 					break;
+
+#undef page_crossing_stall_read
+
 					case OperationCorrectAddressHigh:
 						address_.full = nextAddress.full;
 					continue;

--- a/Processors/6502/Implementation/6502Implementation.hpp
+++ b/Processors/6502/Implementation/6502Implementation.hpp
@@ -152,8 +152,11 @@ if(number_of_cycles <= Cycles(0)) break;
 					case OperationRSTPickVector:		nextAddress.full = 0xfffc;											continue;
 					case CycleReadVectorLow:			read_mem(pc_.bytes.low, nextAddress.full);							break;
 					case CycleReadVectorHigh:			read_mem(pc_.bytes.high, nextAddress.full+1);						break;
-					case OperationSetI:
+					case OperationSetIRQFlags:
 						inverse_interrupt_flag_ = 0;
+						if(is_65c02(personality)) decimal_flag_ = false;
+					continue;
+					case OperationSetNMIRSTFlags:
 						if(is_65c02(personality)) decimal_flag_ = false;
 					continue;
 
@@ -681,6 +684,7 @@ inline const ProcessorStorage::MicroOp *ProcessorStorage::get_reset_program() {
 		CycleNoWritePush,
 		OperationRSTPickVector,
 		CycleNoWritePush,
+		OperationSetNMIRSTFlags,
 		CycleReadVectorLow,
 		CycleReadVectorHigh,
 		OperationMoveToNextProgram
@@ -697,7 +701,7 @@ inline const ProcessorStorage::MicroOp *ProcessorStorage::get_irq_program() {
 		OperationBRKPickVector,
 		OperationSetOperandFromFlags,
 		CyclePushOperand,
-		OperationSetI,
+		OperationSetIRQFlags,
 		CycleReadVectorLow,
 		CycleReadVectorHigh,
 		OperationMoveToNextProgram
@@ -714,6 +718,7 @@ inline const ProcessorStorage::MicroOp *ProcessorStorage::get_nmi_program() {
 		OperationNMIPickVector,
 		OperationSetOperandFromFlags,
 		CyclePushOperand,
+		OperationSetNMIRSTFlags,
 		CycleReadVectorLow,
 		CycleReadVectorHigh,
 		OperationMoveToNextProgram

--- a/Processors/6502/Implementation/6502Storage.cpp
+++ b/Processors/6502/Implementation/6502Storage.cpp
@@ -80,7 +80,7 @@ ProcessorStorage::ProcessorStorage(Personality personality) {
 	overflow_flag_ &= Flag::Overflow;
 
 	const InstructionList operations_6502[256] = {
-		/* 0x00 BRK */			Program(CycleIncPCPushPCH, CyclePushPCL, OperationBRKPickVector, OperationSetOperandFromFlagsWithBRKSet, CyclePushOperand, OperationSetI, CycleReadVectorLow, CycleReadVectorHigh),
+		/* 0x00 BRK */			Program(CycleIncPCPushPCH, CyclePushPCL, OperationBRKPickVector, OperationSetOperandFromFlagsWithBRKSet, CyclePushOperand, OperationSetIRQFlags, CycleReadVectorLow, CycleReadVectorHigh),
 		/* 0x01 ORA x, ind */	IndexedIndirectRead(OperationORA),
 		/* 0x02 JAM */			JAM,																	/* 0x03 ASO x, ind */	IndexedIndirectReadModifyWrite(OperationASO),
 		/* 0x04 NOP zpg */		ZeroNop(),																/* 0x05 ORA zpg */		ZeroRead(OperationORA),

--- a/Processors/6502/Implementation/6502Storage.cpp
+++ b/Processors/6502/Implementation/6502Storage.cpp
@@ -61,7 +61,7 @@ using namespace CPU::MOS6502;
 #define IndirectIndexedReadModifyWrite(...)	Program(IndirectIndexed,	ReadModifyWrite(__VA_ARGS__))
 
 #define Immediate(op)						Program(OperationIncrementPC,		op)
-#define Implied(op)							Program(OperationCopyOperandFromA,	op,	OperationCopyOperandToA)
+#define Implied(op)							Program(OperationSTA,				op,	OperationCopyOperandToA)
 
 #define ZeroNop()							Program(Zero, CycleFetchOperandFromAddress)
 #define ZeroXNop()							Program(ZeroX, CycleFetchOperandFromAddress)

--- a/Processors/6502/Implementation/6502Storage.hpp
+++ b/Processors/6502/Implementation/6502Storage.hpp
@@ -191,7 +191,10 @@ class ProcessorStorage {
 			OperationSetFlagsFromA,		// sets the zero and negative flags based on the value of a
 			OperationSetFlagsFromX,		// sets the zero and negative flags based on the value of x
 			OperationSetFlagsFromY,		// sets the zero and negative flags based on the value of y
-			CycleScheduleJam			// schedules the program for operation F2
+
+			OperationScheduleJam,		// schedules the program for operation F2
+			OperationScheduleWait,		// puts the processor into WAI mode (i.e. it'll do nothing until an interrupt is received)
+			OperationScheduleStop,		// puts the processor into STP mode (i.e. it'll do nothing until a reset is received)
 		};
 
 		using InstructionList = MicroOp[10];
@@ -252,6 +255,8 @@ class ProcessorStorage {
 
 		bool ready_is_active_ = false;
 		bool ready_line_is_enabled_ = false;
+		bool stop_is_active_ = false;
+		bool wait_is_active_ = false;
 
 		uint8_t irq_line_ = 0, irq_request_history_ = 0;
 		bool nmi_line_is_enabled_ = false, set_overflow_line_is_enabled_ = false;

--- a/Processors/6502/Implementation/6502Storage.hpp
+++ b/Processors/6502/Implementation/6502Storage.hpp
@@ -160,8 +160,11 @@ class ProcessorStorage {
 			OperationBCC,	// schedules the branch program if the carry flag is clear
 			OperationBCS,	// schedules the branch program if the carry flag is set
 			OperationBNE,	// schedules the branch program if the zero flag is clear
-			OperationBEQ,	// schedules the branch program if the zero flag is set
+			OperationBEQ,	// schedules the branch program if the zero flag is set; 65C02: otherwise jumps straight into a fetch-decode-execute without considering whether to take an interrupt
 			OperationBRA,	// schedules the branch program
+			// 65C02 modification to all branches: if the branch isn't taken, the next fetch-decode-execute
+			// sequence is scheduled immediately, without any possibility of responding to an interrupt.
+			// Cf. http://forum.6502.org/viewtopic.php?f=4&t=1634
 
 			OperationBBRBBS,	// inspecting the operation_, if the appropriate bit of operand_ is set or clear schedules a program to read and act upon the second operand; otherwise schedule a program to read and discard it
 

--- a/Processors/6502/Implementation/6502Storage.hpp
+++ b/Processors/6502/Implementation/6502Storage.hpp
@@ -23,62 +23,173 @@ class ProcessorStorage {
 			to perform whereas those called OperationX occur for free (so, in effect, their cost is loaded onto the next cycle).
 		*/
 		enum MicroOp {
-			CycleFetchOperation,						CycleFetchOperand,					OperationDecodeOperation,				CycleIncPCPushPCH,
-			CyclePushPCH,								CyclePushPCL,						CyclePushA,								CyclePushOperand,
-			CyclePushX,									CyclePushY,							OperationSetIRQFlags,					OperationSetNMIRSTFlags,
+			CycleFetchOperation,		// fetches (PC) to operation_, storing PC to last_operation_pc_ before incrementing it
+			CycleFetchOperand,			// 6502: fetches from (PC) to operand_; 65C02: as 6502 unless operation_ indicates a one-cycle NOP, in which case this is a no0op
+			OperationDecodeOperation,	// schedules the microprogram associated with operation_
+			OperationMoveToNextProgram,	// either schedules the next fetch-decode-execute or an interrupt response if a request has been pending for at least one cycle
 
-			OperationBRKPickVector,						OperationNMIPickVector,				OperationRSTPickVector,
-			CycleReadVectorLow,							CycleReadVectorHigh,
+			CycleIncPCPushPCH,			// increments the PC and pushes PC.h to the stack
+			CyclePushPCL,				// pushes PC.l to the stack
+			CyclePushPCH,				// pushes PC.h to the stack
+			CyclePushA,					// pushes A to the stack
+			CyclePushX,					// pushes X to the stack
+			CyclePushY,					// pushes Y to the stack
+			CyclePushOperand,			// pushes operand_ to the stack
 
-			CycleReadFromS,								CycleReadFromPC,
-			CyclePullOperand,							CyclePullPCL,						CyclePullPCH,							CyclePullA,
-			CyclePullX,									CyclePullY,
-			CycleNoWritePush,
-			CycleReadAndIncrementPC,					CycleIncrementPCAndReadStack,		CycleIncrementPCReadPCHLoadPCL,			CycleReadPCHLoadPCL,
-			CycleReadAddressHLoadAddressL,
+			OperationSetIRQFlags,		// 6502: sets I; 65C02: sets I and resets D
+			OperationSetNMIRSTFlags,	// 6502: no-op. 65C02: resets D
 
-			CycleReadPCLFromAddress,					CycleReadPCHFromAddressLowInc,		CycleReadPCHFromAddressFixed,			CycleReadPCHFromAddressInc,
+			OperationBRKPickVector,		// 65C02: sets next_address_ to the BRK vector location; 6502: as 65C02 if no NMI is pending; otherwise sets next_address_ to the NMI address and resets the internal NMI-pending flag
+			OperationNMIPickVector,		// sets next_address_ to the NMI vector
+			OperationRSTPickVector,		// sets next_address_ to the RST vector
+			CycleReadVectorLow,			// reads PC.l from next_address_
+			CycleReadVectorHigh,		// reads PC.h from (next_address_+1)
 
-			CycleLoadAddressAbsolute,
-			OperationLoadAddressZeroPage,				CycleLoadAddessZeroX,				CycleLoadAddessZeroY,					CycleAddXToAddressLow,
-			CycleAddYToAddressLow,						CycleAddXToAddressLowRead,			OperationCorrectAddressHigh,			CycleAddYToAddressLowRead,
-			OperationMoveToNextProgram,					OperationIncrementPC,
-			CycleFetchOperandFromAddress,				CycleWriteOperandToAddress,			OperationCopyOperandFromA,				OperationCopyOperandToA,
-			CycleIncrementPCFetchAddressLowFromOperand,	CycleAddXToOperandFetchAddressLow,	CycleIncrementOperandFetchAddressHigh,	OperationDecrementOperand,
-			CycleFetchAddressLowFromOperand,
-			OperationIncrementOperand,					OperationORA,						OperationAND,							OperationEOR,
-			OperationINS,								OperationADC,						OperationSBC,							OperationLDA,
-			OperationLDX,								OperationLDY,						OperationLAX,							OperationSTA,
-			OperationSTX,								OperationSTY,						OperationSTZ,
-			OperationSAX,								OperationSHA,
-			OperationSHX,								OperationSHY,						OperationSHS,							OperationCMP,
-			OperationCPX,								OperationCPY,						OperationBIT,							OperationBITNoNV,
-			OperationASL,								OperationRMB,						OperationSMB,
-			OperationASO,								OperationROL,						OperationRLA,							OperationLSR,
-			OperationLSE,								OperationASR,						OperationROR,							OperationRRA,
-			OperationCLC,								OperationCLI,						OperationCLV,							OperationCLD,
-			OperationSEC,								OperationSEI,						OperationSED,
-			OperationTRB,								OperationTSB,
+			CycleReadFromS,				// performs a read from the stack pointer, throwing the result away
+			CycleReadFromPC,			// performs a read from the program counter, throwing the result away
 
-			OperationINC,								OperationDEC,						OperationINX,							OperationDEX,
-			OperationINY,								OperationDEY,						OperationINA,							OperationDEA,
+			CyclePullPCL,				// pulls PC.l from the stack
+			CyclePullPCH,				// pulls PC.h from the stack
+			CyclePullA,					// pulls A from the stack
+			CyclePullX,					// pulls X from the stack
+			CyclePullY,					// pulls Y from the stack
+			CyclePullOperand,			// pulls operand_ from the stack
 
-			OperationBPL,								OperationBMI,						OperationBVC,							OperationBVS,
-			OperationBCC,								OperationBCS,						OperationBNE,							OperationBEQ,
-			OperationBRA,								OperationBBRBBS,
+			CycleNoWritePush,				// decrements S as though it were a push, but reads from the new stack address instead of writing
+			CycleReadAndIncrementPC,		// reads from the PC, throwing away the result, and increments the PC
+			CycleIncrementPCAndReadStack,	// increments the PC and reads from the stack pointer, throwing away the result
+			CycleIncrementPCReadPCHLoadPCL,	// increments the PC, schedules a read of PC.h from the post-incremented PC, then copies operand_ to PC.l
+			CycleReadPCHLoadPCL,			// schedules a read of PC.h from the post-incremented PC, then copies operand_ to PC.l
+			CycleReadAddressHLoadAddressL,	// increments the PC; copies operand_ to address_.l; reads address_.h from the new PC
 
-			OperationTXA,								OperationTYA,						OperationTXS,							OperationTAY,
-			OperationTAX,								OperationTSX,
+			CycleReadPCLFromAddress,		// reads PC.l from address_
+			CycleReadPCHFromAddressLowInc,	// increments address_.l and reads PC.h from address_
+			CycleReadPCHFromAddressFixed,	// if address_.l is 0, increments address_.h; and reads PC.h from address_
+			CycleReadPCHFromAddressInc,		// increments address_ and reads PC.h from it
 
-			OperationARR,								OperationSBX,						OperationLXA,							OperationANE,
-			OperationANC,								OperationLAS,
+			CycleLoadAddressAbsolute,		// copies operand_ to address_.l, increments the PC, reads address_.h from PC, increments the PC again
+			OperationLoadAddressZeroPage,	// copies operand_ to address_ and increments the PC
+			CycleLoadAddessZeroX,			// copies (operand_+x)&0xff to address_, increments the PC, and reads from operand_, throwing away the result
+			CycleLoadAddessZeroY,			// copies (operand_+y)&0xff to address_, increments the PC, and reads from operand_, throwing away the result
 
-			CycleFetchFromHalfUpdatedPC,				CycleAddSignedOperandToPC,			OperationAddSignedOperandToPC16,
+			CycleAddXToAddressLow,			// calculates address_ + x and stores it to next_address_; copies next_address_.l back to address_.l; if address_ now does not equal next_address_, schedules a throwaway read from address_
+			CycleAddYToAddressLow,			// calculates address_ + y and stores it to next_address_; copies next_address_.l back to address_.l; if address_ now does not equal next_address_, schedules a throwaway read from address_
+			CycleAddXToAddressLowRead,		// calculates address_ + x and stores it to next_address; copies next_address.l back to address_.l; schedules a throwaway read from address_
+			CycleAddYToAddressLowRead,		// calculates address_ + y and stores it to next_address; copies next_address.l back to address_.l; schedules a throwaway read from address_
+			OperationCorrectAddressHigh,	// copies next_address_ to address_
 
-			OperationSetFlagsFromOperand,				OperationSetOperandFromFlagsWithBRKSet,
-			OperationSetOperandFromFlags,
-			OperationSetFlagsFromA,						OperationSetFlagsFromX,				OperationSetFlagsFromY,
-			CycleScheduleJam
+			OperationIncrementPC,			// increments the PC
+			CycleFetchOperandFromAddress,	// fetches operand_ from address_
+			CycleWriteOperandToAddress,		// writes operand_ to address_
+
+			CycleIncrementPCFetchAddressLowFromOperand,	// increments the PC and loads address_.l from (operand_)
+			CycleAddXToOperandFetchAddressLow,			// adds x [in]to operand_, producing an 8-bit result, and reads address_.l from (operand_)
+			CycleIncrementOperandFetchAddressHigh,		// increments operand_, producing an 8-bit result, and reads address_.h from (operand_)
+			OperationDecrementOperand,					// decrements operand_
+			OperationIncrementOperand,					// increments operand_
+			CycleFetchAddressLowFromOperand,			// reads address_.l from (operand_)
+
+			OperationORA,	// ORs operand_ into a, setting the negative and zero flags
+			OperationAND,	// ANDs operand_ into a, setting the negative and zero flags
+			OperationEOR,	// EORs operand_ into a, setting the negative and zero flags
+
+			OperationINS,	// increments operand_, then performs an SBC of operand_ from a
+			OperationADC,	// performs an ADC of operand_ into a_; if this is a 65C02 and decimal mode is set, performs an extra read to operand_ from address_
+			OperationSBC,	// performs an SBC of operand_ from a_; if this is a 65C02 and decimal mode is set, performs an extra read to operand_ from address_
+
+			OperationCMP,	// CMPs a and operand_, setting negative, zero and carry flags
+			OperationCPX,	// CMPs x and operand_, setting negative, zero and carry flags
+			OperationCPY,	// CMPs y and operand_, setting negative, zero and carry flags
+			OperationBIT,	// sets the zero, negative and overflow flags as per a BIT of operand_ against a
+			OperationBITNoNV,	// sets the zero flag as per a BIT of operand_ against a
+
+			OperationLDA,	// loads a with operand_, setting the negative and zero flags
+			OperationLDX,	// loads x with operand_, setting the negative and zero flags
+			OperationLDY,	// loads y with operand_, setting the negative and zero flags
+			OperationLAX,	// loads a and x with operand_, setting the negative and zero flags
+			OperationCopyOperandToA,		// sets a_ = operand_, not setting any flags
+
+			OperationSTA,	// loads operand_ with a
+			OperationSTX,	// loads operand_ with x
+			OperationSTY,	// loads operand_ with y
+			OperationSTZ,	// loads operand_ with 0
+			OperationSAX,	// loads operand_ with a & x
+			OperationSHA,	// loads operand_ with a & x & (address.h+1)
+			OperationSHX,	// loads operand_ with x & (address.h+1)
+			OperationSHY,	// loads operand_ with y & (address.h+1)
+			OperationSHS,	// loads s with a & x, then loads operand_ with s & (address.h+1)
+
+			OperationASL,	// shifts operand_ left, moving the top bit into carry and setting the negative and zero flags
+			OperationASO,	// performs an ASL of operand and ORs it into a
+			OperationROL,	// performs a ROL of operand_
+			OperationRLA,	// performs a ROL of operand_ and ANDs it into a
+			OperationLSR,	// shifts operand_ right, setting carry, negative and zero flags
+			OperationLSE,	// performs an LSR and EORs the result into a
+			OperationASR,	// ANDs operand_ into a, then performs an LSR
+			OperationROR,	// performs a ROR of operand_, setting carry, negative and zero flags
+			OperationRRA,	// performs a ROR of operand_ but sets only the carry flag
+
+			OperationCLC,	// resets the carry flag
+			OperationCLI,	// resets I
+			OperationCLV,	// resets the overflow flag
+			OperationCLD,	// resets the decimal flag
+			OperationSEC,	// sets the carry flag
+			OperationSEI,	// sets I
+			OperationSED,	// sets the decimal flag
+
+			OperationRMB,	// resets the bit in operand_ implied by operatiopn_
+			OperationSMB,	// sets the bit in operand_ implied by operatiopn_
+			OperationTRB,	// sets zero according to operand_ & a, then resets any bits in operand_ that are set in a
+			OperationTSB,	// sets zero according to operand_ & a, then sets any bits in operand_ that are set in a
+
+			OperationINC,	// increments operand_, setting the negative and zero flags
+			OperationDEC,	// decrements operand_, setting the negative and zero flags
+			OperationINX,	// increments x, setting the negative and zero flags
+			OperationDEX,	// decrements x, setting the negative and zero flags
+			OperationINY,	// increments y, setting the negative and zero flags
+			OperationDEY,	// decrements y, setting the negative and zero flags
+			OperationINA,	// increments a, setting the negative and zero flags
+			OperationDEA,	// decrements a, setting the negative and zero flags
+
+			OperationBPL,	// schedules the branch program if the negative flag is clear
+			OperationBMI,	// schedules the branch program if the negative flag is set
+			OperationBVC,	// schedules the branch program if the overflow flag is clear
+			OperationBVS,	// schedules the branch program if the overflow flag is set
+			OperationBCC,	// schedules the branch program if the carry flag is clear
+			OperationBCS,	// schedules the branch program if the carry flag is set
+			OperationBNE,	// schedules the branch program if the zero flag is clear
+			OperationBEQ,	// schedules the branch program if the zero flag is set
+			OperationBRA,	// schedules the branch program
+
+			OperationBBRBBS,	// inspecting the operation_, if the appropriate bit of operand_ is set or clear schedules a program to read and act upon the second operand; otherwise schedule a program to read and discard it
+
+			OperationTXA,	// copies x to a, setting the zero and negative flags
+			OperationTYA,	// copies y to a, setting the zero and negative flags
+			OperationTXS,	// copies x to s
+			OperationTAY,	// copies a to y, setting the zero and negative flags
+			OperationTAX,	// copies a to x, setting the zero and negative flags
+			OperationTSX,	// copies s to x, setting the zero and negative flags
+
+			/* The following are amongst the 6502's undocumented (/unintended) operations */
+			OperationARR,	// performs a mixture of ANDing operand_ into a, and shifting the result right
+			OperationSBX,	// performs a mixture of an SBC of x&a and operand_, mutating x
+			OperationLXA,	// loads a and x with (a | 0xee) & operand, setting the negative and zero flags
+			OperationANE,	// loads a_ with (a | 0xee) & operand & x, setting the negative and zero flags
+			OperationANC,	// ANDs operand_ into a, setting the negative and zero flags, and loading carry as if the result were shifted right
+			OperationLAS,	// loads a, x and s with s & operand, setting the negative and zero flags
+
+			CycleFetchFromHalfUpdatedPC,		// performs a throwaway read from (PC + (signed)operand).l combined with PC.h
+			CycleAddSignedOperandToPC,			// sets next_address to PC + (signed)operand. If the high byte of next_address differs from the PC, schedules a throwaway read from the half-updated PC
+			OperationAddSignedOperandToPC16,	// adds (signed)operand into the PC
+
+			OperationSetFlagsFromOperand,			// sets all flags based on operand_
+			OperationSetOperandFromFlagsWithBRKSet,	// sets operand_ to the value of all flags, with the break flag set
+			OperationSetOperandFromFlags,			// sets operand_ to the value of all flags
+
+			OperationSetFlagsFromA,		// sets the zero and negative flags based on the value of a
+			OperationSetFlagsFromX,		// sets the zero and negative flags based on the value of x
+			OperationSetFlagsFromY,		// sets the zero and negative flags based on the value of y
+			CycleScheduleJam			// schedules the program for operation F2
 		};
 
 		using InstructionList = MicroOp[10];

--- a/Processors/6502/Implementation/6502Storage.hpp
+++ b/Processors/6502/Implementation/6502Storage.hpp
@@ -25,7 +25,7 @@ class ProcessorStorage {
 		enum MicroOp {
 			CycleFetchOperation,						CycleFetchOperand,					OperationDecodeOperation,				CycleIncPCPushPCH,
 			CyclePushPCH,								CyclePushPCL,						CyclePushA,								CyclePushOperand,
-			CyclePushX,									CyclePushY,							OperationSetI,
+			CyclePushX,									CyclePushY,							OperationSetIRQFlags,					OperationSetNMIRSTFlags,
 
 			OperationBRKPickVector,						OperationNMIPickVector,				OperationRSTPickVector,
 			CycleReadVectorLow,							CycleReadVectorHigh,

--- a/Processors/6502/Implementation/6502Storage.hpp
+++ b/Processors/6502/Implementation/6502Storage.hpp
@@ -17,10 +17,12 @@ class ProcessorStorage {
 	protected:
 		ProcessorStorage(Personality);
 
-		/*
+		/*!
 			This emulation functions by decomposing instructions into micro programs, consisting of the micro operations
-			as per the enum below. Each micro op takes at most one cycle. By convention, those called CycleX take a cycle
+			defined by MicroOp. Each micro op takes at most one cycle. By convention, those called CycleX take a cycle
 			to perform whereas those called OperationX occur for free (so, in effect, their cost is loaded onto the next cycle).
+
+			This micro-instruction set was put together in a fairly ad hoc fashion, I'm afraid, so is unlikely to be optimal.
 		*/
 		enum MicroOp {
 			CycleFetchOperation,		// fetches (PC) to operation_, storing PC to last_operation_pc_ before incrementing it
@@ -72,10 +74,10 @@ class ProcessorStorage {
 			CycleLoadAddessZeroX,			// copies (operand_+x)&0xff to address_, increments the PC, and reads from operand_, throwing away the result
 			CycleLoadAddessZeroY,			// copies (operand_+y)&0xff to address_, increments the PC, and reads from operand_, throwing away the result
 
-			CycleAddXToAddressLow,			// calculates address_ + x and stores it to next_address_; copies next_address_.l back to address_.l; if address_ now does not equal next_address_, schedules a throwaway read from address_
-			CycleAddYToAddressLow,			// calculates address_ + y and stores it to next_address_; copies next_address_.l back to address_.l; if address_ now does not equal next_address_, schedules a throwaway read from address_
-			CycleAddXToAddressLowRead,		// calculates address_ + x and stores it to next_address; copies next_address.l back to address_.l; schedules a throwaway read from address_
-			CycleAddYToAddressLowRead,		// calculates address_ + y and stores it to next_address; copies next_address.l back to address_.l; schedules a throwaway read from address_
+			CycleAddXToAddressLow,			// calculates address_ + x and stores it to next_address_; copies next_address_.l back to address_.l; 6502: if address_ now does not equal next_address_, schedules a throwaway read from address_; 65C02: schedules a throaway read from PC-1
+			CycleAddYToAddressLow,			// calculates address_ + y and stores it to next_address_; copies next_address_.l back to address_.l; 6502: if address_ now does not equal next_address_, schedules a throwaway read from address_; 65C02: schedules a throaway read from PC-1
+			CycleAddXToAddressLowRead,		// calculates address_ + x and stores it to next_address; copies next_address.l back to address_.l; 6502: schedules a throwaway read from address_; 65C02: schedules a throaway read from PC-1
+			CycleAddYToAddressLowRead,		// calculates address_ + y and stores it to next_address; copies next_address.l back to address_.l; 6502: schedules a throwaway read from address_; 65C02: schedules a throaway read from PC-1
 			OperationCorrectAddressHigh,	// copies next_address_ to address_
 
 			OperationIncrementPC,			// increments the PC

--- a/Processors/6502/Implementation/6502Storage.hpp
+++ b/Processors/6502/Implementation/6502Storage.hpp
@@ -162,9 +162,6 @@ class ProcessorStorage {
 			OperationBNE,	// schedules the branch program if the zero flag is clear
 			OperationBEQ,	// schedules the branch program if the zero flag is set; 65C02: otherwise jumps straight into a fetch-decode-execute without considering whether to take an interrupt
 			OperationBRA,	// schedules the branch program
-			// 65C02 modification to all branches: if the branch isn't taken, the next fetch-decode-execute
-			// sequence is scheduled immediately, without any possibility of responding to an interrupt.
-			// Cf. http://forum.6502.org/viewtopic.php?f=4&t=1634
 
 			OperationBBRBBS,	// inspecting the operation_, if the appropriate bit of operand_ is set or clear schedules a program to read and act upon the second operand; otherwise schedule a program to read and discard it
 
@@ -184,7 +181,7 @@ class ProcessorStorage {
 			OperationLAS,	// loads a, x and s with s & operand, setting the negative and zero flags
 
 			CycleFetchFromHalfUpdatedPC,		// performs a throwaway read from (PC + (signed)operand).l combined with PC.h
-			CycleAddSignedOperandToPC,			// sets next_address to PC + (signed)operand. If the high byte of next_address differs from the PC, schedules a throwaway read from the half-updated PC
+			CycleAddSignedOperandToPC,			// sets next_address to PC + (signed)operand. If the high byte of next_address differs from the PC, schedules a throwaway read from the half-updated PC. 65C02 specific: if the top two bytes are the same, proceeds directly to fetch-decode-execute, ignoring any pending interrupts.
 			OperationAddSignedOperandToPC16,	// adds (signed)operand into the PC
 
 			OperationSetFlagsFromOperand,			// sets all flags based on operand_


### PR DESCRIPTION
UNREADY!

Introduces profiles for the:
- 6502;
- NES 6502;
- Synertek 65C02 (seemingly a synonym of the 65SC02);
- WDC 65C02 (with added bit instructions, but no STP or WEI); and
- Rockwell 65C02 (like the WDC, but with added STP and WEI).

Corrects the following errors in the prior 65C02 implementation:
* ensures D is clear on NMI and RST;
* prevents NMI from usurping BRK.
* indexing across a page boundary on the 65C02 rereads the last instruction byte rather than an incorrect address;
* read-modify-write absolute indexed (i.e. abs,x and abs,y) ASL, LSR, ROL and ROR with no page boundary crossing complete in 6 cycles rather than 7; and
* branches that complete in three cycles (i.e. branch taken, no page crossing) can no longer segue directly into responding to an IRQ or NMI. Reacting is deferred.

Amongst other changes, the 6502's personality is now a template parameter rather than a construction parameter. I feel that it's going to be sufficiently rare that two 6502s are going to be instantiated with the same bus handler but a different personality that binary bloat isn't a strong concern; the (slight, allowing for branch prediction) inner-loop improvement is therefore worth taking.