### PR TITLE
Corrects likely crash shortly after starting a TMS9918 or derivative

### DIFF
--- a/Components/9918/9918.cpp
+++ b/Components/9918/9918.cpp
@@ -370,7 +370,8 @@ void TMS9918::run_for(const HalfCycles cycles) {
 				intersect(
 					line_buffer.first_pixel_output_column,
 					line_buffer.next_border_column,
-					if(start == line_buffer.first_pixel_output_column) {
+					if(!asked_for_write_area_) {
+						asked_for_write_area_ = true;
 						pixel_origin_ = pixel_target_ = reinterpret_cast<uint32_t *>(
 							crt_->allocate_write_area(static_cast<unsigned int>(line_buffer.next_border_column - line_buffer.first_pixel_output_column))
 						);
@@ -392,6 +393,7 @@ void TMS9918::run_for(const HalfCycles cycles) {
 						const unsigned int length = static_cast<unsigned int>(line_buffer.next_border_column - line_buffer.first_pixel_output_column);
 						crt_->output_data(length * 4, length);
 						pixel_origin_ = pixel_target_ = nullptr;
+						asked_for_write_area_ = false;
 					}
 				);
 

--- a/Components/9918/Implementation/9918Base.hpp
+++ b/Components/9918/Implementation/9918Base.hpp
@@ -788,6 +788,7 @@ class Base {
 #undef slot
 
 		uint32_t *pixel_target_ = nullptr, *pixel_origin_ = nullptr;
+		bool asked_for_write_area_ = false;
 		void draw_tms_character(int start, int end);
 		void draw_tms_text(int start, int end);
 		void draw_sms(int start, int end);

--- a/Outputs/CRT/Internals/TextureBuilder.hpp
+++ b/Outputs/CRT/Internals/TextureBuilder.hpp
@@ -91,7 +91,7 @@ class TextureBuilder {
 		void submit();
 
 		struct WriteArea {
-			uint16_t x, y, length;
+			uint16_t x = 0, y = 0, length = 0;
 		};
 		/// Finalises all write areas allocated since the last call to @c flush. Only finalised areas will be
 		/// submitted upon the next @c submit. The supplied function will be called with a list of write areas


### PR DESCRIPTION
Also seeks to ensure a more obviously-guaranteed crash should there be a regression in the future.

Issue was: telling the CRT to output data without having previously asked for somewhere to put it. Fix is: make sure that request occurs. For future consideration: make the CRT tolerant to that misuse?

Fixes #560 