### PR TITLE
Ensures offset and flags are initialised to 0.

### DIFF
--- a/Components/9918/Implementation/9918Base.hpp
+++ b/Components/9918/Implementation/9918Base.hpp
@@ -211,8 +211,8 @@ class Base {
 			// The names array holds pattern names, as an offset into memory, and
 			// potentially flags also.
 			struct {
-				size_t offset;
-				uint8_t flags;
+				size_t offset = 0;
+				uint8_t flags = 0;
 			} names[40];
 
 			// The patterns array holds tile patterns, corresponding 1:1 with names.


### PR DESCRIPTION
This prevents a potential crash at startup.