### PR TITLE
Initial GameController joystick support.

### DIFF
--- a/OSBindings/Mac/Clock Signal/Joystick Manager/CSJoystickManager.m
+++ b/OSBindings/Mac/Clock Signal/Joystick Manager/CSJoystickManager.m
@@ -471,7 +471,7 @@ static void DeviceRemoved(void *context, IOReturn result, void *sender, IOHIDDev
 		if (![joystick isKindOfClass:[CSGCJoystick class]]) {
 			continue;
 		}
-		if(joystick.device == controller) return;
+		if([joystick.device isEqual:controller]) return;
 	}
 
 	// Prepare to collate a list of buttons, axes and hats for the new device.
@@ -509,7 +509,7 @@ static void DeviceRemoved(void *context, IOReturn result, void *sender, IOHIDDev
 		if (![joystick isKindOfClass:[CSGCJoystick class]]) {
 			continue;
 		}
-		if(joystick.device == controller) {
+		if([joystick.device isEqual:controller]) {
 			[_joysticks removeObject:joystick];
 			return;
 		}
@@ -521,7 +521,8 @@ static void DeviceRemoved(void *context, IOReturn result, void *sender, IOHIDDev
 	IOHIDManagerClose(_hidManager, kIOHIDOptionsTypeNone);
 	CFRelease(_hidManager);
 	if (@available(macOS 11.0, *)) {
-		[[NSNotificationCenter defaultCenter] removeObserver:self];
+		[[NSNotificationCenter defaultCenter] removeObserver:self name:GCControllerDidConnectNotification object:nil];
+		[[NSNotificationCenter defaultCenter] removeObserver:self name:GCControllerDidDisconnectNotification object:nil];
 	}
 }
 


### PR DESCRIPTION
This is a hacked-together implementation of the GameController framework for Clock Signal.
Current limitation: only four buttons are set up, a, b, x, and y. Any more buttons will need to be manually added.
The d-pad is interpreted as a hat switch.
The left analog stick and the x axis of the the right are used for `CSJoystickAxisTypeX`, `CSJoystickAxisTypeY`, and `CSJoystickAxisTypeZ`.

Note that you will need Mac OS 11 (Big Sur) or later, as the GameController frameworks were somewhat lacking in useful utilities until recently.