### PR TITLE
Qt: don't copy the result of get_keyboard().

### DIFF
--- a/OSBindings/Qt/mainwindow.cpp
+++ b/OSBindings/Qt/mainwindow.cpp
@@ -1020,7 +1020,7 @@ bool MainWindow::processEvent(QKeyEvent *event) {
 			const auto keyboardMachine = machine->keyboard_machine();
 			if(!keyboardMachine) return true;
 
-			auto keyboard = keyboardMachine->get_keyboard();
+			auto &keyboard = keyboardMachine->get_keyboard();
 			keyboard.set_key_pressed(*key, event->text().size() ? event->text()[0].toLatin1() : '\0', isPressed);
 			if(keyboard.is_exclusive() || keyboard.observed_keys().find(*key) != keyboard.observed_keys().end()) {
 				return false;


### PR DESCRIPTION
Resolves the remaining portion of #852 