### PR TITLE
Use url(forResource:... instead of path(forResource:… 

### DIFF
--- a/OSBindings/Mac/Clock SignalTests/65816kromTests.swift
+++ b/OSBindings/Mac/Clock SignalTests/65816kromTests.swift
@@ -26,13 +26,13 @@ class Krom65816Tests: XCTestCase {
 
 	func runTest(_ name: String, pcLimit: UInt32?) {
 		var testData: Data?
-		if let filename = Bundle(for: type(of: self)).path(forResource: name, ofType: "sfc") {
-			testData = try? Data(contentsOf: URL(fileURLWithPath: filename))
+		if let filename = Bundle(for: type(of: self)).url(forResource: name, withExtension: "sfc") {
+			testData = try? Data(contentsOf: filename)
 		}
 
 		var testOutput: String?
-		if let filename = Bundle(for: type(of: self)).path(forResource: name + "-trace_compare", ofType: "log") {
-			testOutput = try? String(contentsOf: URL(fileURLWithPath: filename))
+		if let filename = Bundle(for: type(of: self)).url(forResource: name + "-trace_compare", withExtension: "log") {
+			testOutput = try? String(contentsOf: filename)
 		}
 
 		XCTAssertNotNil(testData)


### PR DESCRIPTION
It cuts down on creating a URL struct.