### PR TITLE
Corrects time propagation for Apple II cards

### DIFF
--- a/Machines/Apple/AppleII/Card.hpp
+++ b/Machines/Apple/AppleII/Card.hpp
@@ -83,10 +83,8 @@ class Card {
 			will receive a perform_bus_operation every cycle. To reduce the number of
 			virtual method calls, they **will not** receive run_for. run_for will propagate
 			only to cards that register for IO and/or Device accesses only.
-
-
 		*/
-		int get_select_constraints() {
+		int get_select_constraints() const {
 			return select_constraints_;
 		}
 

--- a/Machines/Apple/AppleII/DiskIICard.cpp
+++ b/Machines/Apple/AppleII/DiskIICard.cpp
@@ -65,7 +65,7 @@ void DiskIICard::set_activity_observer(Activity::Observer *observer) {
 
 void DiskIICard::set_component_prefers_clocking(ClockingHint::Source *component, ClockingHint::Preference preference) {
 	diskii_clocking_preference_ = preference;
-	set_select_constraints((preference != ClockingHint::Preference::RealTime) ? (IO | Device) : 0);
+	set_select_constraints((preference != ClockingHint::Preference::RealTime) ? (IO | Device) : None);
 }
 
 Storage::Disk::Drive &DiskIICard::get_drive(int drive) {

--- a/Storage/Disk/Drive.cpp
+++ b/Storage/Disk/Drive.cpp
@@ -20,8 +20,8 @@ using namespace Storage::Disk;
 
 Drive::Drive(int input_clock_rate, int revolutions_per_minute, int number_of_heads):
 	Storage::TimedEventLoop(input_clock_rate),
-	rotational_multiplier_(60.0f / float(revolutions_per_minute)),
 	available_heads_(number_of_heads) {
+	set_rotation_speed(revolutions_per_minute);
 
 	const auto seed = static_cast<std::default_random_engine::result_type>(std::chrono::system_clock::now().time_since_epoch().count());
 	std::default_random_engine randomiser(seed);


### PR DESCRIPTION
... and an issue with post-write head placement for machines with fixed-speed drives (i.e. everything other than the Macintosh).

This fixes #625