### PR TITLE
Reintroduces a separate chrominance buffer

### DIFF
--- a/Machines/AppleII/AppleII.hpp
+++ b/Machines/AppleII/AppleII.hpp
@@ -18,6 +18,9 @@
 
 namespace AppleII {
 
+/// @returns The options available for an Apple II.
+std::vector<std::unique_ptr<Configurable::Option>> get_options();
+
 class Machine {
 	public:
 		virtual ~Machine();

--- a/Machines/AppleII/Video.cpp
+++ b/Machines/AppleII/Video.cpp
@@ -42,6 +42,10 @@ void VideoBase::set_scan_target(Outputs::Display::ScanTarget *scan_target) {
 	crt_.set_scan_target(scan_target);
 }
 
+void VideoBase::set_display_type(Outputs::Display::DisplayType display_type) {
+	crt_.set_display_type(display_type);
+}
+
 /*
 	Rote setters and getters.
 */

--- a/Machines/AppleII/Video.hpp
+++ b/Machines/AppleII/Video.hpp
@@ -39,6 +39,9 @@ class VideoBase {
 		/// Sets the scan target.
 		void set_scan_target(Outputs::Display::ScanTarget *scan_target);
 
+		/// Sets the type of output.
+		void set_display_type(Outputs::Display::DisplayType);
+
 		/*
 			Descriptions for the setters below are taken verbatim from
 			the Apple IIe Technical Reference. Addresses are the conventional

--- a/Machines/Oric/Oric.cpp
+++ b/Machines/Oric/Oric.cpp
@@ -219,6 +219,7 @@ template <Analyser::Static::Oric::Target::DiskInterface disk_interface> class Co
 				via_(via_port_handler_),
 				diskii_(2000000) {
 			set_clock_rate(1000000);
+			speaker_.set_input_rate(1000000.0f);
 			via_port_handler_.set_interrupt_delegate(this);
 			tape_player_.set_delegate(this);
 			Memory::Fuzz(ram_, sizeof(ram_));

--- a/Machines/Utility/MachineForTarget.cpp
+++ b/Machines/Utility/MachineForTarget.cpp
@@ -132,6 +132,7 @@ std::map<std::string, std::vector<std::unique_ptr<Configurable::Option>>> Machin
 	std::map<std::string, std::vector<std::unique_ptr<Configurable::Option>>> options;
 
 	options.emplace(std::make_pair(LongNameForTargetMachine(Analyser::Machine::AmstradCPC), AmstradCPC::get_options()));
+	options.emplace(std::make_pair(LongNameForTargetMachine(Analyser::Machine::AppleII), AppleII::get_options()));
 	options.emplace(std::make_pair(LongNameForTargetMachine(Analyser::Machine::Electron), Electron::get_options()));
 	options.emplace(std::make_pair(LongNameForTargetMachine(Analyser::Machine::MSX), MSX::get_options()));
 	options.emplace(std::make_pair(LongNameForTargetMachine(Analyser::Machine::Oric), Oric::get_options()));

--- a/OSBindings/Mac/Clock Signal/Base.lproj/AppleIIOptions.xib
+++ b/OSBindings/Mac/Clock Signal/Base.lproj/AppleIIOptions.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14113" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14113"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -13,37 +13,43 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Options" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" hidesOnDeactivate="YES" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="ZW7-Bw-4RP" customClass="MachinePanel" customModule="Clock_Signal" customModuleProvider="target">
+        <window title="Options" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" hidesOnDeactivate="YES" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="ZW7-Bw-4RP" customClass="MachinePanel" customModule="Clock_Signal" customModuleProvider="target">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" utility="YES" nonactivatingPanel="YES" HUD="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="80" y="150" width="200" height="54"/>
+            <rect key="contentRect" x="80" y="150" width="200" height="61"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1440" height="900"/>
             <view key="contentView" id="tpZ-0B-QQu">
-                <rect key="frame" x="0.0" y="0.0" width="200" height="54"/>
+                <rect key="frame" x="0.0" y="0.0" width="200" height="61"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <button translatesAutoresizingMaskIntoConstraints="NO" id="e1J-pw-zGw">
-                        <rect key="frame" x="18" y="18" width="164" height="18"/>
-                        <buttonCell key="cell" type="check" title="Accelerate DOS 3.3" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="tD6-UB-ESB">
-                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                            <font key="font" metaFont="system"/>
-                        </buttonCell>
+                    <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ex3-VM-58z">
+                        <rect key="frame" x="18" y="17" width="165" height="25"/>
+                        <popUpButtonCell key="cell" type="push" title="Colour" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="1" imageScaling="proportionallyDown" inset="2" selectedItem="gOu-dv-tre" id="u3N-Je-c2L">
+                            <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="menu"/>
+                            <menu key="menu" id="BUS-Pl-jBm">
+                                <items>
+                                    <menuItem title="Colour" state="on" tag="1" id="gOu-dv-tre"/>
+                                    <menuItem title="Monochrome" tag="3" id="qhQ-ab-jRo"/>
+                                </items>
+                            </menu>
+                        </popUpButtonCell>
                         <connections>
-                            <action selector="setFastLoading:" target="ZW7-Bw-4RP" id="JmG-Ks-jSh"/>
+                            <action selector="setDisplayType:" target="ZW7-Bw-4RP" id="f7A-2O-wR8"/>
                         </connections>
-                    </button>
+                    </popUpButton>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="bottom" secondItem="e1J-pw-zGw" secondAttribute="bottom" constant="20" id="5ce-DO-a4T"/>
-                    <constraint firstItem="e1J-pw-zGw" firstAttribute="leading" secondItem="tpZ-0B-QQu" secondAttribute="leading" constant="20" id="HSD-3d-Bl7"/>
-                    <constraint firstAttribute="trailing" secondItem="e1J-pw-zGw" secondAttribute="trailing" constant="20" id="Q9M-FH-92N"/>
-                    <constraint firstItem="e1J-pw-zGw" firstAttribute="top" secondItem="tpZ-0B-QQu" secondAttribute="top" constant="20" id="ul9-lf-Y3u"/>
+                    <constraint firstAttribute="bottom" secondItem="ex3-VM-58z" secondAttribute="bottom" constant="20" id="4ZS-q5-TJL"/>
+                    <constraint firstItem="ex3-VM-58z" firstAttribute="leading" secondItem="tpZ-0B-QQu" secondAttribute="leading" constant="20" id="8Pj-Ns-TrJ"/>
+                    <constraint firstAttribute="trailing" secondItem="ex3-VM-58z" secondAttribute="trailing" constant="20" id="QWA-lY-ugz"/>
+                    <constraint firstItem="ex3-VM-58z" firstAttribute="top" secondItem="tpZ-0B-QQu" secondAttribute="top" constant="20" id="szw-WO-3tS"/>
                 </constraints>
             </view>
             <connections>
-                <outlet property="fastLoadingButton" destination="e1J-pw-zGw" id="jj7-OZ-mOH"/>
+                <outlet property="displayTypeButton" destination="ex3-VM-58z" id="lmZ-aN-lcj"/>
             </connections>
-            <point key="canvasLocation" x="175" y="30"/>
+            <point key="canvasLocation" x="-161" y="38.5"/>
         </window>
     </objects>
 </document>

--- a/OSBindings/Mac/Clock Signal/Documents/MachinePanel.swift
+++ b/OSBindings/Mac/Clock Signal/Documents/MachinePanel.swift
@@ -32,6 +32,7 @@ class MachinePanel: NSPanel {
 		switch tag {
 			case 1: return .composite
 			case 2: return .sVideo
+			case 3: return .monochromeComposite
 			default: break
 		}
 		return .RGB

--- a/OSBindings/Mac/Clock Signal/Machine/CSMachine.h
+++ b/OSBindings/Mac/Clock Signal/Machine/CSMachine.h
@@ -24,7 +24,8 @@
 typedef NS_ENUM(NSInteger, CSMachineVideoSignal) {
 	CSMachineVideoSignalComposite,
 	CSMachineVideoSignalSVideo,
-	CSMachineVideoSignalRGB
+	CSMachineVideoSignalRGB,
+	CSMachineVideoSignalMonochromeComposite
 };
 
 typedef NS_ENUM(NSInteger, CSMachineKeyboardInputMode) {

--- a/OSBindings/Mac/Clock Signal/Machine/CSMachine.mm
+++ b/OSBindings/Mac/Clock Signal/Machine/CSMachine.mm
@@ -461,9 +461,10 @@ struct ActivityObserver: public Activity::Observer {
 		Configurable::SelectionSet selection_set;
 		Configurable::Display display;
 		switch(videoSignal) {
-			case CSMachineVideoSignalRGB:		display = Configurable::Display::RGB;				break;
-			case CSMachineVideoSignalSVideo:	display = Configurable::Display::SVideo;			break;
-			case CSMachineVideoSignalComposite:	display = Configurable::Display::CompositeColour;	break;
+			case CSMachineVideoSignalRGB:					display = Configurable::Display::RGB;					break;
+			case CSMachineVideoSignalSVideo:				display = Configurable::Display::SVideo;				break;
+			case CSMachineVideoSignalComposite:				display = Configurable::Display::CompositeColour;		break;
+			case CSMachineVideoSignalMonochromeComposite:	display = Configurable::Display::CompositeMonochrome;	break;
 		}
 		append_display_selection(selection_set, display);
 		configurable_device->set_selections(selection_set);
@@ -483,9 +484,10 @@ struct ActivityObserver: public Activity::Observer {
 	// Get the standard option for this video signal.
 	Configurable::StandardOptions option;
 	switch(videoSignal) {
-		case CSMachineVideoSignalRGB:		option = Configurable::DisplayRGB;				break;
-		case CSMachineVideoSignalSVideo:	option = Configurable::DisplaySVideo;			break;
-		case CSMachineVideoSignalComposite:	option = Configurable::DisplayCompositeColour;	break;
+		case CSMachineVideoSignalRGB:					option = Configurable::DisplayRGB;					break;
+		case CSMachineVideoSignalSVideo:				option = Configurable::DisplaySVideo;				break;
+		case CSMachineVideoSignalComposite:				option = Configurable::DisplayCompositeColour;		break;
+		case CSMachineVideoSignalMonochromeComposite:	option = Configurable::DisplayCompositeMonochrome;	break;
 	}
 	std::unique_ptr<Configurable::Option> display_option = std::move(standard_options(option).front());
 	Configurable::ListOption *display_list_option = dynamic_cast<Configurable::ListOption *>(display_option.get());

--- a/OSBindings/Mac/Clock Signal/Machine/StaticAnalyser/CSStaticAnalyser.mm
+++ b/OSBindings/Mac/Clock Signal/Machine/StaticAnalyser/CSStaticAnalyser.mm
@@ -189,7 +189,7 @@ static Analyser::Static::ZX8081::Target::MemoryModel ZX8081MemoryModelFromSize(K
 - (NSString *)optionsPanelNibName {
 	switch(_targets.front()->machine) {
 		case Analyser::Machine::AmstradCPC:		return @"CompositeOptions";
-//		case Analyser::Machine::AppleII:		return @"AppleIIOptions";
+		case Analyser::Machine::AppleII:		return @"AppleIIOptions";
 		case Analyser::Machine::Atari2600:		return @"Atari2600Options";
 		case Analyser::Machine::Electron:		return @"QuickLoadCompositeOptions";
 		case Analyser::Machine::MasterSystem:	return @"CompositeOptions";

--- a/Outputs/OpenGL/Primitives/Shader.cpp
+++ b/Outputs/OpenGL/Primitives/Shader.cpp
@@ -53,7 +53,7 @@ Shader::Shader(const std::string &vertex_shader, const std::string &fragment_sha
 	GLuint index = 0;
 	for(const auto &name: binding_names) {
 		bindings.emplace_back(name, index);
-		index += 4;
+		++index;
 	}
 	init(vertex_shader, fragment_shader, bindings);
 }
@@ -68,6 +68,21 @@ void Shader::init(const std::string &vertex_shader, const std::string &fragment_
 
 	for(const auto &binding : attribute_bindings) {
 		glBindAttribLocation(shader_program_, binding.index, binding.name.c_str());
+#ifndef NDEBUG
+		const auto error = glGetError();
+		switch(error) {
+			case 0: break;
+			case GL_INVALID_VALUE:
+				LOG("GL_INVALID_VALUE when attempting to bind " << binding.name << " to index " << binding.index << " (i.e. index is greater than or equal to GL_MAX_VERTEX_ATTRIBS)");
+			break;
+			case GL_INVALID_OPERATION:
+				LOG("GL_INVALID_OPERATION when attempting to bind " << binding.name << " to index " << binding.index << " (i.e. name begins with gl_)");
+			break;
+			default:
+				LOG("Error " << error << " when attempting to bind " << binding.name << " to index " << binding.index);
+			break;
+		}
+#endif
 	}
 
 	glLinkProgram(shader_program_);

--- a/Outputs/OpenGL/Primitives/Shader.hpp
+++ b/Outputs/OpenGL/Primitives/Shader.hpp
@@ -50,7 +50,7 @@ public:
 		Attempts to compile a shader, throwing @c VertexShaderCompilationError, @c FragmentShaderCompilationError or @c ProgramLinkageError upon failure.
 		@param vertex_shader The vertex shader source code.
 		@param fragment_shader The fragment shader source code.
-		@param binding_names A list of attributes to generate bindings for; these will be given indices 0, 4, 8 ... 4(n-1).
+		@param binding_names A list of attributes to generate bindings for; these will be given indices 0, 1, 2 ... n-1.
 	*/
 	Shader(const std::string &vertex_shader, const std::string &fragment_shader, const std::vector<std::string> &binding_names);
 	~Shader();

--- a/Outputs/OpenGL/ScanTarget.cpp
+++ b/Outputs/OpenGL/ScanTarget.cpp
@@ -308,20 +308,20 @@ void ScanTarget::setup_pipeline() {
 
 	// Destroy or create a QAM buffer and shader, if appropriate.
 	const bool needs_qam_buffer = (modals_.display_type == DisplayType::CompositeColour || modals_.display_type == DisplayType::SVideo);
-	if(needs_qam_buffer && !qam_chroma_texture_) {
-		qam_chroma_texture_.reset(new TextureTarget(LineBufferWidth, LineBufferHeight, QAMChromaTextureUnit, GL_NEAREST, false));
-	} else {
-		qam_chroma_texture_.reset();
-		qam_separation_shader_.reset();
-	}
-
 	if(needs_qam_buffer) {
+		if(!qam_chroma_texture_) {
+			qam_chroma_texture_.reset(new TextureTarget(LineBufferWidth, LineBufferHeight, QAMChromaTextureUnit, GL_NEAREST, false));
+		}
+
 		qam_separation_shader_ = qam_separation_shader();
 		glBindVertexArray(line_vertex_array_);
 		glBindBuffer(GL_ARRAY_BUFFER, line_buffer_name_);
 		enable_vertex_attributes(ShaderType::QAMSeparation, *qam_separation_shader_);
 		set_uniforms(ShaderType::QAMSeparation, *qam_separation_shader_);
 		qam_separation_shader_->set_uniform("textureName", GLint(UnprocessedLineBufferTextureUnit - GL_TEXTURE0));
+	} else {
+		qam_chroma_texture_.reset();
+		qam_separation_shader_.reset();
 	}
 
 	// Establish an output shader.

--- a/Outputs/OpenGL/ScanTarget.hpp
+++ b/Outputs/OpenGL/ScanTarget.hpp
@@ -178,7 +178,8 @@ class ScanTarget: public Outputs::Display::ScanTarget {
 			globals for shaders of @c type to @c target.
 		*/
 		static void enable_vertex_attributes(ShaderType type, Shader &target);
-		void set_uniforms(ShaderType type, Shader &target);
+		void set_uniforms(ShaderType type, Shader &target) const;
+		std::vector<std::string> bindings(ShaderType type) const;
 
 		GLsync fence_ = nullptr;
 		std::atomic_flag is_drawing_;

--- a/Outputs/OpenGL/ScanTargetGLSLFragments.cpp
+++ b/Outputs/OpenGL/ScanTargetGLSLFragments.cpp
@@ -421,15 +421,12 @@ std::unique_ptr<Shader> ScanTarget::conversion_shader() const {
 
 				// Split and average chrominance.
 				"vec2 chrominances[4] = vec2[4]("
-					"textureLod(textureName, qamTextureCoordinates[0], 0).gb,"
-					"textureLod(textureName, qamTextureCoordinates[1], 0).gb,"
-					"textureLod(textureName, qamTextureCoordinates[2], 0).gb,"
-					"textureLod(textureName, qamTextureCoordinates[3], 0).gb"
+					"textureLod(qamTextureName, qamTextureCoordinates[0], 0).gb,"
+					"textureLod(qamTextureName, qamTextureCoordinates[1], 0).gb,"
+					"textureLod(qamTextureName, qamTextureCoordinates[2], 0).gb,"
+					"textureLod(qamTextureName, qamTextureCoordinates[3], 0).gb"
 				");"
-				"vec2 channels = vec2("
-					"dot(vec4(chrominances[0].x, chrominances[1].x, chrominances[2].x, chrominances[3].x), vec4(0.25))*2.0 - 1.0,"
-					"dot(vec4(chrominances[0].y, chrominances[1].y, chrominances[2].y, chrominances[3].y), vec4(0.25))*2.0 - 1.0"
-				");"
+				"vec2 channels = (chrominances[0] + chrominances[1] + chrominances[2] + chrominances[3])*0.5 - vec2(1.0);"
 
 				// Apply a colour space conversion to get RGB.
 				"fragColour3 = mix("

--- a/Outputs/OpenGL/ScanTargetGLSLFragments.cpp
+++ b/Outputs/OpenGL/ScanTargetGLSLFragments.cpp
@@ -14,7 +14,7 @@ using namespace Outputs::Display::OpenGL;
 
 // MARK: - State setup for compiled shaders.
 
-void Outputs::Display::OpenGL::ScanTarget::set_uniforms(ShaderType type, Shader &target) {
+void Outputs::Display::OpenGL::ScanTarget::set_uniforms(ShaderType type, Shader &target) const {
 	// Slightly over-amping rowHeight here is a cheap way to make sure that lines
 	// converge even allowing for the fact that they may not be spaced by exactly
 	// the expected distance. Cf. the stencil-powered logic for making sure all
@@ -142,6 +142,30 @@ void ScanTarget::enable_vertex_attributes(ShaderType type, Shader &target) {
 		break;
 	}
 #undef rt_offset_of
+}
+
+std::vector<std::string> ScanTarget::bindings(ShaderType type) const {
+	switch(type) {
+		case ShaderType::Composition: return {
+			"startDataX",
+			"startClock",
+			"endDataX",
+			"endClock",
+			"dataY",
+			"lineY"
+		};
+
+		default: return {
+			"startPoint",
+			"endPoint",
+			"startClock",
+			"endClock",
+			"lineY",
+			"lineCompositeAmplitude",
+			"startCompositeAngle",
+			"endCompositeAngle"
+		};
+	}
 }
 
 // MARK: - Shader code.
@@ -421,16 +445,7 @@ std::unique_ptr<Shader> ScanTarget::conversion_shader() const {
 	return std::unique_ptr<Shader>(new Shader(
 		vertex_shader,
 		fragment_shader,
-		{
-			"startPoint",
-			"endPoint",
-			"startClock",
-			"endClock",
-			"lineY",
-			"lineCompositeAmplitude",
-			"startCompositeAngle",
-			"endCompositeAngle"
-		}
+		bindings(ShaderType::Conversion)
 	));
 }
 
@@ -504,14 +519,7 @@ std::unique_ptr<Shader> ScanTarget::composition_shader() const {
 	return std::unique_ptr<Shader>(new Shader(
 		vertex_shader,
 		fragment_shader + "}",
-		{
-			"startDataX",
-			"startClock",
-			"endDataX",
-			"endClock",
-			"dataY",
-			"lineY",
-		}
+		bindings(ShaderType::Composition)
 	));
 }
 
@@ -624,14 +632,6 @@ std::unique_ptr<Shader> ScanTarget::qam_separation_shader() const {
 	return std::unique_ptr<Shader>(new Shader(
 		vertex_shader,
 		fragment_shader,
-		{
-			"startClock",
-			"startCompositeAngle",
-			"endClock",
-			"endCompositeAngle",
-
-			"lineY",
-			"lineCompositeAmplitude"
-		}
+		bindings(ShaderType::QAMSeparation)
 	));
 }

--- a/Outputs/OpenGL/ScanTargetGLSLFragments.cpp
+++ b/Outputs/OpenGL/ScanTargetGLSLFragments.cpp
@@ -563,15 +563,16 @@ std::unique_ptr<Shader> ScanTarget::qam_separation_shader() const {
 		"void main(void) {"
 			"float lateral = float(gl_VertexID & 1);"
 			"float longitudinal = float((gl_VertexID & 2) >> 1);"
+			"float centreClock = mix(startClock, endClock, lateral);"
 
-			"vec2 eyePosition = vec2(abs(mix(startCompositeAngle, endCompositeAngle, lateral) * 4.0/64.0), lineY + longitudinal) / vec2(2048.0, 2048.0);"
+			"compositeAngle = mix(startCompositeAngle, endCompositeAngle, lateral) / 64.0;"
+
+			"vec2 eyePosition = vec2(abs(compositeAngle) * 4.0, lineY + longitudinal) / vec2(2048.0, 2048.0);"
 			"gl_Position = vec4(eyePosition*2.0 - vec2(1.0), 0.0, 1.0);"
 
-			"compositeAngle = (mix(startCompositeAngle, endCompositeAngle, lateral) / 32.0) * 3.141592654;"
+			"compositeAngle = compositeAngle * 2.0 * 3.141592654;"
 			"compositeAmplitude = lineCompositeAmplitude / 255.0;"
-			"oneOverCompositeAmplitude = mix(0.0, 255.0 / lineCompositeAmplitude, step(0.01, lineCompositeAmplitude));"
-
-			"float centreClock = mix(startClock, endClock, lateral);";
+			"oneOverCompositeAmplitude = mix(0.0, 255.0 / lineCompositeAmplitude, step(0.01, lineCompositeAmplitude));";
 
 	if(is_svideo) {
 		vertex_shader +=
@@ -617,7 +618,7 @@ std::unique_ptr<Shader> ScanTarget::qam_separation_shader() const {
 	};
 
 	fragment_shader +=
-			"fragColour = fragColour*vec4(0.5) + vec4(0.5);"
+			"fragColour = fragColour*0.5 + vec4(0.5);"
 		"}";
 
 	return std::unique_ptr<Shader>(new Shader(

--- a/Outputs/OpenGL/ScanTargetGLSLFragments.cpp
+++ b/Outputs/OpenGL/ScanTargetGLSLFragments.cpp
@@ -564,7 +564,7 @@ std::unique_ptr<Shader> ScanTarget::qam_separation_shader() const {
 			"float lateral = float(gl_VertexID & 1);"
 			"float longitudinal = float((gl_VertexID & 2) >> 1);"
 
-			"vec2 eyePosition = vec2(abs(mix(startCompositeAngle, endCompositeAngle, lateral) * 4.0), lineY + longitudinal) / vec2(2048.0, 2048.0);"
+			"vec2 eyePosition = vec2(abs(mix(startCompositeAngle, endCompositeAngle, lateral) * 4.0/64.0), lineY + longitudinal) / vec2(2048.0, 2048.0);"
 			"gl_Position = vec4(eyePosition*2.0 - vec2(1.0), 0.0, 1.0);"
 
 			"compositeAngle = (mix(startCompositeAngle, endCompositeAngle, lateral) / 32.0) * 3.141592654;"

--- a/Outputs/OpenGL/ScanTargetGLSLFragments.cpp
+++ b/Outputs/OpenGL/ScanTargetGLSLFragments.cpp
@@ -320,27 +320,13 @@ std::unique_ptr<Shader> ScanTarget::conversion_shader() const {
 		case DisplayType::SVideo:
 			fragment_shader +=
 				// Sample four times over, at proper angle offsets.
-				"vec2 samples[4] = vec2[4]("
-					"svideo_sample(textureCoordinates[0], angles[0]),"
-					"svideo_sample(textureCoordinates[1], angles[1]),"
-					"svideo_sample(textureCoordinates[2], angles[2]),"
-					"svideo_sample(textureCoordinates[3], angles[3])"
-				");"
-				"vec4 chrominances = vec4("
-					"samples[0].y,"
-					"samples[1].y,"
-					"samples[2].y,"
-					"samples[3].y"
-				");"
+				"vec2 sample = svideo_sample(textureCoordinates[1], compositeAngle);"
 
 				// Split and average chrominance.
-				"vec2 channels = vec2("
-					"dot(cos(angles), chrominances),"
-					"dot(sin(angles), chrominances)"
-				") * vec2(0.25);"
+				"vec2 channels = vec2(0.0, 0.0);"
 
 				// Apply a colour space conversion to get RGB.
-				"fragColour3 = lumaChromaToRGB * vec3(samples[1].x, channels);";
+				"fragColour3 = lumaChromaToRGB * vec3(sample.r, channels);";
 		break;
 
 		case DisplayType::CompositeColour:
@@ -593,7 +579,7 @@ std::unique_ptr<Shader> ScanTarget::qam_separation_shader() const {
 
 	if(is_svideo) {
 		vertex_shader +=
-			"textureCoordinate = vec2(centreClock + textureCoordinateOffsets[0], lineY + 0.5) / textureSize(textureName, 0)";
+			"textureCoordinate = vec2(centreClock, lineY + 0.5) / textureSize(textureName, 0);";
 	} else {
 		vertex_shader +=
 			"textureCoordinates[0] = vec2(centreClock + textureCoordinateOffsets[0], lineY + 0.5) / textureSize(textureName, 0);"

--- a/Outputs/OpenGL/ScanTargetGLSLFragments.cpp
+++ b/Outputs/OpenGL/ScanTargetGLSLFragments.cpp
@@ -631,12 +631,10 @@ std::unique_ptr<Shader> ScanTarget::qam_separation_shader() const {
 				// Take the average to calculate luminance, then subtract that from all four samples to
 				// give chrominance.
 				"float luminance = dot(samples, vec4(0.25));"
-				"float chrominance = (samples.y - luminance) * oneOverCompositeAmplitude;"
+				"float chrominance = (dot(samples.yz, vec2(0.5)) - luminance) * oneOverCompositeAmplitude;"
 
-				"vec2 channels = vec2(cos(compositeAngle), sin(compositeAngle)) * chrominance;"
-
-				// Apply a colour space conversion to get RGB.
-				"fragColour = vec4(luminance, channels, 1.0);";
+				// Pack that all up and send it on its way.
+				"fragColour = vec4(luminance, vec2(cos(compositeAngle), sin(compositeAngle)) * chrominance, 1.0);";
 	};
 
 	fragment_shader +=


### PR DESCRIPTION
This diversion back into OpenGL is taking far too long; essentially this switches the whole flow back to what it was for calculating chrominance — a point sample at four times the colour subcarrier, subject to a rolling average.

As it keeps luminance at full output resolution, this does not negate resolution of the aliasing issue.