### PR TITLE
Update CSMachine.mm

### DIFF
--- a/OSBindings/Mac/Clock Signal/Machine/CSMachine.mm
+++ b/OSBindings/Mac/Clock Signal/Machine/CSMachine.mm
@@ -131,7 +131,7 @@ struct ActivityObserver: public Activity::Observer {
 }
 
 - (NSString *)description {
-	return [NSString stringWithFormat:@"%@/%@, %@ bytes, CRCs: %@", _fileName, _descriptiveName, @(_size), _crc32s];
+	return [NSString stringWithFormat:@"%@/%@, %lu bytes, CRCs: %@", _fileName, _descriptiveName, (unsigned long)_size, _crc32s];
 }
 
 @end


### PR DESCRIPTION
No need to create a temporary `NSNumber` object to be passed to a variadic method.