### PR TITLE
Implements a nascent `run_until`

### DIFF
--- a/Analyser/Dynamic/MultiMachine/Implementation/MultiSpeaker.cpp
+++ b/Analyser/Dynamic/MultiMachine/Implementation/MultiSpeaker.cpp
@@ -53,7 +53,7 @@ void MultiSpeaker::speaker_did_complete_samples(Speaker *speaker, const std::vec
 		std::lock_guard<std::mutex> lock_guard(front_speaker_mutex_);
 		if(speaker != front_speaker_) return;
 	}
-	delegate_->speaker_did_complete_samples(this, buffer);
+	did_complete_samples(this, buffer);
 }
 
 void MultiSpeaker::speaker_did_change_input_clock(Speaker *speaker) {

--- a/Concurrency/BestEffortUpdater.cpp
+++ b/Concurrency/BestEffortUpdater.cpp
@@ -80,7 +80,7 @@ void BestEffortUpdater::update_loop() {
 				// Cap running at 1/5th of a second, to avoid doing a huge amount of work after any
 				// brief system interruption.
 				const double duration = std::min(double(integer_duration) / 1e9, 0.2);
-				delegate->update(this, duration, has_skipped_);
+				delegate->update(this, duration, has_skipped_, 0);
 				has_skipped_ = false;
 			}
 		}

