### PR TITLE
Improves 68000 trace support

### DIFF
--- a/Processors/68000/Implementation/68000Implementation.hpp
+++ b/Processors/68000/Implementation/68000Implementation.hpp
@@ -273,7 +273,7 @@ template <class T, bool dtack_is_implicit, bool signal_will_perform> void Proces
 							break;
 						}
 
-						if(last_trace_flag_) {
+						if(trace_flag_ && last_trace_flag_) {
 							// The user has set the trace bit in the status register.
 							active_program_ = nullptr;
 							active_micro_op_ = short_exception_micro_ops_;

--- a/Processors/68000/Implementation/68000Implementation.hpp
+++ b/Processors/68000/Implementation/68000Implementation.hpp
@@ -273,11 +273,12 @@ template <class T, bool dtack_is_implicit, bool signal_will_perform> void Proces
 							break;
 						}
 
-						if(trace_flag_) {
+						if(last_trace_flag_) {
 							// The user has set the trace bit in the status register.
 							active_program_ = nullptr;
 							active_micro_op_ = short_exception_micro_ops_;
 							populate_trap_steps(9, get_status());
+							program_counter_.full -= 4;
 						} else {
 #ifdef LOG_TRACE
 							if(should_log) {
@@ -310,7 +311,7 @@ template <class T, bool dtack_is_implicit, bool signal_will_perform> void Proces
 							}
 #endif
 
-							if(signal_will_perform) {
+							if constexpr (signal_will_perform) {
 								bus_handler_.will_perform(program_counter_.full - 4, decoded_instruction_.full);
 							}
 
@@ -363,6 +364,7 @@ template <class T, bool dtack_is_implicit, bool signal_will_perform> void Proces
 								}
 							}
 						}
+						last_trace_flag_ = trace_flag_;
 					}
 
 					auto bus_program = &all_bus_steps_[active_micro_op_->bus_program];

--- a/Processors/68000/Implementation/68000Storage.hpp
+++ b/Processors/68000/Implementation/68000Storage.hpp
@@ -53,6 +53,8 @@ class ProcessorStorage {
 		uint_fast32_t negative_flag_;	// The negative flag is set if this value is non-zero.
 		uint_fast32_t trace_flag_;		// The trace flag is set if this value is non-zero.
 
+		uint_fast32_t last_trace_flag_ = 0;
+
 		// Bus inputs.
 		int bus_interrupt_level_ = 0;
 		bool dtack_ = false;
@@ -498,7 +500,7 @@ class ProcessorStorage {
 
 			// Switch to supervisor mode, disable the trace bit.
 			set_is_supervisor(true);
-			trace_flag_ = 0;
+			trace_flag_ = last_trace_flag_ = 0;
 
 			// Pick a vector.
 			effective_address_[0].full = vector << 2;
@@ -521,7 +523,7 @@ class ProcessorStorage {
 
 			// Switch to supervisor mode, disable the trace bit.
 			set_is_supervisor(true);
-			trace_flag_ = 0;
+			trace_flag_ = last_trace_flag_ = 0;
 
 			// Pick a vector.
 			effective_address_[0].full = vector << 2;


### PR DESCRIPTION
Specifically:
* ensures pushed PC is correct return address; and
* adds a one-instruction delay to the trace command coming into effect.