### PR TITLE
Ensures proper handover of speaker state when picking in a multimachine.

### DIFF
--- a/Analyser/Dynamic/MultiMachine/Implementation/MultiSpeaker.cpp
+++ b/Analyser/Dynamic/MultiMachine/Implementation/MultiSpeaker.cpp
@@ -37,6 +37,13 @@ float MultiSpeaker::get_ideal_clock_rate_in_range(float minimum, float maximum) 
 	return ideal / float(speakers_.size());
 }
 
+//void MultiSpeaker::set_output_rate(float cycles_per_second, int buffer_size, bool stereo) {
+//	stereo_output_ = stereo;
+//	for(const auto &speaker: speakers_) {
+//		speaker->set_output_rate(cycles_per_second, buffer_size, stereo);
+//	}
+//}
+
 void MultiSpeaker::set_computed_output_rate(float cycles_per_second, int buffer_size, bool stereo) {
 	stereo_output_ = stereo;
 	for(const auto &speaker: speakers_) {

--- a/Analyser/Dynamic/MultiMachine/Implementation/MultiSpeaker.cpp
+++ b/Analyser/Dynamic/MultiMachine/Implementation/MultiSpeaker.cpp
@@ -37,13 +37,6 @@ float MultiSpeaker::get_ideal_clock_rate_in_range(float minimum, float maximum) 
 	return ideal / float(speakers_.size());
 }
 
-//void MultiSpeaker::set_output_rate(float cycles_per_second, int buffer_size, bool stereo) {
-//	stereo_output_ = stereo;
-//	for(const auto &speaker: speakers_) {
-//		speaker->set_output_rate(cycles_per_second, buffer_size, stereo);
-//	}
-//}
-
 void MultiSpeaker::set_computed_output_rate(float cycles_per_second, int buffer_size, bool stereo) {
 	stereo_output_ = stereo;
 	for(const auto &speaker: speakers_) {

--- a/Outputs/Speaker/Speaker.hpp
+++ b/Outputs/Speaker/Speaker.hpp
@@ -45,6 +45,16 @@ class Speaker {
 			compute_output_rate();
 		}
 
+		/*!
+			Takes a copy of the most recent output rate provided to @c rhs.
+		*/
+		void copy_output_rate(const Speaker &rhs) {
+			output_cycles_per_second_ = rhs.output_cycles_per_second_;
+			output_buffer_size_ = rhs.output_buffer_size_;
+			stereo_output_.store(rhs.stereo_output_.load(std::memory_order::memory_order_relaxed), std::memory_order::memory_order_relaxed);
+			compute_output_rate();
+		}
+
 		/// Sets the output volume, in the range [0, 1].
 		virtual void set_output_volume(float) = 0;
 


### PR DESCRIPTION
Corrects the crashing part of #826 but leaves multimachines still oddly mute.

Will look at the second issue separately — it's always worth getting a fix for a crash onto master ASAP.