### PR TITLE
Corrects Apple II video defects

### DIFF
--- a/ClockReceiver/ClockDeferrer.hpp
+++ b/ClockReceiver/ClockDeferrer.hpp
@@ -15,13 +15,10 @@
 	A ClockDeferrer maintains a list of ordered actions and the times at which
 	they should happen, and divides a total execution period up into the portions
 	that occur between those actions, triggering each action when it is reached.
-
-	@c Class should be a class that implements @c advance(TimeUnit), to advance
-	that amount of time.
 */
 template <typename TimeUnit> class ClockDeferrer {
 	public:
-		/// Constructs a ClockDeferrer that will call target.advance in between deferred actions.
+		/// Constructs a ClockDeferrer that will call target(period) in between deferred actions.
 		ClockDeferrer(std::function<void(TimeUnit)> &&target) : target_(std::move(target)) {}
 
 		/*!
@@ -37,7 +34,7 @@ template <typename TimeUnit> class ClockDeferrer {
 		/*!
 			Runs for @c length units of time.
 
-			The target's @c advance will be called with one or more periods that add up to @c length;
+			The constructor-supplied target will be called with one or more periods that add up to @c length;
 			any scheduled actions will be called between periods.
 		*/
 		void run_for(TimeUnit length) {

--- a/ClockReceiver/ClockDeferrer.hpp
+++ b/ClockReceiver/ClockDeferrer.hpp
@@ -1,0 +1,84 @@
+//
+//  ClockDeferrer.hpp
+//  Clock Signal
+//
+//  Created by Thomas Harte on 23/08/2018.
+//  Copyright © 2018 Thomas Harte. All rights reserved.
+//
+
+#ifndef ClockDeferrer_h
+#define ClockDeferrer_h
+
+#include <vector>
+
+/*!
+	A ClockDeferrer maintains a list of ordered actions and the times at which
+	they should happen, and divides a total execution period up into the portions
+	that occur between those actions, triggering each action when it is reached.
+
+	@c Class should be a class that implements @c advance(TimeUnit), to advance
+	that amount of time.
+*/
+template <typename TimeUnit> class ClockDeferrer {
+	public:
+		/// Constructs a ClockDeferrer that will call target.advance in between deferred actions.
+		ClockDeferrer(std::function<void(TimeUnit)> &&target) : target_(std::move(target)) {}
+
+		/*!
+			Schedules @c action to occur in @c delay units of time.
+
+			Actions must be scheduled in the order they will occur. It is undefined behaviour
+			to schedule them out of order.
+		*/
+		void defer(TimeUnit delay, const std::function<void(void)> &action) {
+			pending_actions_.emplace_back(delay, action);
+		}
+
+		/*!
+			Runs for @c length units of time.
+
+			The target's @c advance will be called with one or more periods that add up to @c length;
+			any scheduled actions will be called between periods.
+		*/
+		void run_for(TimeUnit length) {
+			// If there are no pending actions, just run for the entire length.
+			// This should be the normal branch.
+			if(pending_actions_.empty()) {
+				target_(length);
+				return;
+			}
+
+			// Divide the time to run according to the pending actions.
+			while(length > TimeUnit(0)) {
+				TimeUnit next_period = pending_actions_.empty() ? length : std::min(length, pending_actions_[0].delay);
+				target_(next_period);
+				length -= next_period;
+
+				off_t performances = 0;
+				for(auto &action: pending_actions_) {
+					action.delay -= next_period;
+					if(!action.delay) {
+						action.action();
+						++performances;
+					}
+				}
+				if(performances) {
+					pending_actions_.erase(pending_actions_.begin(), pending_actions_.begin() + performances);
+				}
+			}
+		}
+
+	private:
+		std::function<void(TimeUnit)> target_;
+
+		// The list of deferred actions.
+		struct DeferredAction {
+			TimeUnit delay;
+			std::function<void(void)> action;
+
+			DeferredAction(TimeUnit delay, const std::function<void(void)> &action) : delay(delay), action(std::move(action)) {}
+		};
+		std::vector<DeferredAction> pending_actions_;
+};
+
+#endif /* ClockDeferrer_h */

--- a/Machines/AppleII/AppleII.cpp
+++ b/Machines/AppleII/AppleII.cpp
@@ -52,11 +52,9 @@ template <Analyser::Static::AppleII::Target::Model model> class ConcreteMachine:
 			public:
 				VideoBusHandler(uint8_t *ram, uint8_t *aux_ram) : ram_(ram), aux_ram_(aux_ram) {}
 
-				uint8_t perform_read(uint16_t address) {
-					return ram_[address];
-				}
-				uint16_t perform_aux_read(uint16_t address) {
-					return static_cast<uint16_t>(ram_[address] | (aux_ram_[address] << 8));
+				void perform_read(uint16_t address, size_t count, uint8_t *base_target, uint8_t *auxiliary_target) {
+					memcpy(base_target, &ram_[address], count);
+					memcpy(auxiliary_target, &aux_ram_[address], count);
 				}
 
 			private:

--- a/Machines/AppleII/Video.cpp
+++ b/Machines/AppleII/Video.cpp
@@ -25,7 +25,7 @@ VideoBase::VideoBase(bool is_iie, std::function<void(Cycles)> &&target) :
 
 	// Show only the centre 75% of the TV frame.
 	crt_->set_video_signal(Outputs::CRT::VideoSignal::Composite);
-	crt_->set_visible_area(Outputs::CRT::Rect(0.115f, 0.122f, 0.77f, 0.77f));
+	crt_->set_visible_area(Outputs::CRT::Rect(0.118f, 0.122f, 0.77f, 0.77f));
 	crt_->set_immediate_default_phase(0.0f);
 }
 

--- a/Machines/AppleII/Video.cpp
+++ b/Machines/AppleII/Video.cpp
@@ -24,7 +24,7 @@ VideoBase::VideoBase(bool is_iie) :
 
 	// Show only the centre 75% of the TV frame.
 	crt_->set_video_signal(Outputs::CRT::VideoSignal::Composite);
-	crt_->set_visible_area(Outputs::CRT::Rect(0.115f + 0.030769230769231f, 0.122f, 0.77f, 0.77f));
+	crt_->set_visible_area(Outputs::CRT::Rect(0.115f, 0.122f, 0.77f, 0.77f));
 	crt_->set_immediate_default_phase(0.0f);
 }
 
@@ -36,67 +36,85 @@ Outputs::CRT::CRT *VideoBase::get_crt() {
 	Rote setters and getters.
 */
 void VideoBase::set_alternative_character_set(bool alternative_character_set) {
-	alternative_character_set_ = alternative_character_set;
+	set_alternative_character_set_ = alternative_character_set;
+	defer(2, [=] {
+		alternative_character_set_ = alternative_character_set;
+	});
 }
 
 bool VideoBase::get_alternative_character_set() {
-	return alternative_character_set_;
+	return set_alternative_character_set_;
 }
 
 void VideoBase::set_80_columns(bool columns_80) {
-	columns_80_ = columns_80;
+	set_columns_80_ = columns_80;
+	defer(2, [=] {
+		columns_80_ = columns_80;
+	});
 }
 
 bool VideoBase::get_80_columns() {
-	return columns_80_;
+	return set_columns_80_;
 }
 
 void VideoBase::set_80_store(bool store_80) {
-	store_80_ = store_80;
+	set_store_80_ = store_80_ = store_80;
 }
 
 bool VideoBase::get_80_store() {
-	return store_80_;
+	return set_store_80_;
 }
 
 void VideoBase::set_page2(bool page2) {
-	page2_ = page2;
+	set_page2_ = page2_ = page2;
 }
 
 bool VideoBase::get_page2() {
-	return page2_;
+	return set_page2_;
 }
 
 void VideoBase::set_text(bool text) {
-	text_ = text;
+	set_text_ = text;
+	defer(2, [=] {
+		text_ = text;
+	});
 }
 
 bool VideoBase::get_text() {
-	return text_;
+	return set_text_;
 }
 
 void VideoBase::set_mixed(bool mixed) {
-	mixed_ = mixed;
+	set_mixed_ = mixed;
+	defer(2, [=] {
+		mixed_ = mixed;
+	});
 }
 
 bool VideoBase::get_mixed() {
-	return mixed_;
+	return set_mixed_;
 }
 
 void VideoBase::set_high_resolution(bool high_resolution) {
-	high_resolution_ = high_resolution;
+	set_high_resolution_ = high_resolution;
+	defer(2, [=] {
+		high_resolution_ = high_resolution;
+	});
 }
 
 bool VideoBase::get_high_resolution() {
-	return high_resolution_;
+	return set_high_resolution_;
 }
 
 void VideoBase::set_double_high_resolution(bool double_high_resolution) {
-	double_high_resolution_ = double_high_resolution;
+	set_double_high_resolution_ = double_high_resolution;
+	defer(2, [=] {
+		double_high_resolution_ = double_high_resolution;
+	});
 }
 
 bool VideoBase::get_double_high_resolution() {
-	return double_high_resolution_;
+	return set_double_high_resolution_;
 }
 
 void VideoBase::set_character_rom(const std::vector<uint8_t> &character_rom) {
@@ -282,4 +300,8 @@ void VideoBase::output_double_high_resolution(uint8_t *target, uint8_t *source, 
 		graphics_carry_ = auxiliary_source[c] & 0x40;
 		target += 14;
 	}
+}
+
+void VideoBase::defer(int delay, const std::function<void(void)> &action) {
+	pending_actions_.emplace_back(delay, action);
 }

--- a/Machines/AppleII/Video.cpp
+++ b/Machines/AppleII/Video.cpp
@@ -10,8 +10,9 @@
 
 using namespace AppleII::Video;
 
-VideoBase::VideoBase() :
-	crt_(new Outputs::CRT::CRT(910, 1, Outputs::CRT::DisplayType::NTSC60, 1)) {
+VideoBase::VideoBase(bool is_iie) :
+	crt_(new Outputs::CRT::CRT(910, 1, Outputs::CRT::DisplayType::NTSC60, 1)),
+	is_iie_(is_iie) {
 
 	// Set a composite sampling function that assumes one byte per pixel input, and
 	// accepts any non-zero value as being fully on, zero being fully off.
@@ -114,4 +115,181 @@ void VideoBase::set_character_rom(const std::vector<uint8_t> &character_rom) {
 				((graphic & 0x40) ? 0x01 : 0x00);
 		}
 	}
+}
+
+uint8_t *VideoBase::output_text(uint8_t *target, uint8_t *source, size_t length, size_t pixel_row) {
+	const uint8_t inverses[] = {
+		0xff,
+		is_iie_ ? static_cast<uint8_t>(0xff) : static_cast<uint8_t>((flash_ / flash_length) * 0xff),
+		is_iie_ ? static_cast<uint8_t>(0xff) : static_cast<uint8_t>(0x00),
+		is_iie_ ? static_cast<uint8_t>(0xff) : static_cast<uint8_t>(0x00)
+	};
+	const int or_mask = alternative_character_set_ ? 0x100 : 0x000;
+	const int and_mask = is_iie_ ? ~0 : 0x3f;
+
+	for(size_t c = 0; c < length; ++c) {
+		const int character = (source[c] | or_mask) & and_mask;
+		const uint8_t xor_mask = inverses[character >> 6];
+		const std::size_t character_address = static_cast<std::size_t>(character << 3) + pixel_row;
+		const uint8_t character_pattern = character_rom_[character_address] ^ xor_mask;
+
+		// The character ROM is output MSB to LSB rather than LSB to MSB.
+		target[0] = character_pattern & 0x40;
+		target[1] = character_pattern & 0x20;
+		target[2] = character_pattern & 0x10;
+		target[3] = character_pattern & 0x08;
+		target[4] = character_pattern & 0x04;
+		target[5] = character_pattern & 0x02;
+		target[6] = character_pattern & 0x01;
+		graphics_carry_ = character_pattern & 0x01;
+		target += 7;
+	}
+
+	return target;
+}
+
+uint8_t *VideoBase::output_double_text(uint8_t *target, uint8_t *source, uint8_t *auxiliary_source, size_t length, size_t pixel_row) {
+	for(size_t c = 0; c < length; ++c) {
+		const std::size_t character_addresses[2] = {
+			static_cast<std::size_t>(
+				auxiliary_source[c] << 3
+			) + pixel_row,
+			static_cast<std::size_t>(
+				source[c] << 3
+			) + pixel_row,
+		};
+
+		const size_t pattern_offset = alternative_character_set_ ? (256*8) : 0;
+		const uint8_t character_patterns[2] = {
+			character_rom_[character_addresses[0] + pattern_offset],
+			character_rom_[character_addresses[1] + pattern_offset],
+		};
+
+		// The character ROM is output MSB to LSB rather than LSB to MSB.
+		target[0] = character_patterns[0] & 0x40;
+		target[1] = character_patterns[0] & 0x20;
+		target[2] = character_patterns[0] & 0x10;
+		target[3] = character_patterns[0] & 0x08;
+		target[4] = character_patterns[0] & 0x04;
+		target[5] = character_patterns[0] & 0x02;
+		target[6] = character_patterns[0] & 0x01;
+		target[7] = character_patterns[1] & 0x40;
+		target[8] = character_patterns[1] & 0x20;
+		target[9] = character_patterns[1] & 0x10;
+		target[10] = character_patterns[1] & 0x08;
+		target[11] = character_patterns[1] & 0x04;
+		target[12] = character_patterns[1] & 0x02;
+		target[13] = character_patterns[1] & 0x01;
+		graphics_carry_ = character_patterns[1] & 0x01;
+		target += 14;
+	}
+
+	return target;
+}
+
+uint8_t *VideoBase::output_low_resolution(uint8_t *target, uint8_t *source, size_t length, int row) {
+	const int row_shift = row&4;
+	for(size_t c = 0; c < length; ++c) {
+		// Low-resolution graphics mode shifts the colour code on a loop, but has to account for whether this
+		// 14-sample output window is starting at the beginning of a colour cycle or halfway through.
+		if(c&1) {
+			target[0] = target[4] = target[8] = target[12] = (source[c] >> row_shift) & 4;
+			target[1] = target[5] = target[9] = target[13] = (source[c] >> row_shift) & 8;
+			target[2] = target[6] = target[10] = (source[c] >> row_shift) & 1;
+			target[3] = target[7] = target[11] = (source[c] >> row_shift) & 2;
+			graphics_carry_ = (source[c] >> row_shift) & 8;
+		} else {
+			target[0] = target[4] = target[8] = target[12] = (source[c] >> row_shift) & 1;
+			target[1] = target[5] = target[9] = target[13] = (source[c] >> row_shift) & 2;
+			target[2] = target[6] = target[10] = (source[c] >> row_shift) & 4;
+			target[3] = target[7] = target[11] = (source[c] >> row_shift) & 8;
+			graphics_carry_ = (source[c] >> row_shift) & 2;
+		}
+		target += 14;
+	}
+
+	return target;
+}
+
+uint8_t *VideoBase::output_double_low_resolution(uint8_t *target, uint8_t *source, uint8_t *auxiliary_source, size_t length, int row) {
+	const int row_shift = row&4;
+	for(size_t c = 0; c < length; ++c) {
+		if(c&1) {
+			target[0] = target[4] = (auxiliary_source[c] >> row_shift) & 2;
+			target[1] = target[5] = (auxiliary_source[c] >> row_shift) & 4;
+			target[2] = target[6] = (auxiliary_source[c] >> row_shift) & 8;
+			target[3] = (auxiliary_source[c] >> row_shift) & 1;
+
+			target[8] = target[12] = (source[c] >> row_shift) & 4;
+			target[9] = target[13] = (source[c] >> row_shift) & 8;
+			target[10] = (source[c] >> row_shift) & 1;
+			target[7] = target[11] = (source[c] >> row_shift) & 2;
+			graphics_carry_ = (source[c] >> row_shift) & 8;
+		} else {
+			target[0] = target[4] = (auxiliary_source[c] >> row_shift) & 8;
+			target[1] = target[5] = (auxiliary_source[c] >> row_shift) & 1;
+			target[2] = target[6] = (auxiliary_source[c] >> row_shift) & 2;
+			target[3] = (auxiliary_source[c] >> row_shift) & 4;
+
+			target[8] = target[12] = (source[c] >> row_shift) & 1;
+			target[9] = target[13] = (source[c] >> row_shift) & 2;
+			target[10] = (source[c] >> row_shift) & 4;
+			target[7] = target[11] = (source[c] >> row_shift) & 8;
+			graphics_carry_ = (source[c] >> row_shift) & 2;
+		}
+		target += 14;
+	}
+
+	return target;
+}
+
+uint8_t *VideoBase::output_high_resolution(uint8_t *target, uint8_t *source, size_t length) {
+	for(size_t c = 0; c < length; ++c) {
+		// High resolution graphics shift out LSB to MSB, optionally with a delay of half a pixel.
+		// If there is a delay, the previous output level is held to bridge the gap.
+		if(base_stream_[c] & 0x80) {
+			target[0] = graphics_carry_;
+			target[1] = target[2] = source[c] & 0x01;
+			target[3] = target[4] = source[c] & 0x02;
+			target[5] = target[6] = source[c] & 0x04;
+			target[7] = target[8] = source[c] & 0x08;
+			target[9] = target[10] = source[c] & 0x10;
+			target[11] = target[12] = source[c] & 0x20;
+			target[13] = source[c] & 0x40;
+		} else {
+			target[0] = target[1] = source[c] & 0x01;
+			target[2] = target[3] = source[c] & 0x02;
+			target[4] = target[5] = source[c] & 0x04;
+			target[6] = target[7] = source[c] & 0x08;
+			target[8] = target[9] = source[c] & 0x10;
+			target[10] = target[11] = source[c] & 0x20;
+			target[12] = target[13] = source[c] & 0x40;
+		}
+		graphics_carry_ = source[c] & 0x40;
+		target += 14;
+	}
+	return target;
+}
+
+uint8_t *VideoBase::output_double_high_resolution(uint8_t *target, uint8_t *source, uint8_t *auxiliary_source, size_t length) {
+	for(size_t c = 0; c < length; ++c) {
+		target[0] = graphics_carry_;
+		target[1] = auxiliary_source[c] & 0x01;
+		target[2] = auxiliary_source[c] & 0x02;
+		target[3] = auxiliary_source[c] & 0x04;
+		target[4] = auxiliary_source[c] & 0x08;
+		target[5] = auxiliary_source[c] & 0x10;
+		target[6] = auxiliary_source[c] & 0x20;
+		target[7] = auxiliary_source[c] & 0x40;
+		target[8] = auxiliary_source[c] & 0x01;
+		target[9] = auxiliary_source[c] & 0x02;
+		target[10] = auxiliary_source[c] & 0x04;
+		target[11] = auxiliary_source[c] & 0x08;
+		target[12] = auxiliary_source[c] & 0x10;
+		target[13] = auxiliary_source[c] & 0x20;
+		graphics_carry_ = auxiliary_source[c] & 0x40;
+		pixel_pointer_ += 14;
+	}
+
+	return target;
 }

--- a/Machines/AppleII/Video.cpp
+++ b/Machines/AppleII/Video.cpp
@@ -258,7 +258,7 @@ void VideoBase::output_high_resolution(uint8_t *target, uint8_t *source, size_t 
 	for(size_t c = 0; c < length; ++c) {
 		// High resolution graphics shift out LSB to MSB, optionally with a delay of half a pixel.
 		// If there is a delay, the previous output level is held to bridge the gap.
-		if(base_stream_[c] & 0x80) {
+		if(source[c] & 0x80) {
 			target[0] = graphics_carry_;
 			target[1] = target[2] = source[c] & 0x01;
 			target[3] = target[4] = source[c] & 0x02;

--- a/Machines/AppleII/Video.cpp
+++ b/Machines/AppleII/Video.cpp
@@ -117,7 +117,7 @@ void VideoBase::set_character_rom(const std::vector<uint8_t> &character_rom) {
 	}
 }
 
-uint8_t *VideoBase::output_text(uint8_t *target, uint8_t *source, size_t length, size_t pixel_row) {
+uint8_t *VideoBase::output_text(uint8_t *target, uint8_t *source, size_t length, size_t pixel_row) const {
 	const uint8_t inverses[] = {
 		0xff,
 		is_iie_ ? static_cast<uint8_t>(0xff) : static_cast<uint8_t>((flash_ / flash_length) * 0xff),
@@ -144,11 +144,10 @@ uint8_t *VideoBase::output_text(uint8_t *target, uint8_t *source, size_t length,
 		graphics_carry_ = character_pattern & 0x01;
 		target += 7;
 	}
-
 	return target;
 }
 
-uint8_t *VideoBase::output_double_text(uint8_t *target, uint8_t *source, uint8_t *auxiliary_source, size_t length, size_t pixel_row) {
+uint8_t *VideoBase::output_double_text(uint8_t *target, uint8_t *source, uint8_t *auxiliary_source, size_t length, size_t pixel_row) const {
 	for(size_t c = 0; c < length; ++c) {
 		const std::size_t character_addresses[2] = {
 			static_cast<std::size_t>(
@@ -183,11 +182,10 @@ uint8_t *VideoBase::output_double_text(uint8_t *target, uint8_t *source, uint8_t
 		graphics_carry_ = character_patterns[1] & 0x01;
 		target += 14;
 	}
-
 	return target;
 }
 
-uint8_t *VideoBase::output_low_resolution(uint8_t *target, uint8_t *source, size_t length, int row) {
+uint8_t *VideoBase::output_low_resolution(uint8_t *target, uint8_t *source, size_t length, int row) const {
 	const int row_shift = row&4;
 	for(size_t c = 0; c < length; ++c) {
 		// Low-resolution graphics mode shifts the colour code on a loop, but has to account for whether this
@@ -207,11 +205,10 @@ uint8_t *VideoBase::output_low_resolution(uint8_t *target, uint8_t *source, size
 		}
 		target += 14;
 	}
-
 	return target;
 }
 
-uint8_t *VideoBase::output_double_low_resolution(uint8_t *target, uint8_t *source, uint8_t *auxiliary_source, size_t length, int row) {
+uint8_t *VideoBase::output_double_low_resolution(uint8_t *target, uint8_t *source, uint8_t *auxiliary_source, size_t length, int row) const {
 	const int row_shift = row&4;
 	for(size_t c = 0; c < length; ++c) {
 		if(c&1) {
@@ -239,11 +236,10 @@ uint8_t *VideoBase::output_double_low_resolution(uint8_t *target, uint8_t *sourc
 		}
 		target += 14;
 	}
-
 	return target;
 }
 
-uint8_t *VideoBase::output_high_resolution(uint8_t *target, uint8_t *source, size_t length) {
+uint8_t *VideoBase::output_high_resolution(uint8_t *target, uint8_t *source, size_t length) const {
 	for(size_t c = 0; c < length; ++c) {
 		// High resolution graphics shift out LSB to MSB, optionally with a delay of half a pixel.
 		// If there is a delay, the previous output level is held to bridge the gap.
@@ -271,7 +267,7 @@ uint8_t *VideoBase::output_high_resolution(uint8_t *target, uint8_t *source, siz
 	return target;
 }
 
-uint8_t *VideoBase::output_double_high_resolution(uint8_t *target, uint8_t *source, uint8_t *auxiliary_source, size_t length) {
+uint8_t *VideoBase::output_double_high_resolution(uint8_t *target, uint8_t *source, uint8_t *auxiliary_source, size_t length) const {
 	for(size_t c = 0; c < length; ++c) {
 		target[0] = graphics_carry_;
 		target[1] = auxiliary_source[c] & 0x01;
@@ -288,8 +284,7 @@ uint8_t *VideoBase::output_double_high_resolution(uint8_t *target, uint8_t *sour
 		target[12] = auxiliary_source[c] & 0x10;
 		target[13] = auxiliary_source[c] & 0x20;
 		graphics_carry_ = auxiliary_source[c] & 0x40;
-		pixel_pointer_ += 14;
+		target += 14;
 	}
-
 	return target;
 }

--- a/Machines/AppleII/Video.hpp
+++ b/Machines/AppleII/Video.hpp
@@ -178,7 +178,7 @@ class VideoBase {
 		// Graphics carry is the final level output in a fetch window;
 		// it carries on into the next if it's high resolution with
 		// the delay bit set.
-		uint8_t graphics_carry_ = 0;
+		mutable uint8_t graphics_carry_ = 0;
 
 		// This holds a copy of the character ROM. The regular character
 		// set is assumed to be in the first 64*8 bytes; the alternative
@@ -198,37 +198,37 @@ class VideoBase {
 			Outputs 40-column text to @c target, using @c length bytes from @c source.
 			@return One byte after the final value written to @c target.
 		*/
-		uint8_t *output_text(uint8_t *target, uint8_t *source, size_t length, size_t pixel_row);
+		uint8_t *output_text(uint8_t *target, uint8_t *source, size_t length, size_t pixel_row) const;
 
 		/*!
 			Outputs 80-column text to @c target, drawing @c length columns from @c source and @c auxiliary_source.
 			@return One byte after the final value written to @c target.
 		*/
-		uint8_t *output_double_text(uint8_t *target, uint8_t *source, uint8_t *auxiliary_source, size_t length, size_t pixel_row);
+		uint8_t *output_double_text(uint8_t *target, uint8_t *source, uint8_t *auxiliary_source, size_t length, size_t pixel_row) const;
 
 		/*!
 			Outputs 40-column low-resolution graphics to @c target, drawing @c length columns from @c source.
 			@return One byte after the final value written to @c target.
 		*/
-		uint8_t *output_low_resolution(uint8_t *target, uint8_t *source, size_t length, int row);
+		uint8_t *output_low_resolution(uint8_t *target, uint8_t *source, size_t length, int row) const;
 
 		/*!
 			Outputs 80-column low-resolution graphics to @c target, drawing @c length columns from @c source and @c auxiliary_source.
 			@return One byte after the final value written to @c target.
 		*/
-		uint8_t *output_double_low_resolution(uint8_t *target, uint8_t *source, uint8_t *auxiliary_source, size_t length, int row);
+		uint8_t *output_double_low_resolution(uint8_t *target, uint8_t *source, uint8_t *auxiliary_source, size_t length, int row) const;
 
 		/*!
 			Outputs 40-column high-resolution graphics to @c target, drawing @c length columns from @c source.
 			@return One byte after the final value written to @c target.
 		*/
-		uint8_t *output_high_resolution(uint8_t *target, uint8_t *source, size_t length);
+		uint8_t *output_high_resolution(uint8_t *target, uint8_t *source, size_t length) const;
 
 		/*!
 			Outputs 80-column double-high-resolution graphics to @c target, drawing @c length columns from @c source.
 			@return One byte after the final value written to @c target.
 		*/
-		uint8_t *output_double_high_resolution(uint8_t *target, uint8_t *source, uint8_t *auxiliary_source, size_t length);
+		uint8_t *output_double_high_resolution(uint8_t *target, uint8_t *source, uint8_t *auxiliary_source, size_t length) const;
 };
 
 template <class BusHandler, bool is_iie> class Video: public VideoBase {

--- a/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
@@ -1007,6 +1007,7 @@
 		4B894516201967B4007DE474 /* StaticAnalyser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StaticAnalyser.cpp; sourceTree = "<group>"; };
 		4B894517201967B4007DE474 /* StaticAnalyser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StaticAnalyser.cpp; sourceTree = "<group>"; };
 		4B894540201967D6007DE474 /* Machines.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Machines.hpp; sourceTree = "<group>"; };
+		4B8A7E85212F988200F2BBC6 /* ClockDeferrer.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = ClockDeferrer.hpp; sourceTree = "<group>"; };
 		4B8D287E1F77207100645199 /* TrackSerialiser.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = TrackSerialiser.hpp; sourceTree = "<group>"; };
 		4B8E4ECD1DCE483D003716C3 /* KeyboardMachine.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = KeyboardMachine.hpp; sourceTree = "<group>"; };
 		4B8EF6071FE5AF830076CCDD /* LowpassSpeaker.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = LowpassSpeaker.hpp; sourceTree = "<group>"; };
@@ -3149,6 +3150,7 @@
 				4BB06B211F316A3F00600C7A /* ForceInline.hpp */,
 				4BB146C61F49D7D700253439 /* ClockingHintSource.hpp */,
 				4B449C942063389900A095C8 /* TimeTypes.hpp */,
+				4B8A7E85212F988200F2BBC6 /* ClockDeferrer.hpp */,
 			);
 			name = ClockReceiver;
 			path = ../../ClockReceiver;


### PR DESCRIPTION
Resolves #528 ; also contains a variety of rearrangements that help to separate logic a little more neatly, and introduces the `ClockDeferrer` to help almost anywhere that an action has a delayed effect.