### PR TITLE
Embraces std::make_[unique/shared] in place of .reset(new .

### DIFF
--- a/Analyser/Static/Commodore/Disk.cpp
+++ b/Analyser/Static/Commodore/Disk.cpp
@@ -22,7 +22,7 @@ class CommodoreGCRParser: public Storage::Disk::Controller {
 		std::shared_ptr<Storage::Disk::Drive> drive;
 
 		CommodoreGCRParser() : Storage::Disk::Controller(4000000), shift_register_(0), track_(1) {
-			drive.reset(new Storage::Disk::Drive(4000000, 300, 2));
+			drive = std::make_shared<Storage::Disk::Drive>(4000000, 300, 2);
 			set_drive(drive);
 			drive->set_motor_on(true);
 		}

--- a/Components/1770/1770.cpp
+++ b/Components/1770/1770.cpp
@@ -91,11 +91,15 @@ uint8_t WD1770::get_register(int address) {
 				if(status_.type == Status::One)
 					status |= (status_.spin_up ? Flag::SpinUp : 0);
 			}
-//			LOG("Returned status " << PADHEX(2) << int(status) << " of type " << 1+int(status_.type));
+			LOG("Returned status " << PADHEX(2) << int(status) << " of type " << 1+int(status_.type));
 			return status;
 		}
-		case 1:		return track_;
-		case 2:		return sector_;
+		case 1:
+			LOG("Returned track " << int(track_));
+			return track_;
+		case 2:
+			LOG("Returned sector " << int(sector_));
+			return sector_;
 		case 3:
 			update_status([] (Status &status) {
 				status.data_request = false;

--- a/Components/68901/MFP68901.cpp
+++ b/Components/68901/MFP68901.cpp
@@ -12,7 +12,7 @@
 #include <cstring>
 
 #define LOG_PREFIX "[MFP] "
-//#define NDEBUG
+#define NDEBUG
 #include "../../Outputs/Log.hpp"
 
 using namespace Motorola::MFP68901;

--- a/Concurrency/AsyncTaskQueue.cpp
+++ b/Concurrency/AsyncTaskQueue.cpp
@@ -18,7 +18,7 @@ AsyncTaskQueue::AsyncTaskQueue()
 #ifdef __APPLE__
 	serial_dispatch_queue_ = dispatch_queue_create("com.thomasharte.clocksignal.asyntaskqueue", DISPATCH_QUEUE_SERIAL);
 #else
-	thread_.reset(new std::thread([this]() {
+	thread_ = std::make_unique<std::thread>([this]() {
 		while(!should_destruct_) {
 			std::function<void(void)> next_function;
 
@@ -39,7 +39,7 @@ AsyncTaskQueue::AsyncTaskQueue()
 				processing_condition_.wait(lock);
 			}
 		}
-	}));
+	});
 #endif
 }
 
@@ -88,7 +88,7 @@ DeferringAsyncTaskQueue::~DeferringAsyncTaskQueue() {
 
 void DeferringAsyncTaskQueue::defer(std::function<void(void)> function) {
 	if(!deferred_tasks_) {
-		deferred_tasks_.reset(new std::list<std::function<void(void)>>);
+		deferred_tasks_ = std::make_shared<std::list<std::function<void(void)>>>();
 	}
 	deferred_tasks_->push_back(function);
 }

--- a/Machines/Apple/AppleII/AppleII.cpp
+++ b/Machines/Apple/AppleII/AppleII.cpp
@@ -851,7 +851,7 @@ template <Analyser::Static::AppleII::Target::Model model> class ConcreteMachine:
 		}
 
 		void type_string(const std::string &string) override {
-			string_serialiser_.reset(new Utility::StringSerialiser(string, true));
+			string_serialiser_ = std::make_unique<Utility::StringSerialiser>(string, true);
 		}
 
 		// MARK:: Configuration options.

--- a/Machines/Atari/2600/Atari2600.cpp
+++ b/Machines/Atari/2600/Atari2600.cpp
@@ -87,35 +87,35 @@ class ConcreteMachine:
 
 			using PagingModel = Target::PagingModel;
 			switch(target.paging_model) {
-				case PagingModel::ActivisionStack:	bus_.reset(new Cartridge::Cartridge<Cartridge::ActivisionStack>(rom));	break;
-				case PagingModel::CBSRamPlus:		bus_.reset(new Cartridge::Cartridge<Cartridge::CBSRAMPlus>(rom));		break;
-				case PagingModel::CommaVid:			bus_.reset(new Cartridge::Cartridge<Cartridge::CommaVid>(rom));			break;
-				case PagingModel::MegaBoy:			bus_.reset(new Cartridge::Cartridge<Cartridge::MegaBoy>(rom));			break;
-				case PagingModel::MNetwork:			bus_.reset(new Cartridge::Cartridge<Cartridge::MNetwork>(rom));			break;
-				case PagingModel::None:				bus_.reset(new Cartridge::Cartridge<Cartridge::Unpaged>(rom));			break;
-				case PagingModel::ParkerBros:		bus_.reset(new Cartridge::Cartridge<Cartridge::ParkerBros>(rom));		break;
-				case PagingModel::Pitfall2:			bus_.reset(new Cartridge::Cartridge<Cartridge::Pitfall2>(rom));			break;
-				case PagingModel::Tigervision:		bus_.reset(new Cartridge::Cartridge<Cartridge::Tigervision>(rom));		break;
+				case PagingModel::ActivisionStack:	bus_ = std::make_unique<Cartridge::Cartridge<Cartridge::ActivisionStack>>(rom);	break;
+				case PagingModel::CBSRamPlus:		bus_ = std::make_unique<Cartridge::Cartridge<Cartridge::CBSRAMPlus>>(rom);		break;
+				case PagingModel::CommaVid:			bus_ = std::make_unique<Cartridge::Cartridge<Cartridge::CommaVid>>(rom);		break;
+				case PagingModel::MegaBoy:			bus_ = std::make_unique<Cartridge::Cartridge<Cartridge::MegaBoy>>(rom);			break;
+				case PagingModel::MNetwork:			bus_ = std::make_unique<Cartridge::Cartridge<Cartridge::MNetwork>>(rom);		break;
+				case PagingModel::None:				bus_ = std::make_unique<Cartridge::Cartridge<Cartridge::Unpaged>>(rom);			break;
+				case PagingModel::ParkerBros:		bus_ = std::make_unique<Cartridge::Cartridge<Cartridge::ParkerBros>>(rom);		break;
+				case PagingModel::Pitfall2:			bus_ = std::make_unique<Cartridge::Cartridge<Cartridge::Pitfall2>>(rom);		break;
+				case PagingModel::Tigervision:		bus_ = std::make_unique<Cartridge::Cartridge<Cartridge::Tigervision>>(rom);		break;
 
 				case PagingModel::Atari8k:
 					if(target.uses_superchip) {
-						bus_.reset(new Cartridge::Cartridge<Cartridge::Atari8kSuperChip>(rom));
+						bus_ = std::make_unique<Cartridge::Cartridge<Cartridge::Atari8kSuperChip>>(rom);
 					} else {
-						bus_.reset(new Cartridge::Cartridge<Cartridge::Atari8k>(rom));
+						bus_ = std::make_unique<Cartridge::Cartridge<Cartridge::Atari8k>>(rom);
 					}
 				break;
 				case PagingModel::Atari16k:
 					if(target.uses_superchip) {
-						bus_.reset(new Cartridge::Cartridge<Cartridge::Atari16kSuperChip>(rom));
+						bus_ = std::make_unique<Cartridge::Cartridge<Cartridge::Atari16kSuperChip>>(rom);
 					} else {
-						bus_.reset(new Cartridge::Cartridge<Cartridge::Atari16k>(rom));
+						bus_ = std::make_unique<Cartridge::Cartridge<Cartridge::Atari16k>>(rom);
 					}
 				break;
 				case PagingModel::Atari32k:
 					if(target.uses_superchip) {
-						bus_.reset(new Cartridge::Cartridge<Cartridge::Atari32kSuperChip>(rom));
+						bus_ = std::make_unique<Cartridge::Cartridge<Cartridge::Atari32kSuperChip>>(rom);
 					} else {
-						bus_.reset(new Cartridge::Cartridge<Cartridge::Atari32k>(rom));
+						bus_ = std::make_unique<Cartridge::Cartridge<Cartridge::Atari32k>>(rom);
 					}
 				break;
 			}

--- a/Machines/Atari/ST/DMAController.cpp
+++ b/Machines/Atari/ST/DMAController.cpp
@@ -187,6 +187,12 @@ int DMAController::bus_grant(uint16_t *ram, size_t size) {
 		// Check that the older buffer is full; stop if not.
 		if(!buffer_[active_buffer_ ^ 1].is_full) return 0;
 
+		printf("[1], to %06x: ", address_);
+		for(int c = 0; c < 16; ++c) {
+			printf("%02x ", buffer_[active_buffer_ ^ 1].contents[c]);
+		}
+		printf("\n");
+
 		for(int c = 0; c < 8; ++c) {
 			if(size_t(address_) < size) {
 				ram[address_ >> 1] = uint16_t(
@@ -200,6 +206,12 @@ int DMAController::bus_grant(uint16_t *ram, size_t size) {
 
 		// Check that the newer buffer is full; stop if not.
 		if(!buffer_[active_buffer_ ].is_full) return 8;
+
+		printf("[2], to %06x: ", address_);
+		for(int c = 0; c < 16; ++c) {
+			printf("%02x ", buffer_[active_buffer_].contents[c]);
+		}
+		printf("\n");
 
 		for(int c = 0; c < 8; ++c) {
 			if(size_t(address_) < size) {

--- a/Machines/Atari/ST/DMAController.cpp
+++ b/Machines/Atari/ST/DMAController.cpp
@@ -8,6 +8,9 @@
 
 #include "DMAController.hpp"
 
+#define LOG_PREFIX "[DMA] "
+#include "../../../Outputs/Log.hpp"
+
 #include <cstdio>
 
 using namespace Atari::ST;
@@ -187,11 +190,11 @@ int DMAController::bus_grant(uint16_t *ram, size_t size) {
 		// Check that the older buffer is full; stop if not.
 		if(!buffer_[active_buffer_ ^ 1].is_full) return 0;
 
-		printf("[1], to %06x: ", address_);
-		for(int c = 0; c < 16; ++c) {
-			printf("%02x ", buffer_[active_buffer_ ^ 1].contents[c]);
-		}
-		printf("\n");
+#define b(i, n) " " << PADHEX(2) << buffer_[i].contents[n]
+#define b2(i, n) b(i, n) << b(i, n+1)
+#define b4(i, n) b2(i, n) << b2(i, n+2)
+#define b16(i) b4(i, 0) << b4(i, 4) << b4(i, 8) << b4(i, 12)
+		LOG("[1] to " << PADHEX(6) << address_ << b16(active_buffer_ ^ 1));
 
 		for(int c = 0; c < 8; ++c) {
 			if(size_t(address_) < size) {
@@ -207,11 +210,11 @@ int DMAController::bus_grant(uint16_t *ram, size_t size) {
 		// Check that the newer buffer is full; stop if not.
 		if(!buffer_[active_buffer_ ].is_full) return 8;
 
-		printf("[2], to %06x: ", address_);
-		for(int c = 0; c < 16; ++c) {
-			printf("%02x ", buffer_[active_buffer_].contents[c]);
-		}
-		printf("\n");
+		LOG("[2] to " << PADHEX(6) << address_ << b16(active_buffer_));
+#undef b16
+#undef b4
+#undef b2
+#undef b
 
 		for(int c = 0; c < 8; ++c) {
 			if(size_t(address_) < size) {

--- a/Machines/Commodore/Vic-20/Vic20.cpp
+++ b/Machines/Commodore/Vic-20/Vic20.cpp
@@ -369,7 +369,7 @@ class ConcreteMachine:
 
 			if(target.has_c1540) {
 				// construct the 1540
-				c1540_.reset(new ::Commodore::C1540::Machine(Commodore::C1540::Personality::C1540, rom_fetcher));
+				c1540_ = std::make_unique<::Commodore::C1540::Machine>(Commodore::C1540::Personality::C1540, rom_fetcher);
 
 				// attach it to the serial bus
 				c1540_->set_serial_bus(serial_bus_);

--- a/Machines/Electron/Electron.cpp
+++ b/Machines/Electron/Electron.cpp
@@ -88,7 +88,7 @@ class ConcreteMachine:
 			set_rom(ROM::OS, *roms[1], false);
 
 			if(target.has_dfs || target.has_adfs) {
-				plus3_.reset(new Plus3);
+				plus3_ = std::make_unique<Plus3>();
 
 				if(target.has_dfs) {
 					set_rom(ROM::Slot0, *roms[dfs_rom_position], true);

--- a/Machines/MSX/DiskROM.cpp
+++ b/Machines/MSX/DiskROM.cpp
@@ -13,8 +13,8 @@ using namespace MSX;
 DiskROM::DiskROM(const std::vector<uint8_t> &rom) :
 	WD1770(P1793),
 	rom_(rom) {
-	drives_[0].reset(new Storage::Disk::Drive(8000000, 300, 2));
-	drives_[1].reset(new Storage::Disk::Drive(8000000, 300, 2));
+	drives_[0] = std::make_shared<Storage::Disk::Drive>(8000000, 300, 2);
+	drives_[1] = std::make_shared<Storage::Disk::Drive>(8000000, 300, 2);
 	set_is_double_density(true);
 }
 

--- a/Machines/Oric/Microdisc.cpp
+++ b/Machines/Oric/Microdisc.cpp
@@ -24,7 +24,7 @@ Microdisc::Microdisc() : WD1770(P1793) {
 
 void Microdisc::set_disk(std::shared_ptr<Storage::Disk::Disk> disk, size_t drive) {
 	if(!drives_[drive]) {
-		drives_[drive].reset(new Storage::Disk::Drive(8000000, 300, 2));
+		drives_[drive] = std::make_unique<Storage::Disk::Drive>(8000000, 300, 2);
 		if(drive == selected_drive_) set_drive(drives_[drive]);
 		drives_[drive]->set_activity_observer(observer_, drive_name(drive), false);
 	}

--- a/Machines/Oric/Oric.cpp
+++ b/Machines/Oric/Oric.cpp
@@ -500,7 +500,7 @@ template <Analyser::Static::Oric::Target::DiskInterface disk_interface> class Co
 
 		// for Utility::TypeRecipient::Delegate
 		void type_string(const std::string &string) override final {
-			string_serialiser_.reset(new Utility::StringSerialiser(string, true));
+			string_serialiser_ = std::make_unique<Utility::StringSerialiser>(string, true);
 		}
 
 		// for Microdisc::Delegate

--- a/Machines/Utility/Typer.hpp
+++ b/Machines/Utility/Typer.hpp
@@ -85,7 +85,7 @@ class TypeRecipient: public Typer::Delegate {
 	protected:
 		/// Attaches a typer to this class that will type @c string using @c character_mapper as a source.
 		void add_typer(const std::string &string, std::unique_ptr<CharacterMapper> character_mapper) {
-			typer_.reset(new Typer(string, get_typer_delay(), get_typer_frequency(), std::move(character_mapper), this));
+			typer_ = std::make_unique<Typer>(string, get_typer_delay(), get_typer_frequency(), std::move(character_mapper), this);
 		}
 
 		/*!

--- a/OSBindings/Mac/Clock Signal.xcodeproj/xcshareddata/xcschemes/Clock Signal.xcscheme
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/xcshareddata/xcschemes/Clock Signal.xcscheme
@@ -67,7 +67,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       enableASanStackUseAfterReturn = "YES"

--- a/OSBindings/Mac/Clock Signal/Machine/CSMachine.mm
+++ b/OSBindings/Mac/Clock Signal/Machine/CSMachine.mm
@@ -321,7 +321,7 @@ struct ActivityObserver: public Activity::Observer {
 }
 
 - (void)setupOutputWithAspectRatio:(float)aspectRatio {
-	_scanTarget.reset(new Outputs::Display::OpenGL::ScanTarget);
+	_scanTarget = std::make_unique<Outputs::Display::OpenGL::ScanTarget>();
 	_machine->crt_machine()->set_scan_target(_scanTarget.get());
 }
 

--- a/OSBindings/Mac/Clock SignalTests/68000ArithmeticTests.mm
+++ b/OSBindings/Mac/Clock SignalTests/68000ArithmeticTests.mm
@@ -23,7 +23,7 @@
 }
 
 - (void)setUp {
-    _machine.reset(new RAM68000());
+    _machine = std::make_unique<RAM68000>();
 }
 
 - (void)tearDown {

--- a/OSBindings/Mac/Clock SignalTests/68000BCDTests.mm
+++ b/OSBindings/Mac/Clock SignalTests/68000BCDTests.mm
@@ -19,7 +19,7 @@
 }
 
 - (void)setUp {
-    _machine.reset(new RAM68000());
+    _machine = std::make_unique<RAM68000>();
 }
 
 - (void)tearDown {

--- a/OSBindings/Mac/Clock SignalTests/68000BitwiseTests.mm
+++ b/OSBindings/Mac/Clock SignalTests/68000BitwiseTests.mm
@@ -19,7 +19,7 @@
 }
 
 - (void)setUp {
-    _machine.reset(new RAM68000());
+    _machine = std::make_unique<RAM68000>();
 }
 
 - (void)tearDown {

--- a/OSBindings/Mac/Clock SignalTests/68000ControlFlowTests.mm
+++ b/OSBindings/Mac/Clock SignalTests/68000ControlFlowTests.mm
@@ -20,7 +20,7 @@
 }
 
 - (void)setUp {
-    _machine.reset(new RAM68000());
+    _machine = std::make_unique<RAM68000>();
 }
 
 - (void)tearDown {

--- a/OSBindings/Mac/Clock SignalTests/68000MoveTests.mm
+++ b/OSBindings/Mac/Clock SignalTests/68000MoveTests.mm
@@ -19,7 +19,7 @@
 }
 
 - (void)setUp {
-    _machine.reset(new RAM68000());
+    _machine = std::make_unique<RAM68000>();
 }
 
 - (void)tearDown {

--- a/OSBindings/Mac/Clock SignalTests/68000RollShiftTests.mm
+++ b/OSBindings/Mac/Clock SignalTests/68000RollShiftTests.mm
@@ -20,7 +20,7 @@
 }
 
 - (void)setUp {
-    _machine.reset(new RAM68000());
+    _machine = std::make_unique<RAM68000>();
 }
 
 - (void)tearDown {

--- a/OSBindings/Mac/Clock SignalTests/68000Tests.mm
+++ b/OSBindings/Mac/Clock SignalTests/68000Tests.mm
@@ -111,7 +111,7 @@ class CPU::MC68000::ProcessorStorageTests {
 }
 
 - (void)setUp {
-    _machine.reset(new RAM68000());
+    _machine = std::make_unique<RAM68000>();
 }
 
 - (void)tearDown {
@@ -120,7 +120,7 @@ class CPU::MC68000::ProcessorStorageTests {
 
 - (void)testABCDLong {
 	for(int d = 0; d < 100; ++d) {
-		_machine.reset(new RAM68000());
+		_machine = std::make_unique<RAM68000>();
 		_machine->set_program({
 			0xc100		// ABCD D0, D0
 		});

--- a/OSBindings/Mac/Clock SignalTests/Bridges/C1540Bridge.mm
+++ b/OSBindings/Mac/Clock SignalTests/Bridges/C1540Bridge.mm
@@ -11,6 +11,8 @@
 #include "NSData+StdVector.h"
 #include "CSROMFetcher.hpp"
 
+#include <memory>
+
 class VanillaSerialPort: public Commodore::Serial::Port {
 	public:
 		void set_input(Commodore::Serial::Line line, Commodore::Serial::LineLevel value) {
@@ -29,11 +31,11 @@ class VanillaSerialPort: public Commodore::Serial::Port {
 - (instancetype)init {
 	self = [super init];
 	if(self) {
-		_serialBus.reset(new ::Commodore::Serial::Bus);
-		_serialPort.reset(new VanillaSerialPort);
+		_serialBus = std::make_shared<::Commodore::Serial::Bus>();
+		_serialPort = std::make_shared<VanillaSerialPort>();
 
 		auto rom_fetcher = CSROMFetcher();
-		_c1540.reset(new Commodore::C1540::Machine(Commodore::C1540::Personality::C1540, rom_fetcher));
+		_c1540 = std::make_unique<Commodore::C1540::Machine>(Commodore::C1540::Personality::C1540, rom_fetcher);
 		_c1540->set_serial_bus(_serialBus);
 		Commodore::Serial::AttachPortAndBus(_serialPort, _serialBus);
 	}

--- a/OSBindings/Mac/Clock SignalTests/Bridges/DigitalPhaseLockedLoopBridge.mm
+++ b/OSBindings/Mac/Clock SignalTests/Bridges/DigitalPhaseLockedLoopBridge.mm
@@ -32,7 +32,7 @@ class DigitalPhaseLockedLoopDelegate: public Storage::DigitalPhaseLockedLoop::De
 - (instancetype)initWithClocksPerBit:(NSUInteger)clocksPerBit historyLength:(NSUInteger)historyLength {
 	self = [super init];
 	if(self) {
-		_digitalPhaseLockedLoop.reset(new Storage::DigitalPhaseLockedLoop((unsigned int)clocksPerBit, (unsigned int)historyLength));
+		_digitalPhaseLockedLoop = std::make_unique<Storage::DigitalPhaseLockedLoop>((unsigned int)clocksPerBit, (unsigned int)historyLength));
 		_delegate.bridge = self;
 		_digitalPhaseLockedLoop->set_delegate(&_delegate);
 	}

--- a/OSBindings/Mac/Clock SignalTests/Bridges/MOS6522Bridge.mm
+++ b/OSBindings/Mac/Clock SignalTests/Bridges/MOS6522Bridge.mm
@@ -46,7 +46,7 @@ class VanillaVIAPortHandler: public MOS::MOS6522::PortHandler {
 - (instancetype)init {
 	self = [super init];
 	if(self) {
-		_via.reset(new MOS::MOS6522::MOS6522<VanillaVIAPortHandler>(_viaPortHandler));
+		_via = std::make_unique<MOS::MOS6522::MOS6522<VanillaVIAPortHandler>(_viaPortHandler);
 		_viaPortHandler.bridge = self;
 	}
 	return self;

--- a/OSBindings/Mac/Clock SignalTests/EmuTOSTests.mm
+++ b/OSBindings/Mac/Clock SignalTests/EmuTOSTests.mm
@@ -107,7 +107,7 @@ class EmuTOS: public ComparativeBusHandler {
 	const std::vector<ROMMachine::ROM> rom_names = {{"AtariST", "", image.UTF8String, 0, 0 }};
     const auto roms = CSROMFetcher()(rom_names);
 	NSString *const traceLocation = [[NSBundle bundleForClass:[self class]] pathForResource:trace ofType:@"trace.txt.gz"];
-    _machine.reset(new EmuTOS(*roms[0], traceLocation.UTF8String));
+    _machine = std::make_unique<EmuTOS>(*roms[0], traceLocation.UTF8String);
     _machine->run_for(HalfCycles(length));
 }
 

--- a/OSBindings/Mac/Clock SignalTests/MacintoshVideoTests.mm
+++ b/OSBindings/Mac/Clock SignalTests/MacintoshVideoTests.mm
@@ -23,7 +23,7 @@
 
 - (void)setUp {
 	// Put setup code here. This method is called before the invocation of each test method in the class.
-	_video.reset(new Apple::Macintosh::Video(_dummy_audio, _dummy_drive_speed_accumulator));
+	_video = std::make_unique<Apple::Macintosh::Video>(_dummy_audio, _dummy_drive_speed_accumulator);
 	_video->set_ram(_ram, sizeof(_ram) - 1);
 }
 

--- a/OSBindings/Mac/Clock SignalTests/QLTests.mm
+++ b/OSBindings/Mac/Clock SignalTests/QLTests.mm
@@ -104,7 +104,7 @@ class QL: public ComparativeBusHandler {
 	const std::vector<ROMMachine::ROM> rom_names = {{"SinclairQL", "", "js.rom", 0, 0 }};
 	const auto roms = CSROMFetcher()(rom_names);
 	NSString *const traceLocation = [[NSBundle bundleForClass:[self class]] pathForResource:@"qltrace" ofType:@".txt.gz"];
-	_machine.reset(new QL(*roms[0], traceLocation.UTF8String));
+	_machine = std::make_unique<QL>(*roms[0], traceLocation.UTF8String);
 
 	// This is how many cycles it takes to exhaust the supplied trace file.
 	_machine->run_for(HalfCycles(23923180));

--- a/OSBindings/Mac/Clock SignalTests/TIATests.mm
+++ b/OSBindings/Mac/Clock SignalTests/TIATests.mm
@@ -27,7 +27,7 @@ static void receive_line(uint8_t *next_line)
 {
 	[super setUp];
 	std::function<void(uint8_t *)> function = receive_line;
-	_tia.reset(new Atari2600::TIA(function));
+	_tia = std::make_unique<Atari2600::TIA>(function);
 	line = nullptr;
 
 	_tia->set_playfield(0, 0x00);

--- a/OSBindings/SDL/main.cpp
+++ b/OSBindings/SDL/main.cpp
@@ -248,11 +248,11 @@ ParsedArguments parse_arguments(int argc, char *argv[]) {
 			std::size_t split_index = argument.find("=");
 
 			if(split_index == std::string::npos) {
-				arguments.selections[argument].reset(new Configurable::BooleanSelection(true));
+				arguments.selections[argument] = std::make_unique<Configurable::BooleanSelection>(true);
 			} else {
 				std::string name = argument.substr(0, split_index);
 				std::string value = argument.substr(split_index+1, std::string::npos);
-				arguments.selections[name].reset(new Configurable::ListSelection(value));
+				arguments.selections[name] = std::make_unique<Configurable::ListSelection>(value);
 			}
 		} else {
 			arguments.file_name = arg;
@@ -609,7 +609,7 @@ int main(int argc, char *argv[]) {
 	std::unique_ptr<ActivityObserver> activity_observer;
 	Activity::Source *const activity_source = machine->activity_source();
 	if(activity_source) {
-		activity_observer.reset(new ActivityObserver(activity_source, 4.0f / 3.0f));
+		activity_observer = std::make_unique<ActivityObserver>(activity_source, 4.0f / 3.0f);
 	}
 
 	// Run the main event loop until the OS tells us to quit.

--- a/Outputs/CRT/CRT.cpp
+++ b/Outputs/CRT/CRT.cpp
@@ -50,8 +50,8 @@ void CRT::set_new_timing(int cycles_per_line, int height_of_display, Outputs::Di
 	// The vertical slywheel has an ideal period of `multiplied_cycles_per_line * height_of_display`,
 	// will accept syncs within 1/8th of that (i.e. tolerates 12.5% error) and takes scanlinesVerticalRetraceTime
 	// to retrace.
-	horizontal_flywheel_.reset(new Flywheel(multiplied_cycles_per_line, (millisecondsHorizontalRetraceTime * multiplied_cycles_per_line) >> 6, multiplied_cycles_per_line >> 5));
-	vertical_flywheel_.reset(new Flywheel(multiplied_cycles_per_line * height_of_display, scanlinesVerticalRetraceTime * multiplied_cycles_per_line, (multiplied_cycles_per_line * height_of_display) >> 3));
+	horizontal_flywheel_ = std::make_unique<Flywheel>(multiplied_cycles_per_line, (millisecondsHorizontalRetraceTime * multiplied_cycles_per_line) >> 6, multiplied_cycles_per_line >> 5);
+	vertical_flywheel_ = std::make_unique<Flywheel>(multiplied_cycles_per_line * height_of_display, scanlinesVerticalRetraceTime * multiplied_cycles_per_line, (multiplied_cycles_per_line * height_of_display) >> 3);
 
 	// Figure out the divisor necessary to get the horizontal flywheel into a 16-bit range.
 	const int real_clock_scan_period = vertical_flywheel_->get_scan_period();

--- a/Outputs/OpenGL/Primitives/TextureTarget.cpp
+++ b/Outputs/OpenGL/Primitives/TextureTarget.cpp
@@ -122,7 +122,7 @@ void TextureTarget::draw(float aspect_ratio, float colour_threshold) const {
 			"{"
 				"fragColour = clamp(texture(texID, texCoordVarying), threshold, 1.0);"
 			"}";
-		pixel_shader_.reset(new Shader(vertex_shader, fragment_shader));
+		pixel_shader_ = std::make_unique<Shader>(vertex_shader, fragment_shader);
 		pixel_shader_->bind();
 
 		test_gl(glGenVertexArrays, 1, &drawing_vertex_array_);

--- a/Outputs/OpenGL/ScanTarget.cpp
+++ b/Outputs/OpenGL/ScanTarget.cpp
@@ -369,7 +369,7 @@ void ScanTarget::setup_pipeline() {
 	const bool needs_qam_buffer = (modals_.display_type == DisplayType::CompositeColour || modals_.display_type == DisplayType::SVideo);
 	if(needs_qam_buffer) {
 		if(!qam_chroma_texture_) {
-			qam_chroma_texture_.reset(new TextureTarget(LineBufferWidth, LineBufferHeight, QAMChromaTextureUnit, GL_NEAREST, false));
+			qam_chroma_texture_ = std::make_unique<TextureTarget>(LineBufferWidth, LineBufferHeight, QAMChromaTextureUnit, GL_NEAREST, false);
 		}
 
 		qam_separation_shader_ = qam_separation_shader();

--- a/Outputs/Speaker/Implementation/LowpassSpeaker.hpp
+++ b/Outputs/Speaker/Implementation/LowpassSpeaker.hpp
@@ -219,16 +219,16 @@ template <typename T> class LowpassSpeaker: public Speaker {
 			number_of_taps = (number_of_taps * 2) | 1;
 
 			output_buffer_pointer_ = 0;
-			stepper_.reset(new SignalProcessing::Stepper(
+			stepper_ = std::make_unique<SignalProcessing::Stepper>(
 				uint64_t(filter_parameters.input_cycles_per_second),
-				uint64_t(filter_parameters.output_cycles_per_second)));
+				uint64_t(filter_parameters.output_cycles_per_second));
 
-			filter_.reset(new SignalProcessing::FIRFilter(
+			filter_ = std::make_unique<SignalProcessing::FIRFilter>(
 				static_cast<unsigned int>(number_of_taps),
 				filter_parameters.input_cycles_per_second,
 				0.0,
 				high_pass_frequency,
-				SignalProcessing::FIRFilter::DefaultAttenuation));
+				SignalProcessing::FIRFilter::DefaultAttenuation);
 
 			input_buffer_.resize(std::size_t(number_of_taps));
 			input_buffer_depth_ = 0;

--- a/Storage/Disk/Controller/DiskController.cpp
+++ b/Storage/Disk/Controller/DiskController.cpp
@@ -67,7 +67,7 @@ void Controller::set_expected_bit_length(Time bit_length) {
 	// this conversion doesn't need to be exact because there's a lot of variation to be taken
 	// account of in rotation speed, air turbulence, etc, so a direct conversion will do
 	int clocks_per_bit = cycles_per_bit.get<int>();
-	pll_.reset(new DigitalPhaseLockedLoop(clocks_per_bit, 3));
+	pll_ = std::make_unique<DigitalPhaseLockedLoop>(clocks_per_bit, 3);
 	pll_->set_delegate(this);
 }
 

--- a/Storage/Disk/DiskImage/DiskImageImplementation.hpp
+++ b/Storage/Disk/DiskImage/DiskImageImplementation.hpp
@@ -20,7 +20,7 @@ template <typename T> bool DiskImageHolder<T>::get_is_read_only() {
 
 template <typename T> void DiskImageHolder<T>::flush_tracks() {
 	if(!unwritten_tracks_.empty()) {
-		if(!update_queue_) update_queue_.reset(new Concurrency::AsyncTaskQueue);
+		if(!update_queue_) update_queue_ = std::make_unique<Concurrency::AsyncTaskQueue>();
 
 		using TrackMap = std::map<Track::Address, std::shared_ptr<Track>>;
 		std::shared_ptr<TrackMap> track_copies(new TrackMap);

--- a/Storage/Disk/DiskImage/Formats/G64.cpp
+++ b/Storage/Disk/DiskImage/Formats/G64.cpp
@@ -93,7 +93,7 @@ std::shared_ptr<Track> G64::get_track_at_position(Track::Address address) {
 			}
 		}
 
-		resulting_track.reset(new PCMTrack(std::move(segments)));
+		resulting_track = std::make_shared<PCMTrack>(std::move(segments));
 	} else {
 		PCMSegment segment(
 			Encodings::CommodoreGCR::length_of_a_bit_in_time_zone(static_cast<unsigned int>(speed_zone_offset)),
@@ -101,7 +101,7 @@ std::shared_ptr<Track> G64::get_track_at_position(Track::Address address) {
 			track_contents
 		);
 
-		resulting_track.reset(new PCMTrack(std::move(segment)));
+		resulting_track = std::make_shared<PCMTrack>(std::move(segment));
 	}
 
 	// TODO: find out whether it's possible for a G64 to supply only a partial track. I don't think it is, which would make the

--- a/Storage/Disk/Drive.cpp
+++ b/Storage/Disk/Drive.cpp
@@ -301,7 +301,7 @@ void Drive::set_track(const std::shared_ptr<Track> &track) {
 void Drive::setup_track() {
 	track_ = get_track();
 	if(!track_) {
-		track_.reset(new UnformattedTrack);
+		track_ = std::make_shared<UnformattedTrack>();
 	}
 
 	float offset = 0.0f;

--- a/Storage/Disk/Encodings/AppleGCR/SegmentParser.cpp
+++ b/Storage/Disk/Encodings/AppleGCR/SegmentParser.cpp
@@ -85,7 +85,7 @@ std::map<std::size_t, Sector> Storage::Encodings::AppleGCR::sectors_from_segment
 				// If this is the start of a data section, and at least
 				// one header has been witnessed, start a sector.
 				if(scanner[2] == data_prologue[2]) {
-					new_sector.reset(new Sector);
+					new_sector = std::make_unique<Sector>();
 					new_sector->data.reserve(710);
 				} else {
 					sector_location = static_cast<std::size_t>(bit % segment.data.size());

--- a/Storage/Disk/Encodings/MFM/SegmentParser.cpp
+++ b/Storage/Disk/Encodings/MFM/SegmentParser.cpp
@@ -35,7 +35,7 @@ std::map<std::size_t, Storage::Encodings::MFM::Sector> Storage::Encodings::MFM::
 			break;
 
 			case Shifter::Token::ID:
-				new_sector.reset(new Storage::Encodings::MFM::Sector);
+				new_sector = std::make_unique<Storage::Encodings::MFM::Sector>();
 				is_reading = true;
 				start_location = bit_cursor;
 				position = 0;


### PR DESCRIPTION
Now that I've standardised on C++17, I'm buying into the try-to-avoid-`new` world. At least to some extent.