### PR TITLE
Resolves a potential out-of-bounds array access.

### DIFF
--- a/Outputs/OpenGL/ScanTarget.cpp
+++ b/Outputs/OpenGL/ScanTarget.cpp
@@ -229,8 +229,10 @@ void ScanTarget::end_data(size_t actual_length) {
 		data_type_size_);
 
 	// The write area was allocated in the knowledge that there's sufficient
-	// distance left on the current line, so there's no need to worry about carry.
+	// distance left on the current line, but there's a risk of exactly filling
+	// the final line, in which case this should wrap back to 0.
 	write_pointers_.write_area += actual_length + 1;
+	write_pointers_.write_area %= write_area_texture_.size();
 
 	// Also bookend the end.
 	memcpy(


### PR DESCRIPTION
Risk was: allocation exactly joins end of buffer. In which case the next get_data won't wrap the texture y coordinate since it won't spot an x overage.

Believed to correct the crashing part of #663 