### PR TITLE
Moves ownership of drives inside Disk::Controller.

### DIFF
--- a/Analyser/Static/Commodore/Disk.cpp
+++ b/Analyser/Static/Commodore/Disk.cpp
@@ -19,12 +19,10 @@ using namespace Analyser::Static::Commodore;
 
 class CommodoreGCRParser: public Storage::Disk::Controller {
 	public:
-		std::shared_ptr<Storage::Disk::Drive> drive;
-
 		CommodoreGCRParser() : Storage::Disk::Controller(4000000), shift_register_(0), track_(1) {
 			emplace_drive(4000000, 300, 2);
 			set_drive(1);
-			drive->set_motor_on(true);
+			get_drive().set_motor_on(true);
 		}
 
 		struct Sector {
@@ -59,6 +57,10 @@ class CommodoreGCRParser: public Storage::Disk::Controller {
 			}
 
 			return get_sector(sector);
+		}
+
+		void set_disk(const std::shared_ptr<Storage::Disk::Disk> &disk) {
+			get_drive().set_disk(disk);
 		}
 
 	private:
@@ -170,7 +172,7 @@ class CommodoreGCRParser: public Storage::Disk::Controller {
 std::vector<File> Analyser::Static::Commodore::GetFiles(const std::shared_ptr<Storage::Disk::Disk> &disk) {
 	std::vector<File> files;
 	CommodoreGCRParser parser;
-	parser.drive->set_disk(disk);
+	parser.set_disk(disk);
 
 	// find any sector whatsoever to establish the current track
 	std::shared_ptr<CommodoreGCRParser::Sector> sector;

--- a/Analyser/Static/Commodore/Disk.cpp
+++ b/Analyser/Static/Commodore/Disk.cpp
@@ -22,8 +22,8 @@ class CommodoreGCRParser: public Storage::Disk::Controller {
 		std::shared_ptr<Storage::Disk::Drive> drive;
 
 		CommodoreGCRParser() : Storage::Disk::Controller(4000000), shift_register_(0), track_(1) {
-			drive = std::make_shared<Storage::Disk::Drive>(4000000, 300, 2);
-			set_drive(drive);
+			emplace_drive(4000000, 300, 2);
+			set_drive(1);
 			drive->set_motor_on(true);
 		}
 

--- a/Machines/AmstradCPC/AmstradCPC.cpp
+++ b/Machines/AmstradCPC/AmstradCPC.cpp
@@ -661,17 +661,15 @@ class KeyboardState: public GI::AY38910::PortHandler {
 class FDC: public Intel::i8272::i8272 {
 	private:
 		Intel::i8272::BusHandler bus_handler_;
-		std::shared_ptr<Storage::Disk::Drive> drive_;
 
 	public:
-		FDC() :
-			i8272(bus_handler_, Cycles(8000000)),
-			drive_(new Storage::Disk::Drive(8000000, 300, 1)) {
-			set_drive(drive_);
+		FDC() : i8272(bus_handler_, Cycles(8000000)) {
+			emplace_drive(8000000, 300, 1);
+			set_drive(1);
 		}
 
 		void set_motor_on(bool on) {
-			drive_->set_motor_on(on);
+			get_drive().set_motor_on(on);
 		}
 
 		void select_drive(int c) {
@@ -679,11 +677,11 @@ class FDC: public Intel::i8272::i8272 {
 		}
 
 		void set_disk(std::shared_ptr<Storage::Disk::Disk> disk, int drive) {
-			drive_->set_disk(disk);
+			get_drive().set_disk(disk);
 		}
 
 		void set_activity_observer(Activity::Observer *observer) {
-			drive_->set_activity_observer(observer, "Drive 1", true);
+			get_drive().set_activity_observer(observer, "Drive 1", true);
 		}
 };
 

--- a/Machines/Atari/ST/AtariST.cpp
+++ b/Machines/Atari/ST/AtariST.cpp
@@ -441,7 +441,8 @@ class ConcreteMachine:
 			// Advance the relevant counters.
 			cycles_since_audio_update_ += length;
 			mfp_ += length;
-			dma_ += length;
+			if(dma_clocking_preference_ != ClockingHint::Preference::None)
+				dma_ += length;
 			keyboard_acia_ += length;
 			midi_acia_ += length;
 			bus_phase_ += length;
@@ -462,7 +463,7 @@ class ConcreteMachine:
 				mfp_.flush();
 			}
 
-			if(dma_is_realtime_) {
+			if(dma_clocking_preference_ == ClockingHint::Preference::RealTime) {
 				dma_.flush();
 			}
 
@@ -531,7 +532,7 @@ class ConcreteMachine:
 		bool may_defer_acias_ = true;
 		bool keyboard_needs_clock_ = false;
 		bool mfp_is_realtime_ = false;
-		bool dma_is_realtime_ = false;
+		ClockingHint::Preference dma_clocking_preference_ = ClockingHint::Preference::None;
 		void set_component_prefers_clocking(ClockingHint::Source *component, ClockingHint::Preference clocking) final {
 			// This is being called by one of the components; avoid any time flushing here as that's
 			// already dealt with (and, just to be absolutely sure, to avoid recursive mania).
@@ -540,7 +541,7 @@ class ConcreteMachine:
 				(midi_acia_.last_valid()->preferred_clocking() != ClockingHint::Preference::RealTime);
 			keyboard_needs_clock_ = ikbd_.preferred_clocking() != ClockingHint::Preference::None;
 			mfp_is_realtime_ = mfp_.last_valid()->preferred_clocking() == ClockingHint::Preference::RealTime;
-			dma_is_realtime_ = dma_.last_valid()->preferred_clocking() == ClockingHint::Preference::RealTime;
+			dma_clocking_preference_ = dma_.last_valid()->preferred_clocking();
 		}
 
 		// MARK: - GPIP input.

--- a/Machines/Atari/ST/DMAController.cpp
+++ b/Machines/Atari/ST/DMAController.cpp
@@ -126,7 +126,7 @@ void DMAController::set_floppy_drive_selection(bool drive1, bool drive2, bool si
 }
 
 void DMAController::set_floppy_disk(std::shared_ptr<Storage::Disk::Disk> disk, size_t drive) {
-	fdc_.drives_[drive]->set_disk(disk);
+	fdc_.set_disk(disk, drive);
 }
 
 void DMAController::run_for(HalfCycles duration) {
@@ -256,6 +256,5 @@ ClockingHint::Preference DMAController::preferred_clocking() {
 }
 
 void DMAController::set_activity_observer(Activity::Observer *observer) {
-	fdc_.drives_[0]->set_activity_observer(observer, "Internal", true);
-	fdc_.drives_[1]->set_activity_observer(observer, "External", true);
+	fdc_.set_activity_observer(observer);
 }

--- a/Machines/Commodore/1540/Implementation/C1540Base.hpp
+++ b/Machines/Commodore/1540/Implementation/C1540Base.hpp
@@ -144,7 +144,6 @@ class MachineBase:
 
 	protected:
 		CPU::MOS6502::Processor<CPU::MOS6502::Personality::P6502, MachineBase, false> m6502_;
-		std::shared_ptr<Storage::Disk::Drive> drive_;
 
 		uint8_t ram_[0x800];
 		uint8_t rom_[0x4000];

--- a/Machines/Electron/Plus3.hpp
+++ b/Machines/Electron/Plus3.hpp
@@ -24,8 +24,6 @@ class Plus3 : public WD::WD1770 {
 
 	private:
 		void set_control_register(uint8_t control, uint8_t changes);
-		std::vector<std::shared_ptr<Storage::Disk::Drive>> drives_;
-		int selected_drive_ = 0;
 		uint8_t last_control_ = 0;
 
 		void set_motor_on(bool on);

--- a/Machines/MSX/DiskROM.cpp
+++ b/Machines/MSX/DiskROM.cpp
@@ -13,8 +13,7 @@ using namespace MSX;
 DiskROM::DiskROM(const std::vector<uint8_t> &rom) :
 	WD1770(P1793),
 	rom_(rom) {
-	drives_[0] = std::make_shared<Storage::Disk::Drive>(8000000, 300, 2);
-	drives_[1] = std::make_shared<Storage::Disk::Drive>(8000000, 300, 2);
+	emplace_drives(2, 8000000, 300, 2);
 	set_is_double_density(true);
 }
 
@@ -23,18 +22,19 @@ void DiskROM::write(uint16_t address, uint8_t value, bool pc_is_outside_bios) {
 		case 0x7ff8: case 0x7ff9: case 0x7ffa: case 0x7ffb:
 			WD::WD1770::write(address, value);
 		break;
-		case 0x7ffc:
-			selected_head_ = value & 1;
-			drives_[0]->set_head(selected_head_);
-			drives_[1]->set_head(selected_head_);
-		break;
+		case 0x7ffc: {
+			const int selected_head = value & 1;
+			for_all_drives([selected_head] (Storage::Disk::Drive &drive, size_t index) {
+				drive.set_head(selected_head);
+			});
+		} break;
 		case 0x7ffd: {
-			selected_drive_ = value & 1;
-			set_drive(drives_[selected_drive_]);
+			set_drive(1 << (value & 1));
 
-			bool drive_motor = !!(value & 0x80);
-			drives_[0]->set_motor_on(drive_motor);
-			drives_[1]->set_motor_on(drive_motor);
+			const bool drive_motor = value & 0x80;
+			for_all_drives([drive_motor] (Storage::Disk::Drive &drive, size_t index) {
+				drive.set_motor_on(drive_motor);
+			});
 		} break;
 	}
 }
@@ -59,7 +59,7 @@ void DiskROM::run_for(HalfCycles half_cycles) {
 }
 
 void DiskROM::set_disk(std::shared_ptr<Storage::Disk::Disk> disk, size_t drive) {
-	drives_[drive]->set_disk(disk);
+	get_drive(drive).set_disk(disk);
 }
 
 void DiskROM::set_head_load_request(bool head_load) {
@@ -68,9 +68,7 @@ void DiskROM::set_head_load_request(bool head_load) {
 }
 
 void DiskROM::set_activity_observer(Activity::Observer *observer) {
-	size_t c = 1;
-	for(auto &drive: drives_) {
-		drive->set_activity_observer(observer, "Drive " + std::to_string(c), true);
-		++c;
-	}
+	for_all_drives([observer] (Storage::Disk::Drive &drive, size_t index) {
+		drive.set_activity_observer(observer, "Drive " + std::to_string(index), true);
+	});
 }

--- a/Machines/MSX/DiskROM.hpp
+++ b/Machines/MSX/DiskROM.hpp
@@ -36,9 +36,6 @@ class DiskROM: public ROMSlotHandler, public WD::WD1770 {
 		const std::vector<uint8_t> &rom_;
 
 		long int controller_cycles_ = 0;
-		size_t selected_drive_ = 0;
-		int selected_head_ = 0;
-		std::array<std::shared_ptr<Storage::Disk::Drive>, 2> drives_;
 
 		void set_head_load_request(bool head_load) final;
 };

--- a/Machines/Oric/BD500.cpp
+++ b/Machines/Oric/BD500.cpp
@@ -113,16 +113,16 @@ void BD500::access(int address) {
 void BD500::set_head_load_request(bool head_load) {
 	// Turn all motors on or off; if off then unload the head instantly.
 	is_loading_head_ |= head_load;
-	for(auto &drive : drives_) {
-		if(drive) drive->set_motor_on(head_load);
-	}
+	for_all_drives([head_load] (Storage::Disk::Drive &drive, size_t) {
+		drive.set_motor_on(head_load);
+	});
 	if(!head_load) set_head_loaded(false);
 }
 
 void BD500::run_for(const Cycles cycles) {
 	// If a head load is in progress and the selected drive is now ready,
 	// declare head loaded.
-	if(is_loading_head_ && drives_[selected_drive_] && drives_[selected_drive_]->get_is_ready()) {
+	if(is_loading_head_ && get_drive().get_is_ready()) {
 		set_head_loaded(true);
 		is_loading_head_ = false;
 	}

--- a/Machines/Oric/BD500.cpp
+++ b/Machines/Oric/BD500.cpp
@@ -24,6 +24,18 @@ void BD500::write(int address, uint8_t value) {
 //		if(address == 0x320) printf("Command %02x\n", value);
 		WD::WD1770::write(address, value);
 	}
+
+	if(address == 0x031a) {
+		// Drive select; kudos to iss of Oricutron for figuring this one out;
+		// cf. http://forum.defence-force.org/viewtopic.php?f=25&p=21409#p21393
+		switch(value & 0xe0) {
+			default:	set_drive(0);	break;
+			case 0x20:	set_drive(1);	break;
+			case 0x40:	set_drive(2);	break;
+			case 0x80:	set_drive(4);	break;
+			case 0xc0:	set_drive(8);	break;
+		}
+	}
 }
 
 uint8_t BD500::read(int address) {

--- a/Machines/Oric/BD500.cpp
+++ b/Machines/Oric/BD500.cpp
@@ -14,6 +14,7 @@ BD500::BD500() : DiskController(P1793, 9000000, Storage::Disk::Drive::ReadyType:
 	disable_basic_rom_ = true;
 	select_paged_item();
 	set_is_double_density(true);
+	set_drive(1);
 }
 
 void BD500::write(int address, uint8_t value) {

--- a/Machines/Oric/DiskController.hpp
+++ b/Machines/Oric/DiskController.hpp
@@ -14,15 +14,13 @@ namespace Oric {
 class DiskController: public WD::WD1770 {
 	public:
 		DiskController(WD::WD1770::Personality personality, int clock_rate, Storage::Disk::Drive::ReadyType ready_type) :
-			WD::WD1770(personality), clock_rate_(clock_rate), ready_type_(ready_type) {}
+			WD::WD1770(personality), clock_rate_(clock_rate), ready_type_(ready_type) {
+			emplace_drives(4, clock_rate_, 300, 2, ready_type_);
+			// TODO: don't assume four drives?
+		}
 
 		void set_disk(std::shared_ptr<Storage::Disk::Disk> disk, int d) {
-			const size_t drive = size_t(d);
-			if(!drives_[drive]) {
-				drives_[drive] = std::make_unique<Storage::Disk::Drive>(clock_rate_, 300, 2, ready_type_);
-				if(drive == selected_drive_) set_drive(drives_[drive]);
-			}
-			drives_[drive]->set_disk(disk);
+			get_drive(size_t(d)).set_disk(disk);
 		}
 
 		enum class PagedItem {
@@ -44,14 +42,6 @@ class DiskController: public WD::WD1770 {
 		}
 
 	protected:
-		std::array<std::shared_ptr<Storage::Disk::Drive>, 4> drives_;
-		size_t selected_drive_ = 0;
-		void select_drive(size_t drive) {
-			if(drive != selected_drive_) {
-				selected_drive_ = drive;
-				set_drive(drives_[selected_drive_]);
-			}
-		}
 		Delegate *delegate_ = nullptr;
 
 		bool enable_overlay_ram_ = false;

--- a/Machines/Oric/Microdisc.cpp
+++ b/Machines/Oric/Microdisc.cpp
@@ -33,16 +33,15 @@ void Microdisc::set_control_register(uint8_t control, uint8_t changes) {
 
 	// b65: drive select
 	if((changes >> 5)&3) {
-		selected_drive_ = (control >> 5)&3;
-		set_drive(drives_[selected_drive_]);
+		set_drive(1 << (control >> 5)&3);
 	}
 
 	// b4: side select
 	if(changes & 0x10) {
 		const int head = (control & 0x10) ? 1 : 0;
-		for(auto &drive : drives_) {
-			if(drive) drive->set_head(head);
-		}
+		for_all_drives([head] (Storage::Disk::Drive &drive, size_t) {
+			drive.set_head(head);
+		});
 	}
 
 	// b3: double density select (0 = double)
@@ -86,9 +85,9 @@ void Microdisc::set_head_load_request(bool head_load) {
 
 	// The drive motors (at present: I believe **all drive motors** regardless of the selected drive) receive
 	// the current head load request state.
-	for(auto &drive : drives_) {
-		if(drive) drive->set_motor_on(head_load);
-	}
+	for_all_drives([head_load] (Storage::Disk::Drive &drive, size_t) {
+		drive.set_motor_on(head_load);
+	});
 
 	// A request to load the head results in a delay until the head is confirmed loaded. This delay is handled
 	// in ::run_for. A request to unload the head results in an instant answer that the head is unloaded.

--- a/Machines/Oric/Video.hpp
+++ b/Machines/Oric/Video.hpp
@@ -44,8 +44,8 @@ class VideoOutput {
 		int v_sync_start_position_, v_sync_end_position_, counter_period_;
 
 		// Output target and device.
-		uint8_t *rgb_pixel_target_;
-		uint32_t *composite_pixel_target_;
+		uint8_t *rgb_pixel_target_ = nullptr;
+		uint32_t *composite_pixel_target_ = nullptr;
 		uint32_t colour_forms_[8];
 		Outputs::Display::InputDataType data_type_;
 

--- a/Storage/Disk/Controller/DiskController.hpp
+++ b/Storage/Disk/Controller/DiskController.hpp
@@ -49,9 +49,25 @@ class Controller:
 		void run_for(const Cycles cycles);
 
 		/*!
-			Sets the current drive. This drive is the one the PLL listens to.
+			Sets the current drive(s). Normally this will be exactly one, but some machines allow
+			zero or multiple drives to be attached, with useless results.
 		*/
-		void set_drive(std::shared_ptr<Drive> drive);
+		void set_drive(int index_mask);
+
+		/*!
+			Adds a new drive to the attached list, returning its index.
+		*/
+		template<typename... Args> size_t emplace_drive(Args&&... args) {
+			drives_.emplace_back(std::forward<Args>(args)...);
+			return drives_.size() - 1;
+		}
+
+		template<typename... Args> size_t emplace_drives(size_t count, Args&&... args) {
+			while(count--) {
+				drives_.emplace_back(std::forward<Args>(args)...);
+			}
+			return drives_.size() - 1;
+		}
 
 		/*!
 			Should be implemented by subclasses; communicates each bit that the PLL recognises.
@@ -98,6 +114,18 @@ class Controller:
 		*/
 		Drive &get_drive();
 
+		Drive &get_drive(size_t index) {
+			return drives_[index];
+		}
+
+		void for_all_drives(const std::function<void(Drive &, size_t)> &func) {
+			size_t index = 0;
+			for(auto &drive: drives_) {
+				func(drive, index);
+				++index;
+			}
+		}
+
 		/*!
 			As per ClockingHint::Source.
 		*/
@@ -113,9 +141,10 @@ class Controller:
 		DigitalPhaseLockedLoop<Controller> pll_;
 		friend DigitalPhaseLockedLoop<Controller>;
 
-		std::shared_ptr<Drive> drive_;
-
-		std::shared_ptr<Drive> empty_drive_;
+		Drive empty_drive_;
+		std::vector<Drive> drives_;
+		Drive *drive_;
+		int drive_selection_mask_ = 0xff;
 
 		// ClockingHint::Observer.
 		void set_component_prefers_clocking(ClockingHint::Source *component, ClockingHint::Preference clocking) final;

--- a/Storage/Disk/Controller/DiskController.hpp
+++ b/Storage/Disk/Controller/DiskController.hpp
@@ -55,16 +55,21 @@ class Controller:
 		void set_drive(int index_mask);
 
 		/*!
-			Adds a new drive to the attached list, returning its index.
+			Adds a new drive to the drive list, returning its index.
 		*/
 		template<typename... Args> size_t emplace_drive(Args&&... args) {
 			drives_.emplace_back(std::forward<Args>(args)...);
+			drives_.back().set_clocking_hint_observer(this);
 			return drives_.size() - 1;
 		}
 
+		/*!
+			Adds @c count new drives to the drive list, returning the index of the final one added.
+		*/
 		template<typename... Args> size_t emplace_drives(size_t count, Args&&... args) {
 			while(count--) {
 				drives_.emplace_back(std::forward<Args>(args)...);
+				drives_.back().set_clocking_hint_observer(this);
 			}
 			return drives_.size() - 1;
 		}

--- a/Storage/Disk/Drive.cpp
+++ b/Storage/Disk/Drive.cpp
@@ -170,6 +170,7 @@ void Drive::set_motor_on(bool motor_is_on) {
 	// TODO: momentum.
 	if(motor_is_on) {
 		set_disk_is_rotating(true);
+		time_until_motor_transition = Cycles(0);
 		return;
 	}
 
@@ -431,9 +432,10 @@ void Drive::set_disk_is_rotating(bool is_rotating) {
 	disk_is_rotating_ = is_rotating;
 
 	if(observer_) {
-		observer_->set_drive_motor_status(drive_name_, motor_input_is_on_);
+		observer_->set_drive_motor_status(drive_name_, disk_is_rotating_);
 		if(announce_motor_led_) {
-			observer_->set_led_status(drive_name_, motor_input_is_on_);
+			printf("LED set: %s %d\n", drive_name_.c_str(), int(disk_is_rotating_));
+			observer_->set_led_status(drive_name_, disk_is_rotating_);
 		}
 	}
 

--- a/Storage/Disk/Drive.cpp
+++ b/Storage/Disk/Drive.cpp
@@ -434,7 +434,6 @@ void Drive::set_disk_is_rotating(bool is_rotating) {
 	if(observer_) {
 		observer_->set_drive_motor_status(drive_name_, disk_is_rotating_);
 		if(announce_motor_led_) {
-			printf("LED set: %s %d\n", drive_name_.c_str(), int(disk_is_rotating_));
 			observer_->set_led_status(drive_name_, disk_is_rotating_);
 		}
 	}


### PR DESCRIPTION
This is primarily intended to allow intelligent clocking.

I've also endeavoured to give myself room to allow multiple-drive selection. It's a bit nonsensical, but some machines support it, and it'd be nice to provide nonsensical results if performed.

While I'm here, this also:
* resolves #747 by implementing multiple Byte Drive 500 drives; and
* fixes potential arbitrary memory accesses by the Oric at startup if you're unlucky.