### PR TITLE
Corrects Metal buffer sizing on Retina displays.

### DIFF
--- a/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
@@ -5394,7 +5394,6 @@
 				INFOPLIST_FILE = "Clock Signal/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MTL_TREAT_WARNINGS_AS_ERRORS = YES;
-				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(OTHER_CFLAGS)",
 					"-Wreorder",

--- a/OSBindings/Mac/Clock Signal/ScanTarget/CSScanTarget.mm
+++ b/OSBindings/Mac/Clock Signal/ScanTarget/CSScanTarget.mm
@@ -396,8 +396,13 @@ using BufferingScanTarget = Outputs::Display::BufferingScanTarget;
 }
 
 - (void)updateSizeBuffersToSize:(CGSize)size {
-	const NSUInteger frameBufferWidth = NSUInteger(size.width * _view.layer.contentsScale) * (_isUsingSupersampling ? 2 : 1);
-	const NSUInteger frameBufferHeight = NSUInteger(size.height * _view.layer.contentsScale) * (_isUsingSupersampling ? 2 : 1);
+	// Anecdotally, the size provided here, which ultimately is from _view.drawableSize,
+	// already factors in Retina-style scaling.
+	//
+	// 16384 has been the maximum texture size in all Mac versions of Metal so far, and
+	// I haven't yet found a way to query it dynamically. So it's hard-coded.
+	const NSUInteger frameBufferWidth = MIN(NSUInteger(size.width) * (_isUsingSupersampling ? 2 : 1), 16384);
+	const NSUInteger frameBufferHeight = MIN(NSUInteger(size.height) * (_isUsingSupersampling ? 2 : 1), 16384);
 
 	// Generate a framebuffer and a stencil.
 	MTLTextureDescriptor *const textureDescriptor = [MTLTextureDescriptor


### PR DESCRIPTION
Also enables the M1 again for release builds.