### PR TITLE
Transitions back to explicit FIR usage

### DIFF
--- a/Machines/ZX8081/Video.cpp
+++ b/Machines/ZX8081/Video.cpp
@@ -26,7 +26,7 @@ Video::Video() :
 	crt_(207 * 2, 1, Outputs::Display::Type::PAL50, Outputs::Display::InputDataType::Luminance1) {
 
 	// Show only the centre 80% of the TV frame.
-	crt_.set_display_type(Outputs::Display::DisplayType::CompositeMonochrome);
+	crt_.set_display_type(Outputs::Display::DisplayType::CompositeColour);
 	crt_.set_visible_area(Outputs::Display::Rect(0.1f, 0.1f, 0.8f, 0.8f));
 }
 

--- a/Outputs/OpenGL/Primitives/Shader.cpp
+++ b/Outputs/OpenGL/Primitives/Shader.cpp
@@ -53,7 +53,7 @@ Shader::Shader(const std::string &vertex_shader, const std::string &fragment_sha
 	GLuint index = 0;
 	for(const auto &name: binding_names) {
 		bindings.emplace_back(name, index);
-		++index;
+		index += 4;
 	}
 	init(vertex_shader, fragment_shader, bindings);
 }

--- a/Outputs/OpenGL/Primitives/Shader.hpp
+++ b/Outputs/OpenGL/Primitives/Shader.hpp
@@ -50,7 +50,7 @@ public:
 		Attempts to compile a shader, throwing @c VertexShaderCompilationError, @c FragmentShaderCompilationError or @c ProgramLinkageError upon failure.
 		@param vertex_shader The vertex shader source code.
 		@param fragment_shader The fragment shader source code.
-		@param binding_names A list of attributes to generate bindings for; these will be given indices 0...n-1.
+		@param binding_names A list of attributes to generate bindings for; these will be given indices 0, 4, 8 ... 4(n-1).
 	*/
 	Shader(const std::string &vertex_shader, const std::string &fragment_shader, const std::vector<std::string> &binding_names);
 	~Shader();


### PR DESCRIPTION
Still without intermediate buffering; as well as being more mathematically rigorous and less liable to produce composite artefacts that are in-phase with input data, this seeks to be more robust to sampling errors, albeit through an increase in processing cost.

A relative increase, anyway. It's not intuitive how performance would stack up against the process it's replacing. I think it'll still be an improvement because it still sits upon a huge improvement in data locality, even if it's doing more reading. The actual arithmetic is not unlike that embodied within the original pipeline of three-ish years ago.