### PR TITLE
Corrects accidental dropping of pixel residue.

### DIFF
--- a/Machines/Atari/ST/Video.cpp
+++ b/Machines/Atari/ST/Video.cpp
@@ -171,7 +171,7 @@ void Video::run_for(HalfCycles duration) {
 				}
 
 				// Output the start of the next column, if necessary.
-				if(start_column != end_column && (x_ + run_length) & 7) {
+				if((x_ + run_length) & 7) {
 					shifter_.output_pixels((x_ + run_length) & 7, output_bpp_);
 				}
 			}


### PR DESCRIPTION
Specific issue: the repeated (start_column != end_column) test, which can no longer be correct if start_column has been incremented in the (x_&7) test.

The visible effect was to omit pixels from the output wave, which also affected observed sync timing.