### PR TITLE
Disallows smaller buffer use for 'sharp' displays and tightens sampling window.

### DIFF
--- a/Outputs/OpenGL/ScanTarget.cpp
+++ b/Outputs/OpenGL/ScanTarget.cpp
@@ -393,6 +393,10 @@ Outputs::Display::Metrics &ScanTarget::display_metrics() {
 	return display_metrics_;
 }
 
+bool ScanTarget::is_soft_display_type() {
+	return modals_.display_type == DisplayType::CompositeColour || modals_.display_type == DisplayType::CompositeMonochrome;
+}
+
 void ScanTarget::update(int output_width, int output_height) {
 	if(fence_ != nullptr) {
 		// if the GPU is still busy, don't wait; we'll catch it next time
@@ -557,7 +561,7 @@ void ScanTarget::update(int output_width, int output_height) {
 	// it's a good idea. Go up to a quarter of the requested resolution, subject to
 	// clamping at each stage. If the output resolution changes, or anything else about
 	// the output pipeline, just start trying the highest size again.
-	if(display_metrics_.should_lower_resolution()) {
+	if(display_metrics_.should_lower_resolution() && is_soft_display_type()) {
 		resolution_reduction_level_ = std::min(resolution_reduction_level_+1, 4);
 	}
 	if(output_height_ != output_height || did_setup_pipeline) {

--- a/Outputs/OpenGL/ScanTarget.hpp
+++ b/Outputs/OpenGL/ScanTarget.hpp
@@ -238,6 +238,12 @@ class ScanTarget: public Outputs::Display::ScanTarget {
 		void set_sampling_window(int output_Width, int output_height, Shader &target);
 
 		std::string sampling_function() const;
+
+		/*!
+			@returns true if the current display type is a 'soft' one, i.e. one in which
+			contrast tends to be low, such as a composite colour display.
+		*/
+		bool is_soft_display_type();
 };
 
 }

--- a/Outputs/OpenGL/ScanTargetGLSLFragments.cpp
+++ b/Outputs/OpenGL/ScanTargetGLSLFragments.cpp
@@ -63,7 +63,7 @@ void ScanTarget::set_sampling_window(int output_width, int output_height, Shader
 		GLfloat texture_offsets[4];
 		GLfloat angles[4];
 		for(int c = 0; c < 4; ++c) {
-			texture_offsets[c] = 1.5f * (((one_pixel_width * float(c)) / 3.0f) - (one_pixel_width * 0.5f));
+			texture_offsets[c] = 1.0f * (((one_pixel_width * float(c)) / 3.0f) - (one_pixel_width * 0.5f));
 			angles[c] = GLfloat((texture_offsets[c] / clocks_per_angle) * 2.0f * M_PI);
 		}
 		target.set_uniform("textureCoordinateOffsets", 1, 4, texture_offsets);


### PR DESCRIPTION
Intended to resolve #618