### PR TITLE
Correct typos in Z80.hpp

### DIFF
--- a/Processors/Z80/Z80.hpp
+++ b/Processors/Z80/Z80.hpp
@@ -98,7 +98,7 @@ struct PartialMachineCycle {
 	const HalfCycles length;
 	/// The current value of the address bus.
 	const uint16_t *const address;
-	/// If the Z80 is outputting to the data bus, a pointer to that value. Otherwise, a pointer to the lcoation where the current data bus value should be placed.
+	/// If the Z80 is outputting to the data bus, a pointer to that value. Otherwise, a pointer to the location where the current data bus value should be placed.
 	uint8_t *const value;
 	/// @c true if this operation is occurring only because of an external request; @c false otherwise.
 	const bool was_requested;
@@ -131,7 +131,7 @@ struct PartialMachineCycle {
 
 /*!
 	A class providing empty implementations of the methods a Z80 uses to access the bus. To wire the Z80 to a bus,
-	machines should subclass BusHandler and then declare a realisation of the Z80 template, suplying their bus
+	machines should subclass BusHandler and then declare a realisation of the Z80 template, supplying their bus
 	handler.
 */
 class BusHandler {
@@ -149,7 +149,7 @@ class BusHandler {
 		}
 
 		/*!
-			Announces completion of all the cycles supplied to a .run_for request on the 6502. Intended to allow
+			Announces completion of all the cycles supplied to a .run_for request on the Z80. Intended to allow
 			bus handlers to perform any deferred output work.
 		*/
 		void flush() {}


### PR DESCRIPTION
Just some small corrections to the comments that I came across while reading the code.