--- a/Concurrency/BestEffortUpdater.hpp
+++ b/Concurrency/BestEffortUpdater.hpp
@@ -33,7 +33,13 @@ class BestEffortUpdater {
 
 		/// A delegate receives timing cues.
 		struct Delegate {
-			virtual void update(BestEffortUpdater *updater, Time::Seconds duration, bool did_skip_previous_update, int flags) = 0;
+			/*!
+				Instructs the delegate to run for at least @c duration, providing hints as to whether multiple updates were requested before the previous had completed
+				(as @c did_skip_previous_update) and providing the union of any flags supplied to @c update.
+
+				@returns The amount of time actually run for.
+			*/
+			virtual Time::Seconds update(BestEffortUpdater *updater, Time::Seconds duration, bool did_skip_previous_update, int flags) = 0;
 		};
 
 		/// Sets the current delegate.
@@ -52,13 +58,13 @@ class BestEffortUpdater {
 		std::atomic<bool> should_quit_;
 		std::atomic<bool> is_updating_;
 
-		std::chrono::time_point<std::chrono::high_resolution_clock> target_time_;
+		int64_t target_time_;
 		int flags_ = 0;
 		bool update_requested_;
 		std::mutex update_mutex_;
 		std::condition_variable update_condition_;
 
-		std::chrono::time_point<std::chrono::high_resolution_clock> previous_time_point_;
+		decltype(target_time_) previous_time_point_;
 		bool has_previous_time_point_ = false;
 		std::atomic<bool> has_skipped_ = false;
 

--- a/Concurrency/BestEffortUpdater.hpp
+++ b/Concurrency/BestEffortUpdater.hpp
@@ -43,7 +43,7 @@ class BestEffortUpdater {
 			If the delegate is not currently in the process of an `update` call, calls it now to catch up to the current time.
 			The call is asynchronous; this method will return immediately.
 		*/
-		void update();
+		void update(int flags = 0);
 
 		/// Blocks until any ongoing update is complete; may spin.
 		void flush();
@@ -53,6 +53,7 @@ class BestEffortUpdater {
 		std::atomic<bool> is_updating_;
 
 		std::chrono::time_point<std::chrono::high_resolution_clock> target_time_;
+		int flags_ = 0;
 		bool update_requested_;
 		std::mutex update_mutex_;
 		std::condition_variable update_condition_;

--- a/Concurrency/BestEffortUpdater.hpp
+++ b/Concurrency/BestEffortUpdater.hpp
@@ -33,7 +33,7 @@ class BestEffortUpdater {
 
 		/// A delegate receives timing cues.
 		struct Delegate {
-			virtual void update(BestEffortUpdater *updater, Time::Seconds duration, bool did_skip_previous_update) = 0;
+			virtual void update(BestEffortUpdater *updater, Time::Seconds duration, bool did_skip_previous_update, int flags) = 0;
 		};
 
 		/// Sets the current delegate.

--- a/Machines/CRTMachine.hpp
+++ b/Machines/CRTMachine.hpp
@@ -45,10 +45,18 @@ class Machine {
 		virtual std::string debug_type() { return ""; }
 
 		/// Runs the machine for @c duration seconds.
-		virtual void run_for(Time::Seconds duration) {
+		void run_for(Time::Seconds duration) {
 			const double cycles = (duration * clock_rate_) + clock_conversion_error_;
 			clock_conversion_error_ = std::fmod(cycles, 1.0);
 			run_for(Cycles(static_cast<int>(cycles)));
+		}
+
+		/// Runs for the machine for at least @c duration seconds, and then until @c condition is true.
+		void run_until(Time::Seconds minimum_duration, std::function<bool()> condition) {
+			run_for(minimum_duration);
+			while(!condition()) {
+				run_for(0.002);
+			}
 		}
 
 	protected:

--- a/Machines/CRTMachine.hpp
+++ b/Machines/CRTMachine.hpp
@@ -45,17 +45,57 @@ class Machine {
 		virtual std::string debug_type() { return ""; }
 
 		/// Runs the machine for @c duration seconds.
-		void run_for(Time::Seconds duration) {
+		virtual void run_for(Time::Seconds duration) {
 			const double cycles = (duration * clock_rate_) + clock_conversion_error_;
 			clock_conversion_error_ = std::fmod(cycles, 1.0);
 			run_for(Cycles(static_cast<int>(cycles)));
 		}
 
-		/// Runs for the machine for at least @c duration seconds, and then until @c condition is true.
-		void run_until(Time::Seconds minimum_duration, std::function<bool()> condition) {
+		/*!
+			Runs for the machine for at least @c duration seconds, and then until @c condition is true.
+
+			@returns The amount of time run for.
+		*/
+		Time::Seconds run_until(Time::Seconds minimum_duration, std::function<bool()> condition) {
+			Time::Seconds total_runtime = minimum_duration;
 			run_for(minimum_duration);
 			while(!condition()) {
+				// Advance in increments of one 500th of a second until the condition
+				// is true; that's 1/10th of a 50Hz frame, but more like 1/8.33 of a
+				// 60Hz frame. Though most machines aren't exactly 50Hz or 60Hz, and some
+				// are arbitrary other refresh rates. So those observations are merely
+				// for scale.
 				run_for(0.002);
+				total_runtime += 0.002;
+			}
+			return total_runtime;
+		}
+
+		enum class MachineEvent {
+			/// At least one new packet of audio has been delivered to the spaker's delegate.
+			NewSpeakerSamplesGenerated
+		};
+
+		/*!
+			Runs for at least @c duration seconds, and then until @c event has occurred at least once since this
+			call to @c run_until_event.
+
+			@returns The amount of time run for.
+		*/
+		Time::Seconds run_until(Time::Seconds minimum_duration, MachineEvent event) {
+			switch(event) {
+				case MachineEvent::NewSpeakerSamplesGenerated: {
+					const auto speaker = get_speaker();
+					if(!speaker) {
+						run_for(minimum_duration);
+						return minimum_duration;
+					}
+
+					const int sample_sets = speaker->completed_sample_sets();
+					return run_until(minimum_duration, [sample_sets, speaker]() {
+						return speaker->completed_sample_sets() != sample_sets;
+					});
+				} break;
 			}
 		}
 

--- a/OSBindings/Mac/Clock Signal.xcodeproj/xcshareddata/xcschemes/Clock Signal.xcscheme
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/xcshareddata/xcschemes/Clock Signal.xcscheme
@@ -67,7 +67,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       enableASanStackUseAfterReturn = "YES"

--- a/OSBindings/Mac/Clock Signal.xcodeproj/xcshareddata/xcschemes/Clock Signal.xcscheme
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/xcshareddata/xcschemes/Clock Signal.xcscheme
@@ -67,7 +67,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       enableASanStackUseAfterReturn = "YES"

--- a/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
+++ b/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
@@ -243,7 +243,7 @@ class MachineDocument:
 	/// Responds to the CSAudioQueueDelegate dry-queue warning message by requesting a machine update.
 	final func audioQueueIsRunningDry(_ audioQueue: CSAudioQueue) {
 		bestEffortLock.lock()
-		bestEffortUpdater?.update()
+		bestEffortUpdater?.update(with: .audioNeeded)
 		bestEffortLock.unlock()
 	}
 

--- a/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
+++ b/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
@@ -269,14 +269,6 @@ class MachineDocument:
 		}
 	}
 
-	/// Responds to CSBestEffortUpdaterDelegate update message by running the machine.
-	final func bestEffortUpdater(_ bestEffortUpdater: CSBestEffortUpdater!, runForInterval duration: TimeInterval, didSkipPreviousUpdate: Bool) {
-		if let machine = self.machine, actionLock.try() {
-			machine.run(forInterval: duration)
-			actionLock.unlock()
-		}
-	}
-
 	// MARK: - Pasteboard Forwarding.
 
 	/// Forwards any text currently on the pasteboard into the active machine.

--- a/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
+++ b/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
@@ -15,7 +15,6 @@ class MachineDocument:
 	CSMachineDelegate,
 	CSOpenGLViewDelegate,
 	CSOpenGLViewResponderDelegate,
-	CSBestEffortUpdaterDelegate,
 	CSAudioQueueDelegate,
 	CSROMReciverViewDelegate
 {
@@ -98,7 +97,6 @@ class MachineDocument:
 
 		bestEffortLock.lock()
 		if let bestEffortUpdater = bestEffortUpdater {
-			bestEffortUpdater.delegate = nil
 			bestEffortUpdater.flush()
 			self.bestEffortUpdater = nil
 		}
@@ -221,8 +219,8 @@ class MachineDocument:
 			openGLView.window!.makeKeyAndOrderFront(self)
 			openGLView.window!.makeFirstResponder(openGLView)
 
-			// Start accepting best effort updates.
-			self.bestEffortUpdater!.delegate = self
+			// Start forwarding best-effort updates.
+			self.bestEffortUpdater!.setMachine(machine)
 		}
 	}
 

--- a/OSBindings/Mac/Clock Signal/Machine/CSMachine.h
+++ b/OSBindings/Mac/Clock Signal/Machine/CSMachine.h
@@ -57,7 +57,7 @@ typedef NS_ENUM(NSInteger, CSMachineKeyboardInputMode) {
 */
 - (nullable instancetype)initWithAnalyser:(nonnull CSStaticAnalyser *)result missingROMs:(nullable inout NSMutableArray<CSMissingROM *> *)missingROMs NS_DESIGNATED_INITIALIZER;
 
-- (void)runForInterval:(NSTimeInterval)interval;
+- (void)runForInterval:(NSTimeInterval)interval untilEvent:(int)events;
 
 - (float)idealSamplingRateFromRange:(NSRange)range;
 - (void)setAudioSamplingRate:(float)samplingRate bufferSize:(NSUInteger)bufferSize;

--- a/OSBindings/Mac/Clock Signal/Machine/CSMachine.h
+++ b/OSBindings/Mac/Clock Signal/Machine/CSMachine.h
@@ -57,7 +57,7 @@ typedef NS_ENUM(NSInteger, CSMachineKeyboardInputMode) {
 */
 - (nullable instancetype)initWithAnalyser:(nonnull CSStaticAnalyser *)result missingROMs:(nullable inout NSMutableArray<CSMissingROM *> *)missingROMs NS_DESIGNATED_INITIALIZER;
 
-- (void)runForInterval:(NSTimeInterval)interval untilEvent:(int)events;
+- (NSTimeInterval)runForInterval:(NSTimeInterval)interval untilEvent:(int)events;
 
 - (float)idealSamplingRateFromRange:(NSRange)range;
 - (void)setAudioSamplingRate:(float)samplingRate bufferSize:(NSUInteger)bufferSize;

--- a/OSBindings/Mac/Clock Signal/Machine/CSMachine.mm
+++ b/OSBindings/Mac/Clock Signal/Machine/CSMachine.mm
@@ -259,7 +259,7 @@ struct ActivityObserver: public Activity::Observer {
 	}
 }
 
-- (void)runForInterval:(NSTimeInterval)interval untilEvent:(int)events {
+- (NSTimeInterval)runForInterval:(NSTimeInterval)interval untilEvent:(int)events {
 	@synchronized(self) {
 		if(_joystickMachine && _joystickManager) {
 			[_joystickManager update];
@@ -309,7 +309,7 @@ struct ActivityObserver: public Activity::Observer {
 				}
 			}
 		}
-		_machine->crt_machine()->run_until(interval, events);
+		return _machine->crt_machine()->run_until(interval, events);
 	}
 }
 

--- a/OSBindings/Mac/Clock Signal/Machine/CSMachine.mm
+++ b/OSBindings/Mac/Clock Signal/Machine/CSMachine.mm
@@ -259,7 +259,7 @@ struct ActivityObserver: public Activity::Observer {
 	}
 }
 
-- (void)runForInterval:(NSTimeInterval)interval {
+- (void)runForInterval:(NSTimeInterval)interval untilEvent:(int)events {
 	@synchronized(self) {
 		if(_joystickMachine && _joystickManager) {
 			[_joystickManager update];
@@ -309,7 +309,7 @@ struct ActivityObserver: public Activity::Observer {
 				}
 			}
 		}
-		_machine->crt_machine()->run_for(interval);
+		_machine->crt_machine()->run_until(interval, events);
 	}
 }
 

--- a/OSBindings/Mac/Clock Signal/Updater/CSBestEffortUpdater.h
+++ b/OSBindings/Mac/Clock Signal/Updater/CSBestEffortUpdater.h
@@ -9,20 +9,12 @@
 #import <Foundation/Foundation.h>
 #import <CoreVideo/CoreVideo.h>
 
-@class CSBestEffortUpdater;
-
-@protocol CSBestEffortUpdaterDelegate <NSObject>
-
-- (void)bestEffortUpdater:(CSBestEffortUpdater *)bestEffortUpdater runForInterval:(NSTimeInterval)interval didSkipPreviousUpdate:(BOOL)didSkipPreviousUpdate;
-
-@end
-
+#import "CSMachine.h"
 
 @interface CSBestEffortUpdater : NSObject
 
-@property (nonatomic, weak) id<CSBestEffortUpdaterDelegate> delegate;
-
 - (void)update;
 - (void)flush;
+- (void)setMachine:(CSMachine *)machine;
 
 @end

--- a/OSBindings/Mac/Clock Signal/Updater/CSBestEffortUpdater.h
+++ b/OSBindings/Mac/Clock Signal/Updater/CSBestEffortUpdater.h
@@ -11,9 +11,16 @@
 
 #import "CSMachine.h"
 
+// The following is coupled to the definitions in CRTMachine.hpp, but exposed here
+// for the benefit of Swift.
+typedef NS_ENUM(NSInteger, CSBestEffortUpdaterEvent) {
+	CSBestEffortUpdaterEventAudioNeeded = 1 << 0
+};
+
 @interface CSBestEffortUpdater : NSObject
 
 - (void)update;
+- (void)updateWithEvent:(CSBestEffortUpdaterEvent)event;
 - (void)flush;
 - (void)setMachine:(CSMachine *)machine;
 

--- a/OSBindings/Mac/Clock Signal/Updater/CSBestEffortUpdater.mm
+++ b/OSBindings/Mac/Clock Signal/Updater/CSBestEffortUpdater.mm
@@ -13,8 +13,8 @@
 struct UpdaterDelegate: public Concurrency::BestEffortUpdater::Delegate {
 	__weak CSMachine *machine;
 
-	void update(Concurrency::BestEffortUpdater *updater, Time::Seconds seconds, bool did_skip_previous_update, int flags) {
-		[machine runForInterval:seconds untilEvent:flags];
+	Time::Seconds update(Concurrency::BestEffortUpdater *updater, Time::Seconds seconds, bool did_skip_previous_update, int flags) final {
+		return [machine runForInterval:seconds untilEvent:flags];
 	}
 };
 
@@ -33,6 +33,10 @@ struct UpdaterDelegate: public Concurrency::BestEffortUpdater::Delegate {
 
 - (void)update {
 	_updater.update();
+}
+
+- (void)updateWithEvent:(CSBestEffortUpdaterEvent)event {
+	_updater.update((int)event);
 }
 
 - (void)flush {

--- a/OSBindings/Mac/Clock Signal/Updater/CSBestEffortUpdater.mm
+++ b/OSBindings/Mac/Clock Signal/Updater/CSBestEffortUpdater.mm
@@ -14,7 +14,7 @@ struct UpdaterDelegate: public Concurrency::BestEffortUpdater::Delegate {
 	__weak CSMachine *machine;
 
 	void update(Concurrency::BestEffortUpdater *updater, Time::Seconds seconds, bool did_skip_previous_update, int flags) {
-		[machine runForInterval:seconds];
+		[machine runForInterval:seconds untilEvent:flags];
 	}
 };
 

--- a/OSBindings/Mac/Clock Signal/Updater/CSBestEffortUpdater.mm
+++ b/OSBindings/Mac/Clock Signal/Updater/CSBestEffortUpdater.mm
@@ -11,37 +11,25 @@
 #include "BestEffortUpdater.hpp"
 
 struct UpdaterDelegate: public Concurrency::BestEffortUpdater::Delegate {
-	__weak id<CSBestEffortUpdaterDelegate> delegate;
-	NSLock *delegateLock;
+	__weak CSMachine *machine;
 
-	void update(Concurrency::BestEffortUpdater *updater, Time::Seconds cycles, bool did_skip_previous_update) {
-		[delegateLock lock];
-		__weak id<CSBestEffortUpdaterDelegate> delegateCopy = delegate;
-		[delegateLock unlock];
-
-		[delegateCopy bestEffortUpdater:nil runForInterval:(NSTimeInterval)cycles didSkipPreviousUpdate:did_skip_previous_update];
+	void update(Concurrency::BestEffortUpdater *updater, Time::Seconds seconds, bool did_skip_previous_update, int flags) {
+		[machine runForInterval:seconds];
 	}
 };
 
 @implementation CSBestEffortUpdater {
 	Concurrency::BestEffortUpdater _updater;
 	UpdaterDelegate _updaterDelegate;
-	NSLock *_delegateLock;
 }
 
 - (instancetype)init {
 	self = [super init];
 	if(self) {
-		_delegateLock = [[NSLock alloc] init];
-		_updaterDelegate.delegateLock = _delegateLock;
 		_updater.set_delegate(&_updaterDelegate);
 	}
 	return self;
 }
-
-//- (void)dealloc {
-//	_updater.flush();
-//}
 
 - (void)update {
 	_updater.update();
@@ -51,20 +39,9 @@ struct UpdaterDelegate: public Concurrency::BestEffortUpdater::Delegate {
 	_updater.flush();
 }
 
-- (void)setDelegate:(id<CSBestEffortUpdaterDelegate>)delegate {
-	[_delegateLock lock];
-	_updaterDelegate.delegate = delegate;
-	[_delegateLock unlock];
-}
-
-- (id<CSBestEffortUpdaterDelegate>)delegate {
-	id<CSBestEffortUpdaterDelegate> delegate;
-
-	[_delegateLock lock];
-	delegate = _updaterDelegate.delegate;
-	[_delegateLock unlock];
-
-	return delegate;
+- (void)setMachine:(CSMachine *)machine {
+	_updater.flush();
+	_updaterDelegate.machine = machine;
 }
 
 @end

--- a/OSBindings/SDL/main.cpp
+++ b/OSBindings/SDL/main.cpp
@@ -34,8 +34,8 @@
 namespace {
 
 struct BestEffortUpdaterDelegate: public Concurrency::BestEffortUpdater::Delegate {
-	void update(Concurrency::BestEffortUpdater *updater, Time::Seconds duration, bool did_skip_previous_update) override {
-		machine->crt_machine()->run_for(duration);
+	void update(Concurrency::BestEffortUpdater *updater, Time::Seconds duration, bool did_skip_previous_update, int flags) override {
+		machine->crt_machine()->run_until(duration);
 	}
 
 	Machine::DynamicMachine *machine;

--- a/OSBindings/SDL/main.cpp
+++ b/OSBindings/SDL/main.cpp
@@ -35,7 +35,7 @@ namespace {
 
 struct BestEffortUpdaterDelegate: public Concurrency::BestEffortUpdater::Delegate {
 	void update(Concurrency::BestEffortUpdater *updater, Time::Seconds duration, bool did_skip_previous_update, int flags) override {
-		machine->crt_machine()->run_until(duration);
+		machine->crt_machine()->run_until(duration, flags);
 	}
 
 	Machine::DynamicMachine *machine;

--- a/OSBindings/SDL/main.cpp
+++ b/OSBindings/SDL/main.cpp
@@ -34,8 +34,8 @@
 namespace {
 
 struct BestEffortUpdaterDelegate: public Concurrency::BestEffortUpdater::Delegate {
-	void update(Concurrency::BestEffortUpdater *updater, Time::Seconds duration, bool did_skip_previous_update, int flags) override {
-		machine->crt_machine()->run_until(duration, flags);
+	Time::Seconds update(Concurrency::BestEffortUpdater *updater, Time::Seconds duration, bool did_skip_previous_update, int flags) override {
+		return machine->crt_machine()->run_until(duration, flags);
 	}
 
 	Machine::DynamicMachine *machine;

--- a/Outputs/Speaker/Implementation/LowpassSpeaker.hpp
+++ b/Outputs/Speaker/Implementation/LowpassSpeaker.hpp
@@ -134,7 +134,7 @@ template <typename T> class LowpassSpeaker: public Speaker {
 					// announce to delegate if full
 					if(output_buffer_pointer_ == output_buffer_.size()) {
 						output_buffer_pointer_ = 0;
-						delegate_->speaker_did_complete_samples(this, output_buffer_);
+						did_complete_samples(this, output_buffer_);
 					}
 
 					cycles_remaining -= cycles_to_read;
@@ -159,7 +159,7 @@ template <typename T> class LowpassSpeaker: public Speaker {
 						// Announce to delegate if full.
 						if(output_buffer_pointer_ == output_buffer_.size()) {
 							output_buffer_pointer_ = 0;
-							delegate_->speaker_did_complete_samples(this, output_buffer_);
+							did_complete_samples(this, output_buffer_);
 						}
 
 						// If the next loop around is going to reuse some of the samples just collected, use a memmove to

--- a/Outputs/Speaker/Speaker.hpp
+++ b/Outputs/Speaker/Speaker.hpp
@@ -26,7 +26,7 @@ class Speaker {
 		virtual float get_ideal_clock_rate_in_range(float minimum, float maximum) = 0;
 		virtual void set_output_rate(float cycles_per_second, int buffer_size) = 0;
 
-		int completed_sample_sets() { return completed_sample_sets_; }
+		int completed_sample_sets() const { return completed_sample_sets_; }
 
 		struct Delegate {
 			virtual void speaker_did_complete_samples(Speaker *speaker, const std::vector<int16_t> &buffer) = 0;

--- a/Outputs/Speaker/Speaker.hpp
+++ b/Outputs/Speaker/Speaker.hpp
@@ -26,6 +26,8 @@ class Speaker {
 		virtual float get_ideal_clock_rate_in_range(float minimum, float maximum) = 0;
 		virtual void set_output_rate(float cycles_per_second, int buffer_size) = 0;
 
+		int completed_sample_sets() { return completed_sample_sets_; }
+
 		struct Delegate {
 			virtual void speaker_did_complete_samples(Speaker *speaker, const std::vector<int16_t> &buffer) = 0;
 			virtual void speaker_did_change_input_clock(Speaker *speaker) {}
@@ -35,7 +37,12 @@ class Speaker {
 		}
 
 	protected:
+		void did_complete_samples(Speaker *speaker, const std::vector<int16_t> &buffer) {
+			++completed_sample_sets_;
+			delegate_->speaker_did_complete_samples(this, buffer);
+		}
 		Delegate *delegate_ = nullptr;
+		int completed_sample_sets_ = 0;
 };
 
 }


### PR DESCRIPTION
i.e. run a target machine until a particular event occurs. Used right now by the Mac for ensuring audio is prepared in a timely fashion, intended also to allow a potential future vsync mode.

This also rethinks the BestEffortUpdater logic in an attempt to improve likely CPU affinity.