### PR TITLE
Further improves the ST graphics subsystem

### DIFF
--- a/ClockReceiver/JustInTime.hpp
+++ b/ClockReceiver/JustInTime.hpp
@@ -29,7 +29,7 @@ template <class T, int multiplier = 1, int divider = 1, class LocalTimeScale = H
 
 		/// Adds time to the actor.
 		forceinline void operator += (const LocalTimeScale &rhs) {
-			if(multiplier != 1) {
+			if constexpr (multiplier != 1) {
 				time_since_update_ += rhs * multiplier;
 			} else {
 				time_since_update_ += rhs;
@@ -52,7 +52,7 @@ template <class T, int multiplier = 1, int divider = 1, class LocalTimeScale = H
 		forceinline void flush() {
 			if(!is_flushed_) {
 				is_flushed_ = true;
-				if(divider == 1) {
+				if constexpr (divider == 1) {
 					object_.run_for(time_since_update_.template flush<TargetTimeScale>());
 				} else {
 					const auto duration = time_since_update_.template divide<TargetTimeScale>(LocalTimeScale(divider));

--- a/Machines/Atari/ST/Video.cpp
+++ b/Machines/Atari/ST/Video.cpp
@@ -201,11 +201,11 @@ void Video::advance(HalfCycles duration) {
 		// inside the shifter on the temporary register values.
 
 		if(horizontal_.sync || vertical_.sync) {
-			video_stream_.output_sync(run_length);
+			video_stream_.output(run_length, VideoStream::OutputMode::Sync);
 		} else if(horizontal_.blank || vertical_.blank) {
-			video_stream_.output_blank(run_length);
+			video_stream_.output(run_length, VideoStream::OutputMode::Blank);
 		} else if(!load_) {
-			video_stream_.output_border(run_length, output_bpp_);
+			video_stream_.output(run_length, VideoStream::OutputMode::Pixels);
 		} else {
 			const int since_load = x_ - load_base_;
 
@@ -222,12 +222,12 @@ void Video::advance(HalfCycles duration) {
 			//	was reloaded by the fetch depends on the FIFO.
 
 			if(start_column == end_column) {
-				video_stream_.output_pixels(run_length, output_bpp_);
+				video_stream_.output(run_length, VideoStream::OutputMode::Pixels);
 			} else {
 				// Continue the current column if partway across.
 				if(since_load&7) {
 					// If at least one column boundary is crossed, complete this column.
-					video_stream_.output_pixels(8 - (since_load & 7), output_bpp_);
+					video_stream_.output(8 - (since_load & 7), VideoStream::OutputMode::Pixels);
 					++start_column;	// This starts a new column, so latch a new word.
 					push_latched_data();
 				}
@@ -235,13 +235,13 @@ void Video::advance(HalfCycles duration) {
 				// Run for all columns that have their starts in this time period.
 				int complete_columns = end_column - start_column;
 				while(complete_columns--) {
-					video_stream_.output_pixels(8, output_bpp_);
+					video_stream_.output(8, VideoStream::OutputMode::Pixels);
 					push_latched_data();
 				}
 
 				// Output the start of the next column, if necessary.
 				if((since_load + run_length) & 7) {
-					video_stream_.output_pixels((since_load + run_length) & 7, output_bpp_);
+					video_stream_.output((since_load + run_length) & 7, VideoStream::OutputMode::Pixels);
 				}
 			}
 		}
@@ -484,154 +484,172 @@ void Video::update_output_mode() {
 	if(output_bpp_ != old_bpp_) {
 		// "the 71-Hz-switch does something like a shifter-reset." (and some people use a high-low resolutions switch instead)
 		reset_fifo();
+		video_stream_.set_bpp(output_bpp_);
 	}
 }
 
 // MARK: - The shifter
 
-void Video::VideoStream::flush_output(OutputMode next_mode) {
-	switch(output_mode_) {
-		case OutputMode::Sync:			crt_.output_sync(duration_);					break;
-		case OutputMode::Blank:			crt_.output_blank(duration_);					break;
-		case OutputMode::ColourBurst:	crt_.output_default_colour_burst(duration_);	break;
-		case OutputMode::Border: {
-//			if(!border_colour_) {
-//				crt_.output_blank(duration_);
-//			} else {
-				uint16_t *const colour_pointer = reinterpret_cast<uint16_t *>(crt_.begin_data(1));
-				if(colour_pointer) *colour_pointer = border_colour_;
-				crt_.output_level(duration_);
-//			}
-		} break;
-		case OutputMode::Pixels: {
-			crt_.output_data(duration_, pixel_pointer_);
-			pixel_buffer_ = nullptr;
-			pixel_pointer_ = 0;
-		} break;
-	}
-	duration_ = 0;
-	output_mode_ = next_mode;
-}
-
-void Video::VideoStream::output_colour_burst(int duration) {
-	// More hackery afoot here; if and when duration_ crosses a threshold of 40,
-	// output 40 cycles of colour burst and then redirect to blank.
-	if(output_mode_ != OutputMode::ColourBurst) {
-		flush_output(OutputMode::ColourBurst);
-	}
-	duration_ += duration;
-	if(duration_ >= 40) {
-		const int blank_duration = duration_ - 40;
-		duration_ = 40;
-		flush_output(OutputMode::Blank);
-		output_blank(blank_duration);
-	}
-}
-
-void Video::VideoStream::output_blank(int duration) {
-	if(output_mode_ != OutputMode::Blank) {
-		// Bit of a hack: if this is a transition from sync or we're really in
-		// colour burst, divert into that.
-		if(output_mode_ == OutputMode::Sync || output_mode_ == OutputMode::ColourBurst) {
-			output_colour_burst(duration);
-			return;
-		}
-		flush_output(OutputMode::Blank);
-	}
-	duration_ += duration;
-}
-
-void Video::VideoStream::output_sync(int duration) {
-	if(output_mode_ != OutputMode::Sync) {
-		flush_output(OutputMode::Sync);
-	}
-	duration_ += duration;
-}
-
-void Video::VideoStream::output_border(int duration, OutputBpp bpp) {
-	// If there's still anything in the shifter, redirect this to an output_pixels call.
-	if(output_shifter_) {
-		// This doesn't take an opinion on how much of the shifter remains populated;
-		// it assumes the worst case.
-		const int pixel_length = std::min(32, duration);
-		output_pixels(pixel_length, bpp);
-		duration -= pixel_length;
-		if(!duration) {
-			return;
-		}
+void Video::VideoStream::output(int duration, OutputMode mode) {
+	// If this is a transition from sync to blank, actually transition to colour burst.
+	if(output_mode_ == OutputMode::Sync && mode == OutputMode::Blank) {
+		mode = OutputMode::ColourBurst;
 	}
 
-	// Flush anything that isn't level output *in the current border colour*.
-	if(output_mode_ != OutputMode::Border || border_colour_ != palette_[0]) {
-		flush_output(OutputMode::Border);
-		border_colour_ = palette_[0];
-	}
-	duration_ += duration;
-}
+	// If this is seeming a transition from blank to colour burst, obey it only if/when
+	// sufficient colour burst has been output.
+	if(output_mode_ == OutputMode::Blank && mode == OutputMode::ColourBurst) {
+		if(duration_ + duration >= 40) {
+			const int overage = duration + duration_ - 40;
+			duration_ = 40;
 
-void Video::VideoStream::output_pixels(int duration, OutputBpp bpp) {
-	// If the shifter is empty and there's no pixel buffer at present,
-	// redirect this to an output_level call. Otherwise, do a quick
-	// memset-type fill, since the special case has been detected anyway.
-	if(!output_shifter_) {
-		if(!pixel_buffer_) {
-			output_border(duration, bpp);
+			generate(overage, OutputMode::ColourBurst, true);
 		} else {
-			duration_ += duration;
-
-			switch(bpp_) {
-				case OutputBpp::One: {
-					const size_t pixels = size_t(duration << 1);
-					memset(&pixel_buffer_[pixel_pointer_], 0, pixels * sizeof(uint16_t));
-					pixel_pointer_ += pixels;
-				} break;
-
-				default:
-				case OutputBpp::Four:
-					assert(!(duration & 1));
-					duration >>= 1;
-				case OutputBpp::Two: {
-					while(duration--) {
-						pixel_buffer_[pixel_pointer_] = palette_[0];
-						++pixel_pointer_;
-					}
-				} break;
-			}
+			mode = OutputMode::ColourBurst;
 		}
+	}
+
+	// If this is a transition, or if we're doing pixels, output whatever has been accumulated.
+	if(mode != output_mode_ || output_mode_ == OutputMode::Pixels) {
+		generate(duration, output_mode_, mode != output_mode_);
+	} else {
+		duration_ += duration;
+	}
+
+	// Accumulate time in the current mode.
+	output_mode_ = mode;
+}
+
+void Video::VideoStream::generate(int duration, OutputMode mode, bool is_terminal) {
+	// Three of these are trivial; deal with them upfront. They don't care about the duration of
+	// whatever is new, just about how much was accumulated prior to now.
+	if(mode != OutputMode::Pixels) {
+		switch(mode) {
+			default:
+			case OutputMode::Sync:			crt_.output_sync(duration_);					break;
+			case OutputMode::Blank:			crt_.output_blank(duration_);					break;
+			case OutputMode::ColourBurst:	crt_.output_default_colour_burst(duration_);	break;
+		}
+
+		// Reseed duration
+		duration_ = duration;
+
+		// The shifter should keep running, so throw away the proper amount of content.
+		shift(duration_);
+
 		return;
 	}
 
-	// Flush anything that isn't pixel output in the proper bpp; also flush if there's nowhere
-	// left to put pixels.
-	if(output_mode_ != OutputMode::Pixels || bpp_ != bpp || pixel_pointer_ >= 320) {
-		flush_output(OutputMode::Pixels);
-		bpp_ = bpp;
-		pixel_buffer_ = reinterpret_cast<uint16_t *>(crt_.begin_data(320 + 32));
+	// If the background colour has changed and border is accumulated, flush it.
+	if(border_colour_ != palette_[0] && duration_) {
+		flush_border();
 	}
-	duration_ += duration;
+	border_colour_ = palette_[0];
 
+	// If the shifter is empty, accumulate in duration_ a promise to draw border later.
+	if(!output_shifter_) {
+		if(pixel_pointer_) {
+			flush_pixels();
+		}
+
+		duration_ += duration;
+
+		// If this is terminal, we'll need to draw now. But if it isn't, job done.
+		if(is_terminal) {
+			flush_border();
+		}
+
+		return;
+	}
+
+	// There's definitely some pixels to convey, but perhaps there's some border first?
+	if(duration_) {
+		flush_border();
+	}
+
+	// Time to do some pixels!
+	output_pixels(duration);
+
+	// If was terminal, make sure any transient storage is output.
+	if(is_terminal) {
+		flush_pixels();
+	}
+}
+
+void Video::VideoStream::flush_border() {
+	// Output colour 0 for the entirety of duration_ (or black, if this is 1bpp mode).
+	uint16_t *const colour_pointer = reinterpret_cast<uint16_t *>(crt_.begin_data(1));
+	if(colour_pointer) *colour_pointer = (bpp_ != OutputBpp::One) ?  palette_[0] : 0;
+	crt_.output_level(duration_);
+
+	duration_ = 0;
+}
+
+namespace {
+#if TARGET_RT_BIG_ENDIAN
+	constexpr int upper = 0;
+#else
+	constexpr int upper = 1;
+#endif
+}
+
+void Video::VideoStream::shift(int duration) {
 	switch(bpp_) {
-		case OutputBpp::One: {
-			int pixels = duration << 1;
-			if(pixel_buffer_) {
-				while(pixels--) {
+		case OutputBpp::One:
+			output_shifter_ <<= (duration << 1);
+		break;
+		case OutputBpp::Two:
+			while(duration--) {
+				shifter_halves_[upper] = (shifter_halves_[upper] << 1) & 0xfffefffe;
+				shifter_halves_[upper] |= (shifter_halves_[upper^1] & 0x80008000) >> 15;
+				shifter_halves_[upper^1] = (shifter_halves_[upper^1] << 1) & 0xfffefffe;
+			}
+		break;
+		case OutputBpp::Four:
+			while(duration) {
+				output_shifter_ = (output_shifter_ << 1) & 0xfffefffefffefffe;
+				duration -= 2;
+			}
+		break;
+	}
+}
+
+// TODO: turn this into a template on current BPP, perhaps? Would avoid reevaluation of the conditional.
+void Video::VideoStream::output_pixels(int duration) {
+	constexpr int allocation_size = 352;	// i.e. 320 plus a spare 32.
+
+	// Convert from duration to pixels.
+	int pixels = duration;
+	switch(bpp_) {
+		case OutputBpp::One: pixels <<= 1;	break;
+		default: break;
+		case OutputBpp::Four: pixels >>= 1;	break;
+	}
+
+	while(pixels) {
+		// If no buffer is currently available, attempt to allocate one.
+		if(!pixel_buffer_) {
+			pixel_buffer_ = reinterpret_cast<uint16_t *>(crt_.begin_data(allocation_size, 2));
+
+			// Stop the loop if no buffer is available.
+			if(!pixel_buffer_) break;
+		}
+
+		int pixels_to_draw = std::min(allocation_size - pixel_pointer_, pixels);
+		pixels -= pixels_to_draw;
+
+		switch(bpp_) {
+			case OutputBpp::One:
+				while(pixels_to_draw--) {
 					pixel_buffer_[pixel_pointer_] = ((output_shifter_ >> 63) & 1) * 0xffff;
 					output_shifter_ <<= 1;
+
 					++pixel_pointer_;
 				}
-			} else {
-				pixel_pointer_ += size_t(pixels);
-				output_shifter_ <<= pixels;
-			}
-		} break;
-		case OutputBpp::Two: {
-	#if TARGET_RT_BIG_ENDIAN
-			constexpr int upper = 0;
-	#else
-			constexpr int upper = 1;
-	#endif
-			if(pixel_buffer_) {
-				while(duration--) {
+			break;
+
+			case OutputBpp::Two:
+				while(pixels_to_draw--) {
 					pixel_buffer_[pixel_pointer_] = palette_[
 						((output_shifter_ >> 63) & 1) |
 						((output_shifter_ >> 46) & 2)
@@ -645,20 +663,10 @@ void Video::VideoStream::output_pixels(int duration, OutputBpp bpp) {
 
 					++pixel_pointer_;
 				}
-			} else {
-				pixel_pointer_ += size_t(duration);
-				while(duration--) {
-					shifter_halves_[upper] = (shifter_halves_[upper] << 1) & 0xfffefffe;
-					shifter_halves_[upper] |= (shifter_halves_[upper^1] & 0x80008000) >> 15;
-					shifter_halves_[upper^1] = (shifter_halves_[upper^1] << 1) & 0xfffefffe;
-				}
-			}
-		} break;
-		default:
-		case OutputBpp::Four:
-			assert(!(duration & 1));
-			if(pixel_buffer_) {
-				while(duration) {
+			break;
+
+			case OutputBpp::Four:
+				while(pixels_to_draw--) {
 					pixel_buffer_[pixel_pointer_] = palette_[
 						((output_shifter_ >> 63) & 1) |
 						((output_shifter_ >> 46) & 2) |
@@ -666,18 +674,51 @@ void Video::VideoStream::output_pixels(int duration, OutputBpp bpp) {
 						((output_shifter_ >> 12) & 8)
 					];
 					output_shifter_ = (output_shifter_ << 1) & 0xfffefffefffefffe;
+
 					++pixel_pointer_;
-					duration -= 2;
 				}
-			} else {
-				pixel_pointer_ += size_t(duration >> 1);
-				while(duration) {
-					output_shifter_ = (output_shifter_ << 1) & 0xfffefffefffefffe;
-					duration -= 2;
-				}
-			}
-		break;
+			break;
+		}
+
+		// Check whether the limit has been reached.
+		if(pixel_pointer_ == allocation_size) {
+			flush_pixels();
+		}
 	}
+
+	// If duration remains, that implies no buffer was available, so
+	// just do the corresponding shifting and provide proper timing to the CRT.
+	if(pixels) {
+		int leftover_duration = pixels;
+		switch(bpp_) {
+			case OutputBpp::One: leftover_duration >>= 1;	break;
+			default: break;
+			case OutputBpp::Four: leftover_duration <<= 1;	break;
+		}
+		shift(leftover_duration);
+		crt_.output_data(leftover_duration);
+	}
+
+	// Duration will be at most 32, since this will need to be interspersed with load() calls.
+	// Therefore it's always safe to assume that if a buffer is allocated, then it's big enough,
+	// provided it is flushed fairly proactively.
+}
+
+void Video::VideoStream::flush_pixels() {
+	switch(bpp_) {
+		case OutputBpp::One:	crt_.output_data(pixel_pointer_ >> 1, size_t(pixel_pointer_)); break;
+		default: 				crt_.output_data(pixel_pointer_); break;
+		case OutputBpp::Four:	crt_.output_data(pixel_pointer_ << 1, size_t(pixel_pointer_)); break;
+	}
+
+	pixel_pointer_ = 0;
+	pixel_buffer_ = nullptr;
+}
+
+void Video::VideoStream::set_bpp(OutputBpp bpp) {
+	// TODO: is flushing like this correct?
+	output_shifter_ = 0;
+	bpp_ = bpp;
 }
 
 void Video::VideoStream::load(uint64_t value) {

--- a/Machines/Atari/ST/Video.cpp
+++ b/Machines/Atari/ST/Video.cpp
@@ -412,9 +412,15 @@ HalfCycles Video::get_next_sequence_point() {
 		event_time = std::min(event_time, vsync_x_position);
 	}
 
-	// Test for beginning and end of horizontal sync.
-	if(x_ < line_length_ - hsync_start) 	event_time = std::min(line_length_ - hsync_start, event_time);
-	else if(x_ < line_length_ - hsync_end)	event_time = std::min(line_length_ - hsync_end, event_time);
+	// Test for beginning and end of horizontal sync, and the times when those will actually be communicated.
+	if(x_ < line_length_ - hsync_start) {
+		event_time = std::min(line_length_ - hsync_start, event_time);
+	} else if(x_ < line_length_ - hsync_start + hsync_delay_period)	{
+		event_time = std::min(line_length_ - hsync_start + hsync_delay_period, event_time);
+	} else if(x_ < line_length_ - hsync_end) {
+		event_time = std::min(line_length_ - hsync_end, event_time);
+	}
+	/* Assumed: hsync end will become visible at end of line. */
 
 	// It wasn't any of those, so as a temporary expedient, just supply end of line.
 	return HalfCycles(event_time - x_);

--- a/Machines/Atari/ST/Video.cpp
+++ b/Machines/Atari/ST/Video.cpp
@@ -267,11 +267,10 @@ void Video::advance(HalfCycles duration) {
 				next_vertical_.enable = true;
 			} else if(y_ == vertical_timings.reset_enable) {
 				next_vertical_.enable = false;
-			} else if(next_y_ == vertical_timings.height - 2) {
-				next_vertical_.sync_schedule = VerticalState::SyncSchedule::Begin;
 			} else if(next_y_ == vertical_timings.height) {
+				next_vertical_.sync_schedule = VerticalState::SyncSchedule::Begin;
 				next_y_ = 0;
-			} else if(y_ == 0) {
+			} else if(next_y_ == 2) {
 				next_vertical_.sync_schedule = VerticalState::SyncSchedule::End;
 			}
 		}

--- a/Machines/Atari/ST/Video.cpp
+++ b/Machines/Atari/ST/Video.cpp
@@ -343,7 +343,7 @@ void Video::advance(HalfCycles duration) {
 
 		if(vertical_.sync != vsync) {
 			// Schedule change in outwardly-visible hsync line.
-			add_event(vsync_delay_period - integer_duration, horizontal_.sync ? Event::Type::SetVsync : Event::Type::ResetVsync);
+			add_event(vsync_delay_period - integer_duration, vertical_.sync ? Event::Type::SetVsync : Event::Type::ResetVsync);
 		}
 	}
 }

--- a/Machines/Atari/ST/Video.cpp
+++ b/Machines/Atari/ST/Video.cpp
@@ -698,10 +698,6 @@ void Video::VideoStream::output_pixels(int duration) {
 		shift(leftover_duration);
 		crt_.output_data(leftover_duration);
 	}
-
-	// Duration will be at most 32, since this will need to be interspersed with load() calls.
-	// Therefore it's always safe to assume that if a buffer is allocated, then it's big enough,
-	// provided it is flushed fairly proactively.
 }
 
 void Video::VideoStream::flush_pixels() {

--- a/Machines/Atari/ST/Video.hpp
+++ b/Machines/Atari/ST/Video.hpp
@@ -166,9 +166,9 @@ class Video {
 
 		void reset_fifo();
 
-		class Shifter {
+		class VideoStream {
 			public:
-				Shifter(Outputs::CRT::CRT &crt, uint16_t *palette) : crt_(crt), palette_(palette) {}
+				VideoStream(Outputs::CRT::CRT &crt, uint16_t *palette) : crt_(crt), palette_(palette) {}
 				void output_blank(int duration);
 				void output_sync(int duration);
 				void output_border(int duration, OutputBpp bpp);
@@ -196,7 +196,7 @@ class Video {
 
 				Outputs::CRT::CRT &crt_;
 				uint16_t *palette_ = nullptr;
-		} shifter_;
+		} video_stream_;
 
 		/// Contains copies of the various observeable fields, after the relevant propagation delay.
 		struct PublicState {

--- a/Machines/Atari/ST/Video.hpp
+++ b/Machines/Atari/ST/Video.hpp
@@ -177,7 +177,6 @@ class Video {
 			public:
 				VideoStream(Outputs::CRT::CRT &crt, uint16_t *palette) : crt_(crt), palette_(palette) {}
 
-
 				enum class OutputMode {
 					Sync, Blank, ColourBurst, Pixels,
 				};
@@ -185,7 +184,13 @@ class Video {
 				/// Sets the current data format for the shifter. Changes in output BPP flush the shifter.
 				void set_bpp(OutputBpp bpp);
 
+				/// Outputs signal of type @c mode for @c duration.
 				void output(int duration, OutputMode mode);
+
+				/// Warns the video stream that the border colour, included in the palette that it holds a pointer to,
+				/// will change momentarily. This should be called after the relevant @c output() updates, and
+				/// is used to help elide border-regio output.
+				void will_change_border_colour();
 
 				/// Loads 64 bits into the Shifter. The shifter shifts continuously. If you also declare
 				/// a pixels region then whatever is being shifted will reach the display, in a form that
@@ -208,7 +213,6 @@ class Video {
 				// Internal state that is a function of output intent.
 				int duration_ = 0;
 				OutputMode output_mode_ = OutputMode::Sync;
-				uint16_t border_colour_ = 0;
 				OutputBpp bpp_ = OutputBpp::Four;
 				union {
 					uint64_t output_shifter_;

--- a/Machines/Atari/ST/Video.hpp
+++ b/Machines/Atari/ST/Video.hpp
@@ -15,6 +15,9 @@
 
 #include <vector>
 
+// Testing hook; not for any other user.
+class VideoTester;
+
 namespace Atari {
 namespace ST {
 
@@ -278,6 +281,8 @@ class Video {
 			}
 			pending_events_.emplace(insertion_point, type, delay);
 		}
+
+		friend class ::VideoTester;
 };
 
 }

--- a/Machines/Atari/ST/Video.hpp
+++ b/Machines/Atari/ST/Video.hpp
@@ -228,6 +228,7 @@ class Video {
 		struct PublicState {
 			bool display_enable = false;
 			bool hsync = false;
+			bool vsync = false;
 		} public_state_;
 
 		struct Event {
@@ -235,6 +236,7 @@ class Video {
 			enum class Type {
 				SetDisplayEnable, ResetDisplayEnable,
 				SetHsync, ResetHsync,
+				SetVsync, ResetVsync,
 			} type;
 
 			Event(Type type, int delay) : delay(delay), type(type) {}
@@ -250,6 +252,8 @@ class Video {
 					case Type::ResetDisplayEnable:	state.display_enable = false;	break;
 					case Type::SetHsync:			state.hsync = true;				break;
 					case Type::ResetHsync:			state.hsync = false;			break;
+					case Type::SetVsync:			state.vsync = true;				break;
+					case Type::ResetVsync:			state.vsync = false;			break;
 				}
 			}
 		};

--- a/Machines/Atari/ST/Video.hpp
+++ b/Machines/Atari/ST/Video.hpp
@@ -227,12 +227,14 @@ class Video {
 		/// Contains copies of the various observeable fields, after the relevant propagation delay.
 		struct PublicState {
 			bool display_enable = false;
+			bool hsync = false;
 		} public_state_;
 
 		struct Event {
 			int delay;
 			enum class Type {
-				SetDisplayEnable, ResetDisplayEnable
+				SetDisplayEnable, ResetDisplayEnable,
+				SetHsync, ResetHsync,
 			} type;
 
 			Event(Type type, int delay) : delay(delay), type(type) {}
@@ -246,6 +248,8 @@ class Video {
 					default:
 					case Type::SetDisplayEnable:	state.display_enable = true;	break;
 					case Type::ResetDisplayEnable:	state.display_enable = false;	break;
+					case Type::SetHsync:			state.hsync = true;				break;
+					case Type::ResetHsync:			state.hsync = false;			break;
 				}
 			}
 		};

--- a/Machines/Atari/ST/Video.hpp
+++ b/Machines/Atari/ST/Video.hpp
@@ -269,17 +269,22 @@ class Video {
 				return;
 			}
 
-			// Otherwise enqueue, having subtracted the delay for any preceding events,
-			// and subtracting from the subsequent, if any.
-			auto insertion_point = pending_events_.begin();
-			while(insertion_point != pending_events_.end() && insertion_point->delay > delay) {
-				delay -= insertion_point->delay;
-				++insertion_point;
+			if(!pending_events_.empty()) {
+				// Otherwise enqueue, having subtracted the delay for any preceding events,
+				// and subtracting from the subsequent, if any.
+				auto insertion_point = pending_events_.begin();
+				while(insertion_point != pending_events_.end() && insertion_point->delay < delay) {
+					delay -= insertion_point->delay;
+					++insertion_point;
+				}
+				if(insertion_point != pending_events_.end()) {
+					insertion_point->delay -= delay;
+				}
+
+				pending_events_.emplace(insertion_point, type, delay);
+			} else {
+				pending_events_.emplace_back(type, delay);
 			}
-			if(insertion_point != pending_events_.end()) {
-				insertion_point->delay -= delay;
-			}
-			pending_events_.emplace(insertion_point, type, delay);
 		}
 
 		friend class ::VideoTester;

--- a/OSBindings/Mac/Clock Signal.xcodeproj/xcshareddata/xcschemes/Clock Signal.xcscheme
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/xcshareddata/xcschemes/Clock Signal.xcscheme
@@ -67,7 +67,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       enableASanStackUseAfterReturn = "YES"

--- a/OSBindings/Mac/Clock Signal.xcodeproj/xcshareddata/xcschemes/Clock Signal.xcscheme
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/xcshareddata/xcschemes/Clock Signal.xcscheme
@@ -67,7 +67,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       enableASanStackUseAfterReturn = "YES"

--- a/OSBindings/Mac/Clock Signal.xcodeproj/xcshareddata/xcschemes/Clock Signal.xcscheme
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/xcshareddata/xcschemes/Clock Signal.xcscheme
@@ -23,9 +23,9 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Release"
-      selectedDebuggerIdentifier = ""
-      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       disableMainThreadChecker = "YES"
       codeCoverageEnabled = "YES">

--- a/OSBindings/Mac/Clock SignalTests/AtariSTVideoTests.mm
+++ b/OSBindings/Mac/Clock SignalTests/AtariSTVideoTests.mm
@@ -8,30 +8,38 @@
 
 #import <XCTest/XCTest.h>
 
+#include <memory>
+
 #include "../../../Machines/Atari/ST/Video.hpp"
 
 @interface AtariSTVideoTests : XCTestCase
 @end
 
-@implementation AtariSTVideoTests
+@implementation AtariSTVideoTests {
+	std::unique_ptr<Atari::ST::Video> _video;
+	uint16_t _ram[256*1024];
+}
 
 - (void)setUp {
 	[super setUp];
+
+	// Establish an instance of video.
+	_video = std::make_unique<Atari::ST::Video>();
+	_video->set_ram(_ram, sizeof(_ram));
 }
 
 - (void)tearDown {
 	[super tearDown];
+
+	// Release the video instance.
+	_video = nullptr;
 }
 
+/// Tests that no events occur outside of the sequence points the video predicts.
 - (void)testSequencePoints {
-	// Establish an instance of video.
-	Atari::ST::Video video;
-	uint16_t ram[256*1024];
-	video.set_ram(ram, sizeof(ram));
-
 	// Set 4bpp, 50Hz.
-	video.write(0x05, 0x0200);
-	video.write(0x30, 0x0000);
+	_video->write(0x05, 0x0200);
+	_video->write(0x30, 0x0000);
 
 	// Run for [more than] a whole frame making sure that no observeable outputs
 	// change at any time other than a sequence point.
@@ -43,18 +51,213 @@
 		const bool is_transition_point = next_event == HalfCycles(0);
 
 		if(is_transition_point) {
-			display_enable = video.display_enabled();
-			vsync = video.vsync();
-			hsync = video.hsync();
-			next_event = video.get_next_sequence_point();
+			display_enable = _video->display_enabled();
+			vsync = _video->vsync();
+			hsync = _video->hsync();
+			next_event = _video->get_next_sequence_point();
 		} else {
-			NSAssert(display_enable == video.display_enabled(), @"Unannounced change in display enabled at cycle %zu [%d before next sequence point]", c, next_event.as<int>());
-			NSAssert(vsync == video.vsync(), @"Unannounced change in vsync at cycle %zu [%d before next sequence point]", c, next_event.as<int>());
-			NSAssert(hsync == video.hsync(), @"Unannounced change in hsync at cycle %zu [%d before next sequence point]", c, next_event.as<int>());
+			NSAssert(display_enable == _video->display_enabled(), @"Unannounced change in display enabled at cycle %zu [%d before next sequence point]", c, next_event.as<int>());
+			NSAssert(vsync == _video->vsync(), @"Unannounced change in vsync at cycle %zu [%d before next sequence point]", c, next_event.as<int>());
+			NSAssert(hsync == _video->hsync(), @"Unannounced change in hsync at cycle %zu [%d before next sequence point]", c, next_event.as<int>());
 		}
-		video.run_for(HalfCycles(2));
+		_video->run_for(HalfCycles(2));
 		next_event -= HalfCycles(2);
 	}
+}
+
+- (void)runVideoForCycles:(int)cycles {
+	while(cycles--) {
+		_video->run_for(Cycles(1));
+	}
+}
+
+- (void)syncToStartOfLine {
+	// Run until the visible fetch address changes, to get to the start of the pixel zone.
+	const uint32_t original_address = [self currentVideoAddress];
+	while(original_address == [self currentVideoAddress]) {
+		_video->run_for(Cycles(1));
+	}
+
+	// Run until start of hsync.
+	while(!_video->hsync()) {
+		_video->run_for(Cycles(1));
+	}
+
+	// Run until end of hsync.
+	while(_video->hsync()) {
+		_video->run_for(Cycles(1));
+	}
+
+	// Run 12 cycles further.
+	[self runVideoForCycles:8];
+}
+
+- (void)setFrequency:(int)frequency {
+	switch(frequency) {
+		default:
+		case 50:	_video->write(0x05, 0x200);	_video->write(0x30, 0x000);	break;
+		case 60:	_video->write(0x05, 0x000); _video->write(0x30, 0x000);	break;
+		case 72:								_video->write(0x30, 0x200);	break;
+	}
+}
+
+- (uint32_t)currentVideoAddress {
+	return
+		(_video->read(0x04) & 0xff) |
+		((_video->read(0x03) & 0xff) << 8) |
+		((_video->read(0x02) & 0xff) << 16);
+}
+
+struct RunLength {
+	int frequency;
+	int length;
+};
+
+- (void)testSequence:(const RunLength *)sequence targetLength:(int)duration {
+	[self syncToStartOfLine];
+
+	const uint32_t start_address = [self currentVideoAddress];
+
+	while(sequence->frequency != -1) {
+		[self setFrequency:sequence->frequency];
+		[self runVideoForCycles:sequence->length];
+		++sequence;
+	}
+	const uint32_t final_address = [self currentVideoAddress];
+
+	XCTAssertEqual(final_address - start_address, duration);
+}
+
+- (void)testLineLength54 {
+	// Run as though a regular 50Hz line at least until cycle 52;
+	// then switch to 72 Hz by 164, and allow the line to finish.
+	const RunLength test[] = {
+		{50, 60},
+		{72, 452},
+		{-1}
+	};
+	[self testSequence:test targetLength:54];
+}
+
+- (void)testLineLength56 {
+	// Run as though a regular 60Hz line at least until cycle 52;
+	// then switch to 72 Hz by 164, and allow the line to finish.
+	const RunLength test[] = {
+		{60, 60},
+		{72, 452},
+		{-1}
+	};
+	[self testSequence:test targetLength:56];
+}
+
+- (void)testLineLength80 {
+	// Run a standard 72Hz line.
+	const RunLength test[] = {
+		{72, 224},
+		{-1}
+	};
+	[self testSequence:test targetLength:80];
+}
+
+- (void)testLineLengthLong80 {
+	// Run a 72Hz line with a switch through 50Hz to extend the length to 512 cycles.
+	const RunLength test[] = {
+		{72, 50},
+		{50, 20},
+		{72, 442},
+		{-1}
+	};
+	[self testSequence:test targetLength:80];
+}
+
+- (void)testLineLength158 {
+	// Transition from 50Hz to 60Hz mid-line.
+	const RunLength test[] = {
+		{50, 60},
+		{60, 458},
+		{-1}
+	};
+	[self testSequence:test targetLength:158];
+}
+
+- (void)testLineLength160_60Hz {
+	const RunLength test[] = {
+		{60, 508},
+		{-1}
+	};
+	[self testSequence:test targetLength:160];
+}
+
+- (void)testLineLength160_50Hz {
+	const RunLength test[] = {
+		{50, 512},
+		{-1}
+	};
+	[self testSequence:test targetLength:160];
+}
+
+- (void)testLineLength162 {
+	// Transition from 60Hz to 50Hz mid-line.
+	const RunLength test[] = {
+		{60, 54},
+		{50, 458},
+		{-1}
+	};
+	[self testSequence:test targetLength:162];
+}
+
+- (void)testLineLength184 {
+	// Start off in 72Hz, switch to 60 during pixels.
+	const RunLength test[] = {
+		{72, 8},
+		{60, 500},
+		{-1}
+	};
+	[self testSequence:test targetLength:184];
+}
+
+- (void)testLineLength186 {
+	// Start off in 72Hz, switch to 50 during pixels.
+	const RunLength test[] = {
+		{72, 8},
+		{50, 504},
+		{-1}
+	};
+	[self testSequence:test targetLength:186];
+}
+
+- (void)testLineLength204 {
+	// Start in 50Hz, avoid DE disable.
+	const RunLength test[] = {
+		{50, 374},
+		{60, 138},
+		{-1}
+	};
+	[self testSequence:test targetLength:204];
+}
+
+- (void)testLineLength206 {
+	// Start in 60Hz, get a 50Hz line length, avoid DE disable.
+	const RunLength test[] = {
+		{60, 53},
+		{50, 3},		// To 56.
+		{60, 314},		// 370.
+		{50, 4},		// 374.
+		{60, 138},		// 512.
+		{-1}
+	};
+	[self testSequence:test targetLength:206];
+}
+
+- (void)testLineLength230 {
+	// Start in 72Hz, avoid DE disable.
+	const RunLength test[] = {
+		{72, 8},
+		{50, 366},
+		{60, 138},
+		{-1}
+	};
+	[self testSequence:test targetLength:230];
 }
 
 @end

--- a/OSBindings/Mac/Clock SignalTests/AtariSTVideoTests.mm
+++ b/OSBindings/Mac/Clock SignalTests/AtariSTVideoTests.mm
@@ -61,9 +61,6 @@
 	while(_video->hsync()) {
 		_video->run_for(Cycles(1));
 	}
-
-	// Run 12 cycles further.
-	[self runVideoForCycles:8];
 }
 
 - (void)setFrequency:(int)frequency {
@@ -314,6 +311,21 @@ struct RunLength {
 	[self setVideoBaseAddress:0];
 	[self runVideoForCycles:1];
 	XCTAssertNotEqual([self currentVideoAddress], 0);
+}
+
+// MARK: - Tests Correlating To Exact Pieces of Software
+
+- (void)testUnionDemoScroller {
+	const RunLength test[] = {
+		{72, 8},
+		{50, 365},
+		{60, 8},
+		{50, 59},
+		{72, 12},
+		{50, 60},
+		{-1}
+	};
+	[self testSequence:test targetLength:230];
 }
 
 @end


### PR DESCRIPTION
Specifically:
- eliminates potential pixel buffer overrun;
- ensures the Shifter is fully asynchronous;
- introduces delays on external VSYNC and HSYNC signalling;
- ensures the video address is reloaded for the entirety of VSYNC;
- introduces unit tests as to various 'sync line lengths'; and
- adds VSYNC/HSYNC interrupt latches, so each definitely fires only once.

Wider discussion: various demos still work incorrectly, but games are increasingly working.