### PR TITLE
Reintroduces proper locking of the Mac OpenGL context.

### DIFF
--- a/OSBindings/Mac/Clock Signal/Views/CSOpenGLView.m
+++ b/OSBindings/Mac/Clock Signal/Views/CSOpenGLView.m
@@ -52,16 +52,20 @@ static CVReturn DisplayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeSt
 
 - (void)drawAtTime:(const CVTimeStamp *)now frequency:(double)frequency
 {
-	// Draw the display now regardless of other activity.
-	[self performWithGLContext:^{
-		[self.delegate openGLViewRedraw:self event:CSOpenGLViewRedrawEventTimer];
-		CGLFlushDrawable([[self openGLContext] CGLContextObj]);
-	}];
+	[self redrawWithEvent:CSOpenGLViewRedrawEventTimer];
 }
 
 - (void)drawRect:(NSRect)dirtyRect
 {
-	[self.delegate openGLViewRedraw:self event:CSOpenGLViewRedrawEventAppKit];
+	[self redrawWithEvent:CSOpenGLViewRedrawEventAppKit];
+}
+
+- (void)redrawWithEvent:(CSOpenGLViewRedrawEvent)event
+{
+	[self performWithGLContext:^{
+		[self.delegate openGLViewRedraw:self event:event];
+		CGLFlushDrawable([[self openGLContext] CGLContextObj]);
+	}];
 }
 
 - (void)invalidate

--- a/Outputs/OpenGL/ScanTarget.cpp
+++ b/Outputs/OpenGL/ScanTarget.cpp
@@ -679,14 +679,16 @@ void ScanTarget::update(int output_width, int output_height) {
 void ScanTarget::draw(int output_width, int output_height) {
 	while(is_drawing_.test_and_set());
 
-	// Copy the accumulation texture to the target.
-	test_gl(glBindFramebuffer, GL_FRAMEBUFFER, target_framebuffer_);
-	test_gl(glViewport, 0, 0, (GLsizei)output_width, (GLsizei)output_height);
+	if(accumulation_texture_) {
+		// Copy the accumulation texture to the target.
+		test_gl(glBindFramebuffer, GL_FRAMEBUFFER, target_framebuffer_);
+		test_gl(glViewport, 0, 0, (GLsizei)output_width, (GLsizei)output_height);
 
-	test_gl(glClearColor, 0.0f, 0.0f, 0.0f, 0.0f);
-	test_gl(glClear, GL_COLOR_BUFFER_BIT);
-	accumulation_texture_->bind_texture();
-	accumulation_texture_->draw(float(output_width) / float(output_height), 4.0f / 255.0f);
+		test_gl(glClearColor, 0.0f, 0.0f, 0.0f, 0.0f);
+		test_gl(glClear, GL_COLOR_BUFFER_BIT);
+		accumulation_texture_->bind_texture();
+		accumulation_texture_->draw(float(output_width) / float(output_height), 4.0f / 255.0f);
+	}
 
 	is_drawing_.clear();
 }


### PR DESCRIPTION
Also makes sure that ScanTarget's `draw` is safe to call prior to `update`.

Resolves #599
