### PR TITLE
Implements every-other-cycle-during-pixels RAM timing.

### DIFF
--- a/Machines/Apple/Macintosh/Macintosh.cpp
+++ b/Machines/Apple/Macintosh/Macintosh.cpp
@@ -337,12 +337,12 @@ template <Analyser::Static::Macintosh::Target::Model model> class ConcreteMachin
 					memory_base = ram_.data();
 					word_address &= ram_mask_;
 
-					// Apply a delay due to video contention if applicable; technically this is
-					// incorrectly placed — strictly speaking here I'm extending the part of the
-					// bus cycle after DTACK rather than delaying DTACK. But it adds up to the
-					// same thing.
-					if(ram_subcycle_ < 4) {
-						delay = HalfCycles(4 - ram_subcycle_);
+					// Apply a delay due to video contention if applicable; scheme applied:
+					// only every other access slot is available during the period of video
+					// output. I believe this to be correct for the 128k, 512k and Plus.
+					// More research to do on other models.
+					if(video_is_outputting() && ram_subcycle_ < 8) {
+						delay = HalfCycles(8 - ram_subcycle_);
 						advance_time(delay);
 					}
 				} break;

--- a/Machines/Apple/Macintosh/Video.cpp
+++ b/Machines/Apple/Macintosh/Video.cpp
@@ -14,11 +14,6 @@ using namespace Apple::Macintosh;
 
 namespace {
 
-const HalfCycles line_length(704);
-const int number_of_lines = 370;
-const HalfCycles frame_length(line_length * HalfCycles(number_of_lines));
-const int sync_start = 36;
-const int sync_end = 38;
 
 }
 
@@ -181,13 +176,6 @@ HalfCycles Video::get_next_sequence_point() {
 		else
 			return start_of_vsync + HalfCycles(number_of_lines) * line_length - frame_position_;
 	}
-}
-
-bool Video::is_outputting(HalfCycles offset) {
-	const auto offset_position = frame_position_ + offset % frame_length;
-	const int column = (offset_position % line_length).as_int() >> 4;
-	const int line = (offset_position / line_length).as_int();
-	return line < 342 && column < 32;
 }
 
 void Video::set_use_alternate_buffers(bool use_alternate_screen_buffer, bool use_alternate_audio_buffer) {

--- a/Machines/Apple/Macintosh/Video.hpp
+++ b/Machines/Apple/Macintosh/Video.hpp
@@ -17,6 +17,12 @@
 namespace Apple {
 namespace Macintosh {
 
+static const HalfCycles line_length(704);
+static const int number_of_lines = 370;
+static const HalfCycles frame_length(line_length * HalfCycles(number_of_lines));
+static const int sync_start = 36;
+static const int sync_end = 38;
+
 /*!
 	Models the 68000-era Macintosh video hardware, producing a 512x348 pixel image,
 	within a total scanning area of 370 lines, at 352 cycles per line.
@@ -61,7 +67,12 @@ class Video {
 			@returns @c true if in @c offset half cycles from now, the video will be outputting pixels;
 				@c false otherwise.
 		*/
-		bool is_outputting(HalfCycles offset = HalfCycles(0));
+		bool is_outputting(HalfCycles offset = HalfCycles(0)) {
+			const auto offset_position = frame_position_ + offset % frame_length;
+			const int column = (offset_position % line_length).as_int() >> 4;
+			const int line = (offset_position / line_length).as_int();
+			return line < 342 && column < 32;
+		}
 
 		/*!
 			@returns the amount of time until there is next a transition on the


### PR DESCRIPTION
This is probably the proper scheme for the Macintoshes I actually implement.