### PR TITLE
Corrects off-by-one error in the ST's vertical state machine

### DIFF
--- a/Components/68901/MFP68901.cpp
+++ b/Components/68901/MFP68901.cpp
@@ -209,6 +209,7 @@ HalfCycles MFP68901::get_next_sequence_point() {
 // MARK: - Timers
 
 void MFP68901::set_timer_mode(int timer, TimerMode mode, int prescale, bool reset_timer) {
+	LOG("Timer " << timer << " mode set: " << int(mode) << "; prescale: " << prescale);
 	timers_[timer].mode = mode;
 	timers_[timer].prescale = prescale;
 	if(reset_timer) {
@@ -314,8 +315,6 @@ void MFP68901::update_interrupts() {
 
 	// Update the delegate if necessary.
 	if(interrupt_delegate_ && interrupt_line_ != old_interrupt_line) {
-		if(interrupt_line_)
-			LOG("Generating interrupt: " << std::hex << interrupt_pending_ << " / " << std::hex << interrupt_mask_ << " : " << std::hex << interrupt_in_service_);
 		interrupt_delegate_->mfp68901_did_change_interrupt_status(this);
 	}
 }

--- a/OSBindings/Mac/Clock SignalTests/AtariSTVideoTests.mm
+++ b/OSBindings/Mac/Clock SignalTests/AtariSTVideoTests.mm
@@ -1,0 +1,60 @@
+//
+//  MasterSystemVDPTests.m
+//  Clock SignalTests
+//
+//  Created by Thomas Harte on 09/10/2018.
+//  Copyright © 2018 Thomas Harte. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#include "../../../Machines/Atari/ST/Video.hpp"
+
+@interface AtariSTVideoTests : XCTestCase
+@end
+
+@implementation AtariSTVideoTests
+
+- (void)setUp {
+	[super setUp];
+}
+
+- (void)tearDown {
+	[super tearDown];
+}
+
+- (void)testSequencePoints {
+	// Establish an instance of video.
+	Atari::ST::Video video;
+	uint16_t ram[256*1024];
+	video.set_ram(ram, sizeof(ram));
+
+	// Set 4bpp, 50Hz.
+	video.write(0x05, 0x0200);
+	video.write(0x30, 0x0000);
+
+	// Run for [more than] a whole frame making sure that no observeable outputs
+	// change at any time other than a sequence point.
+	HalfCycles next_event;
+	bool display_enable = false;
+	bool vsync = false;
+	bool hsync = false;
+	for(size_t c = 0; c < 10 * 1000 * 1000; ++c) {
+		const bool is_transition_point = next_event == HalfCycles(0);
+
+		if(is_transition_point) {
+			display_enable = video.display_enabled();
+			vsync = video.vsync();
+			hsync = video.hsync();
+			next_event = video.get_next_sequence_point();
+		} else {
+			NSAssert(display_enable == video.display_enabled(), @"Unannounced change in display enabled at cycle %zu [%d before next sequence point]", c, next_event.as<int>());
+			NSAssert(vsync == video.vsync(), @"Unannounced change in vsync at cycle %zu [%d before next sequence point]", c, next_event.as<int>());
+			NSAssert(hsync == video.hsync(), @"Unannounced change in hsync at cycle %zu [%d before next sequence point]", c, next_event.as<int>());
+		}
+		video.run_for(HalfCycles(2));
+		next_event -= HalfCycles(2);
+	}
+}
+
+@end


### PR DESCRIPTION
Or, arguably, two off-by-one errors. Also adjusts vertical sync placement in horizontal terms.