### PR TITLE
Allow for scons to run on Python 3

### DIFF
--- a/OSBindings/SDL/SConstruct
+++ b/OSBindings/SDL/SConstruct
@@ -1,9 +1,10 @@
 import glob
 import sys
 
-# establish UTF-8 encoding
-reload(sys)
-sys.setdefaultencoding('utf-8')
+# establish UTF-8 encoding for Python 2
+if sys.version_info < (3, 0):
+	reload(sys)
+	sys.setdefaultencoding('utf-8')
 
 # create build environment
 env = Environment()


### PR DESCRIPTION
I was trying to build the program using scons as installed from Python 3, but ran into issues with the `reload` and `sys.setdefaultencoding` functions, both of which were removed in Python 3. Seeing as they're not needed, I added a check to only run those functions if the user is using Python 2 or below.