### PR TITLE
Adds the ZX Spectrum +2a and +3 as emulated machines.

### DIFF
--- a/Analyser/Static/AmstradCPC/StaticAnalyser.cpp
+++ b/Analyser/Static/AmstradCPC/StaticAnalyser.cpp
@@ -11,11 +11,11 @@
 #include <algorithm>
 #include <cstring>
 
-#include "Target.hpp"
-
 #include "../../../Storage/Disk/Parsers/CPM.hpp"
 #include "../../../Storage/Disk/Encodings/MFM/Parser.hpp"
 #include "../../../Storage/Tape/Parsers/Spectrum.hpp"
+
+#include "Target.hpp"
 
 namespace {
 

--- a/Analyser/Static/StaticAnalyser.cpp
+++ b/Analyser/Static/StaticAnalyser.cpp
@@ -66,6 +66,7 @@
 #include "../../Storage/Tape/Formats/TapeUEF.hpp"
 #include "../../Storage/Tape/Formats/TZX.hpp"
 #include "../../Storage/Tape/Formats/ZX80O81P.hpp"
+#include "../../Storage/Tape/Formats/ZXSpectrumTAP.hpp"
 
 // Target Platform Types
 #include "../../Storage/TargetPlatforms.hpp"
@@ -177,6 +178,7 @@ static Media GetMediaAndPlatforms(const std::string &file_name, TargetPlatform::
 	Format("stx", result.disks, Disk::DiskImageHolder<Storage::Disk::STX>, TargetPlatform::AtariST)				// STX
 	Format("tap", result.tapes, Tape::CommodoreTAP, TargetPlatform::Commodore)									// TAP (Commodore)
 	Format("tap", result.tapes, Tape::OricTAP, TargetPlatform::Oric)											// TAP (Oric)
+	Format("tap", result.tapes, Tape::ZXSpectrumTAP, TargetPlatform::ZXSpectrum)								// TAP (ZX Spectrum)
 	Format("tsx", result.tapes, Tape::TZX, TargetPlatform::MSX)													// TSX
 	Format("tzx", result.tapes, Tape::TZX, TargetPlatform::ZX8081 | TargetPlatform::ZXSpectrum)					// TZX
 	Format("uef", result.tapes, Tape::UEF, TargetPlatform::Acorn)												// UEF (tape)

--- a/Analyser/Static/StaticAnalyser.cpp
+++ b/Analyser/Static/StaticAnalyser.cpp
@@ -128,7 +128,7 @@ static Media GetMediaAndPlatforms(const std::string &file_name, TargetPlatform::
 	Format(	"dsk",
 			result.disks,
 			Disk::DiskImageHolder<Storage::Disk::CPCDSK>,
-			TargetPlatform::AmstradCPC | TargetPlatform::Oric)													// DSK (Amstrad CPC)
+			TargetPlatform::AmstradCPC | TargetPlatform::Oric | TargetPlatform::ZXSpectrum)						// DSK (Amstrad CPC, etc)
 	Format("dsk", result.disks, Disk::DiskImageHolder<Storage::Disk::AppleDSK>, TargetPlatform::DiskII)			// DSK (Apple II)
 	Format("dsk", result.disks, Disk::DiskImageHolder<Storage::Disk::MacintoshIMG>, TargetPlatform::Macintosh)	// DSK (Macintosh, floppy disk)
 	Format("dsk", result.mass_storage_devices, MassStorage::HFV, TargetPlatform::Macintosh)						// DSK (Macintosh, hard disk)

--- a/Analyser/Static/ZXSpectrum/StaticAnalyser.cpp
+++ b/Analyser/Static/ZXSpectrum/StaticAnalyser.cpp
@@ -86,8 +86,10 @@ Analyser::Static::TargetList Analyser::Static::ZXSpectrum::GetTargets(const Medi
 	}
 
 	// If any media survived, add the target.
-	if(!target->media.empty())
+	if(!target->media.empty()) {
+		target->should_hold_enter = true;	// To force entry into the 'loader' and thereby load the media.
 		destination.push_back(std::move(target));
+	}
 
 	return destination;
 }

--- a/Analyser/Static/ZXSpectrum/Target.hpp
+++ b/Analyser/Static/ZXSpectrum/Target.hpp
@@ -24,6 +24,7 @@ struct Target: public ::Analyser::Static::Target, public Reflection::StructImpl<
 	);
 
 	Model model = Model::Plus2a;
+	bool should_hold_enter = false;
 
 	Target(): Analyser::Static::Target(Machine::ZXSpectrum) {
 		if(needs_declare()) {

--- a/Components/AY38910/AY38910.hpp
+++ b/Components/AY38910/AY38910.hpp
@@ -164,6 +164,31 @@ template <bool is_stereo> class AY38910: public ::Outputs::Speaker::SampleSource
 		uint8_t c_left_ = 255, c_right_ = 255;
 };
 
+/*!
+	Provides helper code, to provide something closer to the interface exposed by many
+	AY-deploying machines of the era.
+*/
+struct Utility {
+	template <typename AY> static void select_register(AY &ay, uint8_t reg) {
+		ay.set_control_lines(GI::AY38910::ControlLines(GI::AY38910::BDIR | GI::AY38910::BC2 | GI::AY38910::BC1));
+		ay.set_data_input(reg);
+		ay.set_control_lines(GI::AY38910::ControlLines(0));
+	}
+
+	template <typename AY> static void write_data(AY &ay, uint8_t reg) {
+		ay.set_control_lines(GI::AY38910::ControlLines(GI::AY38910::BDIR | GI::AY38910::BC2));
+		ay.set_data_input(reg);
+		ay.set_control_lines(GI::AY38910::ControlLines(0));
+	}
+
+	template <typename AY> static uint8_t read_data(AY &ay) {
+		ay.set_control_lines(GI::AY38910::ControlLines(GI::AY38910::BC2 | GI::AY38910::BC1));
+		const uint8_t result = ay.get_data_output();
+		ay.set_control_lines(GI::AY38910::ControlLines(0));
+		return result;
+	}
+
+};
 
 }
 }

--- a/InstructionSets/Sizes.hpp
+++ b/InstructionSets/Sizes.hpp
@@ -12,7 +12,7 @@
 #include <limits>
 
 /*!
-	Maps to the smallest of the following integers that can contain max_value:
+	Maps to the smallest integral type that can contain max_value, from the following options:
 
 	* uint8_t;
 	* uint16_t;

--- a/Machines/AmstradCPC/FDC.hpp
+++ b/Machines/AmstradCPC/FDC.hpp
@@ -1,0 +1,51 @@
+//
+//  FDC.hpp
+//  Clock Signal
+//
+//  Created by Thomas Harte on 22/03/2021.
+//  Copyright © 2021 Thomas Harte. All rights reserved.
+//
+
+#ifndef FDC_h
+#define FDC_h
+
+#include "../../Components/8272/i8272.hpp"
+
+namespace Amstrad {
+
+/*!
+	Wraps the 8272 so as to provide proper clocking and RPM counts, and just directly
+	exposes motor control, applying the same value to all drives.
+*/
+class FDC: public Intel::i8272::i8272 {
+	private:
+		Intel::i8272::BusHandler bus_handler_;
+
+	public:
+		FDC(Cycles clock_rate = Cycles(8000000)) :
+			i8272(bus_handler_, clock_rate)
+		{
+			emplace_drive(clock_rate.as<int>(), 300, 1);
+			set_drive(1);
+		}
+
+		void set_motor_on(bool on) {
+			get_drive().set_motor_on(on);
+		}
+
+		void select_drive(int) {
+			// TODO: support more than one drive. (and in set_disk)
+		}
+
+		void set_disk(std::shared_ptr<Storage::Disk::Disk> disk, int) {
+			get_drive().set_disk(disk);
+		}
+
+		void set_activity_observer(Activity::Observer *observer) {
+			get_drive().set_activity_observer(observer, "Drive 1", true);
+		}
+};
+
+}
+
+#endif /* FDC_h */

--- a/Machines/Apple/AppleII/AuxiliaryMemorySwitches.hpp
+++ b/Machines/Apple/AppleII/AuxiliaryMemorySwitches.hpp
@@ -200,7 +200,7 @@ template <typename Machine> class AuxiliaryMemorySwitches {
 		}
 
 		/// @returns @c true if the alternative zero page should be used; @c false otherwise.
-		const ZeroState zero_state() const {
+		ZeroState zero_state() const {
 			return switches_.alternative_zero_page;
 		}
 

--- a/Machines/Apple/AppleIIgs/AppleIIgs.cpp
+++ b/Machines/Apple/AppleIIgs/AppleIIgs.cpp
@@ -107,8 +107,8 @@ class MemManagerChecker {
 		return true;
 	}
 
-	bool has_seen_valid_memory_ = false;
-	bool should_validate_ = false;
+//	bool has_seen_valid_memory_ = false;
+//	bool should_validate_ = false;
 
 	public:
 		bool validate_memory_manager(const Apple::IIgs::MemoryMap &memory, bool print) {

--- a/Machines/Apple/AppleIIgs/MemoryMap.hpp
+++ b/Machines/Apple/AppleIIgs/MemoryMap.hpp
@@ -35,7 +35,7 @@ class MemoryMap {
 			// Establish bank mapping.
 			uint8_t next_region = 0;
 			auto region = [&next_region, this]() -> uint8_t {
-				assert(next_region != regions.size());
+				assert(next_region != this->regions.size());
 				return next_region++;
 			};
 			auto set_region = [this](uint8_t bank, uint16_t start, uint16_t end, uint8_t region) {
@@ -49,7 +49,7 @@ class MemoryMap {
 					++target;
 				}
 			};
-			auto set_regions = [this, set_region, region](uint8_t bank, std::initializer_list<uint16_t> addresses, std::vector<uint8_t> allocated_regions = {}) {
+			auto set_regions = [set_region, region](uint8_t bank, std::initializer_list<uint16_t> addresses, std::vector<uint8_t> allocated_regions = {}) {
 				uint16_t previous = 0x0000;
 				auto next_region = allocated_regions.begin();
 				for(uint16_t address: addresses) {

--- a/Machines/MSX/MSX.cpp
+++ b/Machines/MSX/MSX.cpp
@@ -657,7 +657,6 @@ class ConcreteMachine:
 
 		void set_options(const std::unique_ptr<Reflection::Struct> &str) final {
 			const auto options = dynamic_cast<Options *>(str.get());
-
 			set_video_signal_configurable(options->output);
 			allow_fast_tape_ = options->quickload;
 			set_use_fast_tape();

--- a/Machines/Sinclair/Keyboard/Keyboard.hpp
+++ b/Machines/Sinclair/Keyboard/Keyboard.hpp
@@ -36,7 +36,7 @@ enum Key: uint16_t {
 	// Add some virtual keys; these do not exist on a real ZX80, ZX81 or early Spectrum, those all were added to the 128kb Spectrums.
 	// Either way, they're a convenience.
 	KeyDelete	= 0x0801,
-	KeyBreak, KeyLeft, KeyRight, KeyUp, KeyDown, KeyEdit
+	KeyBreak, KeyLeft, KeyRight, KeyUp, KeyDown, KeyEdit, KeySpectrumDot, KeyComma,
 };
 
 class Keyboard {

--- a/Machines/Sinclair/Keyboard/Keyboard.hpp
+++ b/Machines/Sinclair/Keyboard/Keyboard.hpp
@@ -13,7 +13,12 @@
 #include "../../Utility/Typer.hpp"
 
 namespace Sinclair {
-namespace ZX8081 {
+namespace ZX {
+namespace Keyboard {
+
+enum class Machine {
+	ZX80, ZX81, ZXSpectrum
+};
 
 enum Key: uint16_t {
 	KeyShift	= 0x0000 | 0x01,	KeyZ	= 0x0000 | 0x02,	KeyX = 0x0000 | 0x04,	KeyC = 0x0000 | 0x08,	KeyV = 0x0000 | 0x10,
@@ -23,41 +28,53 @@ enum Key: uint16_t {
 	Key0		= 0x0400 | 0x01,	Key9	= 0x0400 | 0x02,	Key8 = 0x0400 | 0x04,	Key7 = 0x0400 | 0x08,	Key6 = 0x0400 | 0x10,
 	KeyP		= 0x0500 | 0x01,	KeyO	= 0x0500 | 0x02,	KeyI = 0x0500 | 0x04,	KeyU = 0x0500 | 0x08,	KeyY = 0x0500 | 0x10,
 	KeyEnter	= 0x0600 | 0x01,	KeyL	= 0x0600 | 0x02,	KeyK = 0x0600 | 0x04,	KeyJ = 0x0600 | 0x08,	KeyH = 0x0600 | 0x10,
-	KeySpace	= 0x0700 | 0x01,	KeyDot	= 0x0700 | 0x02,	KeyM = 0x0700 | 0x04,	KeyN = 0x0700 | 0x08,	KeyB = 0x0700 | 0x10,
+	KeySpace	= 0x0700 | 0x01,								KeyM = 0x0700 | 0x04,	KeyN = 0x0700 | 0x08,	KeyB = 0x0700 | 0x10,
 
-	// Add some virtual keys; these do not exist on a real ZX80 or ZX81. They're just a convenience.
+	// The ZX80 and ZX81 keyboards have a full stop; the ZX Spectrum replaces that key with symbol shift.
+	KeyDot	= 0x0700 | 0x02,		KeySymbolShift = KeyDot,
+
+	// Add some virtual keys; these do not exist on a real ZX80, ZX81 or early Spectrum, those all were added to the 128kb Spectrums.
+	// Either way, they're a convenience.
 	KeyDelete	= 0x0801,
 	KeyBreak, KeyLeft, KeyRight, KeyUp, KeyDown, KeyEdit
 };
 
-struct Keyboard {
-	Keyboard(bool is_zx81);
+class Keyboard {
+	public:
+		Keyboard(Machine machine);
 
-	void set_key_state(uint16_t key, bool is_pressed);
-	void clear_all_keys();
+		void set_key_state(uint16_t key, bool is_pressed);
+		void clear_all_keys();
 
-	uint8_t read(uint16_t address);
+		uint8_t read(uint16_t address);
 
 	private:
 		uint8_t key_states_[8];
-		const bool is_zx81_;
+		const Machine machine_;
 };
 
-struct KeyboardMapper: public MachineTypes::MappedKeyboardMachine::KeyboardMapper {
-	uint16_t mapped_key_for_key(Inputs::Keyboard::Key key) const override;
+class KeyboardMapper: public MachineTypes::MappedKeyboardMachine::KeyboardMapper {
+	public:
+		KeyboardMapper(Machine machine);
+
+		uint16_t mapped_key_for_key(Inputs::Keyboard::Key key) const override;
+
+	private:
+		const Machine machine_;
 };
 
 class CharacterMapper: public ::Utility::CharacterMapper {
 	public:
-		CharacterMapper(bool is_zx81);
+		CharacterMapper(Machine machine);
 		const uint16_t *sequence_for_character(char character) const override;
 
 		bool needs_pause_after_key(uint16_t key) const override;
 
 	private:
-		bool is_zx81_;
+		const Machine machine_;
 };
 
+}
 }
 }
 

--- a/Machines/Sinclair/ZX8081/Keyboard.cpp
+++ b/Machines/Sinclair/ZX8081/Keyboard.cpp
@@ -8,6 +8,8 @@
 
 #include "Keyboard.hpp"
 
+#include <cstring>
+
 using namespace Sinclair::ZX8081;
 
 uint16_t KeyboardMapper::mapped_key_for_key(Inputs::Keyboard::Key key) const {

--- a/Machines/Sinclair/ZX8081/Keyboard.hpp
+++ b/Machines/Sinclair/ZX8081/Keyboard.hpp
@@ -30,6 +30,19 @@ enum Key: uint16_t {
 	KeyBreak, KeyLeft, KeyRight, KeyUp, KeyDown, KeyEdit
 };
 
+struct Keyboard {
+	Keyboard(bool is_zx81);
+
+	void set_key_state(uint16_t key, bool is_pressed);
+	void clear_all_keys();
+
+	uint8_t read(uint16_t address);
+
+	private:
+		uint8_t key_states_[8];
+		const bool is_zx81_;
+};
+
 struct KeyboardMapper: public MachineTypes::MappedKeyboardMachine::KeyboardMapper {
 	uint16_t mapped_key_for_key(Inputs::Keyboard::Key key) const override;
 };

--- a/Machines/Sinclair/ZX8081/ZX8081.cpp
+++ b/Machines/Sinclair/ZX8081/ZX8081.cpp
@@ -34,7 +34,7 @@
 
 namespace {
 	// The clock rate is 3.25Mhz.
-	const unsigned int ZX8081ClockRate = 3250000;
+	constexpr unsigned int ZX8081ClockRate = 3250000;
 }
 
 // TODO:

--- a/Machines/Sinclair/ZX8081/ZX8081.cpp
+++ b/Machines/Sinclair/ZX8081/ZX8081.cpp
@@ -379,6 +379,7 @@ template<bool is_zx81> class ConcreteMachine:
 		}
 
 		// MARK: - Configuration options.
+
 		std::unique_ptr<Reflection::Struct> get_options() final {
 			auto options = std::make_unique<Options>(Configurable::OptionsType::UserFriendly);	// OptionsType is arbitrary, but not optional.
 			options->automatic_tape_motor_control = use_automatic_tape_motor_control_;

--- a/Machines/Sinclair/ZX8081/ZX8081.hpp
+++ b/Machines/Sinclair/ZX8081/ZX8081.hpp
@@ -23,7 +23,6 @@ namespace ZX8081 {
 class Machine {
 	public:
 		virtual ~Machine();
-
 		static Machine *ZX8081(const Analyser::Static::Target *target, const ROMMachine::ROMFetcher &rom_fetcher);
 
 		virtual void set_tape_is_playing(bool is_playing) = 0;

--- a/Machines/Sinclair/ZXSpectrum/Video.cpp
+++ b/Machines/Sinclair/ZXSpectrum/Video.cpp
@@ -1,9 +1,0 @@
-//
-//  Video.cpp
-//  Clock Signal
-//
-//  Created by Thomas Harte on 18/03/2021.
-//  Copyright © 2021 Thomas Harte. All rights reserved.
-//
-
-#include "Video.hpp"

--- a/Machines/Sinclair/ZXSpectrum/Video.cpp
+++ b/Machines/Sinclair/ZXSpectrum/Video.cpp
@@ -1,0 +1,9 @@
+//
+//  Video.cpp
+//  Clock Signal
+//
+//  Created by Thomas Harte on 18/03/2021.
+//  Copyright © 2021 Thomas Harte. All rights reserved.
+//
+
+#include "Video.hpp"

--- a/Machines/Sinclair/ZXSpectrum/Video.hpp
+++ b/Machines/Sinclair/ZXSpectrum/Video.hpp
@@ -225,11 +225,13 @@ template <VideoTiming timing> class Video {
 			return time_since_interrupt_ < interrupt_duration;
 		}
 
-		int access_delay() const {
+		int access_delay(HalfCycles offset) const {
 			constexpr auto timings = get_timings();
-			if(time_since_interrupt_ < timings.first_delay) return 0;
+			const int delay_time = (time_since_interrupt_ + offset.as<int>()) % (timings.cycles_per_line * timings.lines_per_frame);
 
-			const int time_since = time_since_interrupt_ - timings.first_delay;
+			if(delay_time < timings.first_delay) return 0;
+
+			const int time_since = delay_time - timings.first_delay;
 			const int lines = time_since / timings.cycles_per_line;
 			if(lines >= 192) return 0;
 

--- a/Machines/Sinclair/ZXSpectrum/Video.hpp
+++ b/Machines/Sinclair/ZXSpectrum/Video.hpp
@@ -122,7 +122,7 @@ template <VideoTiming timing> class Video {
 
 					if(offset >= burst_position && offset < burst_position+burst_length && end_offset > offset) {
 						const int burst_duration = std::min(burst_position + burst_length, end_offset) - offset;
-						crt_.output_colour_burst(burst_duration, 0);
+						crt_.output_colour_burst(burst_duration, (line&1) * 128);
 						offset += burst_duration;
 					}
 
@@ -199,7 +199,7 @@ template <VideoTiming timing> class Video {
 
 					if(offset >= burst_position && offset < burst_position+burst_length && end_offset > offset) {
 						const int burst_duration = std::min(burst_position + burst_length, end_offset) - offset;
-						crt_.output_colour_burst(burst_duration, 0);
+						crt_.output_colour_burst(burst_duration, (line&1) * 128);
 						offset += burst_duration;
 					}
 

--- a/Machines/Sinclair/ZXSpectrum/Video.hpp
+++ b/Machines/Sinclair/ZXSpectrum/Video.hpp
@@ -9,7 +9,7 @@
 #ifndef Video_hpp
 #define Video_hpp
 
-
+#include "../../../Outputs/CRT/CRT.hpp"
 #include "../../../ClockReceiver/ClockReceiver.hpp"
 
 namespace Sinclair {
@@ -86,6 +86,14 @@ template <VideoTiming timing> class Video {
 		static constexpr int interrupt_duration = 48;
 
 	public:
+		Video() :
+			crt_(227 * 2, 1, Outputs::Display::Type::PAL50, Outputs::Display::InputDataType::Red2Green2Blue2)
+		{
+			// Show only the centre 80% of the TV frame.
+			crt_.set_display_type(Outputs::Display::DisplayType::RGB);
+			crt_.set_visible_area(Outputs::Display::Rect(0.1f, 0.1f, 0.8f, 0.8f));
+
+		}
 
 		HalfCycles get_next_sequence_point() {
 			if(time_since_interrupt_ < interrupt_duration) {
@@ -114,8 +122,19 @@ template <VideoTiming timing> class Video {
 			return timings.delays[line_position & 7];
 		}
 
+		/// Sets the scan target.
+		void set_scan_target(Outputs::Display::ScanTarget *scan_target) {
+			crt_.set_scan_target(scan_target);
+		}
+
+		/// Gets the current scan status.
+		Outputs::Display::ScanStatus get_scaled_scan_status() const {
+			return crt_.get_scaled_scan_status();
+		}
+
 	private:
 		int time_since_interrupt_ = 0;
+		Outputs::CRT::CRT crt_;
 };
 
 }

--- a/Machines/Sinclair/ZXSpectrum/Video.hpp
+++ b/Machines/Sinclair/ZXSpectrum/Video.hpp
@@ -79,13 +79,18 @@ template <VideoTiming timing> class Video {
 			//
 			// Contention begins four cycles before the first video fetch, so it begins at 70904. I don't currently
 			// know whether the four cycles is true across all models, so it's given here as convention_leadin.
+			//
+			// ... except that empirically that all seems to be two cycles off. So maybe I misunderstand what the
+			// contention patterns are supposed to indicate relative to MREQ? It's frustrating that all documentation
+			// I can find is vaguely in terms of contention patterns, and what they mean isn't well-defined in terms
+			// of regular Z80 signalling.
 			constexpr Timings result = {
 				.cycles_per_line = 228 * 2,
 				.lines_per_frame = 311,
 
-				.interrupt_time = 56543 * 2,
+				.interrupt_time = 56545 * 2,
 
-				.contention_leadin = 4 * 2,
+				.contention_leadin = 2 * 2,		// TODO: is this 2? Or 4? Or... ?
 				.contention_duration = 129 * 2,
 
 				.delays = {

--- a/Machines/Sinclair/ZXSpectrum/Video.hpp
+++ b/Machines/Sinclair/ZXSpectrum/Video.hpp
@@ -80,7 +80,7 @@ template <VideoTiming timing> class Video {
 			constexpr auto timings = get_timings();
 			constexpr int first_line = timings.first_delay / timings.cycles_per_line;
 			constexpr int sync_position = 166 * 2;
-			constexpr int sync_length = 14 * 2;
+			constexpr int sync_length = 17 * 2;
 			constexpr int burst_position = sync_position + 40;
 			constexpr int burst_length = 17;
 
@@ -122,7 +122,7 @@ template <VideoTiming timing> class Video {
 
 					if(offset >= burst_position && offset < burst_position+burst_length && end_offset > offset) {
 						const int burst_duration = std::min(burst_position + burst_length, end_offset) - offset;
-						crt_.output_default_colour_burst(burst_duration);
+						crt_.output_colour_burst(burst_duration, 0);
 						offset += burst_duration;
 					}
 
@@ -199,7 +199,7 @@ template <VideoTiming timing> class Video {
 
 					if(offset >= burst_position && offset < burst_position+burst_length && end_offset > offset) {
 						const int burst_duration = std::min(burst_position + burst_length, end_offset) - offset;
-						crt_.output_default_colour_burst(burst_duration);
+						crt_.output_colour_burst(burst_duration, 0);
 						offset += burst_duration;
 					}
 

--- a/Machines/Sinclair/ZXSpectrum/Video.hpp
+++ b/Machines/Sinclair/ZXSpectrum/Video.hpp
@@ -264,7 +264,7 @@ template <VideoTiming timing> class Video {
 			const int line_position = time_since % timings.cycles_per_line;
 			if(line_position >= timings.first_border - timings.first_delay) return 0;
 
-			return timings.delays[line_position & 7];
+			return timings.delays[line_position & 15];
 		}
 
 		void set_border_colour(uint8_t colour) {

--- a/Machines/Sinclair/ZXSpectrum/Video.hpp
+++ b/Machines/Sinclair/ZXSpectrum/Video.hpp
@@ -51,7 +51,7 @@ template <VideoTiming timing> class Video {
 			int cycles_per_line;
 			int lines_per_frame;
 			int first_delay;
-			int first_border;
+			int contended_period;
 			int delays[16];
 		};
 
@@ -60,7 +60,7 @@ template <VideoTiming timing> class Video {
 				.cycles_per_line = 228 * 2,
 				.lines_per_frame = 311,
 				.first_delay = 14361 * 2,
-				.first_border = 14490 * 2,
+				.contended_period = (14490 - 14361) * 2,
 				.delays = {
 					2, 1,
 					0, 0,
@@ -246,7 +246,7 @@ template <VideoTiming timing> class Video {
 			if(lines >= 192) return 0;
 
 			const int line_position = time_since % timings.cycles_per_line;
-			if(line_position >= timings.first_border - timings.first_delay) return 0;
+			if(line_position >= timings.contended_period) return 0;
 
 			return timings.delays[line_position & 15];
 		}

--- a/Machines/Sinclair/ZXSpectrum/Video.hpp
+++ b/Machines/Sinclair/ZXSpectrum/Video.hpp
@@ -210,8 +210,9 @@ template <VideoTiming timing> class Video {
 
 					if(offset >= burst_position && offset < burst_position+burst_length && end_offset > offset) {
 						const int burst_duration = std::min(burst_position + burst_length, end_offset) - offset;
-						crt_.output_colour_burst(burst_duration, 0, is_alternate_line_);
+						crt_.output_colour_burst(burst_duration, 116, is_alternate_line_);
 						offset += burst_duration;
+						// The colour burst phase above is an empirical guess. I need to research further.
 					}
 
 					if(offset >= burst_position+burst_length && end_offset > offset) {

--- a/Machines/Sinclair/ZXSpectrum/Video.hpp
+++ b/Machines/Sinclair/ZXSpectrum/Video.hpp
@@ -1,0 +1,26 @@
+//
+//  Video.hpp
+//  Clock Signal
+//
+//  Created by Thomas Harte on 18/03/2021.
+//  Copyright © 2021 Thomas Harte. All rights reserved.
+//
+
+#ifndef Video_hpp
+#define Video_hpp
+
+namespace Sinclair {
+namespace ZXSpectrum {
+
+enum class VideoTiming {
+	Plus3
+};
+
+template <VideoTiming timing> class Video {
+
+};
+
+}
+}
+
+#endif /* Video_hpp */

--- a/Machines/Sinclair/ZXSpectrum/Video.hpp
+++ b/Machines/Sinclair/ZXSpectrum/Video.hpp
@@ -95,6 +95,10 @@ template <VideoTiming timing> class Video {
 
 		}
 
+		void set_video_source(const uint8_t *source) {
+			memory_ = source;
+		}
+
 		HalfCycles get_next_sequence_point() {
 			if(time_since_interrupt_ < interrupt_duration) {
 				return HalfCycles(interrupt_duration - time_since_interrupt_);
@@ -135,6 +139,7 @@ template <VideoTiming timing> class Video {
 	private:
 		int time_since_interrupt_ = 0;
 		Outputs::CRT::CRT crt_;
+		const uint8_t *memory_ = nullptr;
 };
 
 }

--- a/Machines/Sinclair/ZXSpectrum/Video.hpp
+++ b/Machines/Sinclair/ZXSpectrum/Video.hpp
@@ -126,7 +126,7 @@ template <VideoTiming timing> class Video {
 
 							pixel_target_ = crt_.begin_data(256);
 							attribute_address_ = ((pixel_line / 8) * 32) + 6144;
-							pixel_address_ = ((pixel_line & 0x07) << 8) | ((pixel_line&0x38) << 2) | ((pixel_line&0xc0) << 3);
+							pixel_address_ = ((pixel_line & 0x07) << 8) | ((pixel_line&0x38) << 2) | ((pixel_line&0xc0) << 5);
 						}
 
 						if(pixel_target_) {
@@ -139,8 +139,8 @@ template <VideoTiming timing> class Video {
 								const uint8_t pixels = memory_[pixel_address_] ^ masks[flash_mask_ & (attributes >> 7)];
 
 								const uint8_t colours[2] = {
-									palette[((attributes & 0x40) >> 3) | (attributes & 0x07)],
 									palette[(attributes & 0x78) >> 3],
+									palette[((attributes & 0x40) >> 3) | (attributes & 0x07)],
 								};
 
 								pixel_target_[0] = colours[(pixels >> 7) & 1];

--- a/Machines/Sinclair/ZXSpectrum/Video.hpp
+++ b/Machines/Sinclair/ZXSpectrum/Video.hpp
@@ -9,6 +9,9 @@
 #ifndef Video_hpp
 #define Video_hpp
 
+
+#include "../../../ClockReceiver/ClockReceiver.hpp"
+
 namespace Sinclair {
 namespace ZXSpectrum {
 
@@ -16,8 +19,103 @@ enum class VideoTiming {
 	Plus3
 };
 
-template <VideoTiming timing> class Video {
+/*
+	Timing notes:
 
+	As of the +2a/+3:
+
+		311 lines, 228 cycles/line
+		Delays begin at 14361, follow the pattern 1, 0, 7, 6, 5, 4, 3, 2; run for 129 cycles/line.
+		Possibly delays only affect actual reads and writes; documentation is unclear.
+
+	Unknowns, to me, presently:
+
+		How long the interrupt line held for.
+
+	So...
+
+		Probably two bytes of video and attribute are fetched in each 8-cycle block,
+		with 16 such blocks therefore providing the whole visible display, an island
+		within 28.5 blocks horizontally.
+
+		14364 is 228*63, so I I guess almost 63 lines run from the start of vertical
+		blank through to the top of the display, implying 56 lines on to vertical blank.
+
+*/
+
+template <VideoTiming timing> class Video {
+	private:
+		struct Timings {
+			int cycles_per_line;
+			int lines_per_frame;
+			int first_delay;
+			int first_border;
+			int delays[16];
+		};
+
+		static constexpr Timings get_timings() {
+			constexpr Timings result = {
+				.cycles_per_line = 228 * 2,
+				.lines_per_frame = 311,
+				.first_delay = 14361 * 2,
+				.first_border = 14490 * 2,
+				.delays = {
+					2, 1,
+					0, 0,
+					14, 13,
+					12, 11,
+					10, 9,
+					8, 7,
+					6, 5,
+					4, 3,
+				}
+			};
+			return result;
+		}
+
+	public:
+		void run_for(HalfCycles duration) {
+			constexpr auto timings = get_timings();
+
+			// Advance time. TODO: all the drawing.
+			time_since_interrupt_ = (time_since_interrupt_ + duration.as<int>()) % (timings.cycles_per_line * timings.lines_per_frame);
+		}
+
+	private:
+		// TODO: how long is the interrupt line held for?
+		static constexpr int interrupt_duration = 48;
+
+	public:
+
+		HalfCycles get_next_sequence_point() {
+			if(time_since_interrupt_ < interrupt_duration) {
+				return HalfCycles(interrupt_duration - time_since_interrupt_);
+			}
+
+			constexpr auto timings = get_timings();
+			return timings.cycles_per_line * timings.lines_per_frame - time_since_interrupt_;
+		}
+
+		bool get_interrupt_line() const {
+			return time_since_interrupt_ < interrupt_duration;
+		}
+
+		int access_delay() const {
+			constexpr auto timings = get_timings();
+			if(time_since_interrupt_ < timings.first_delay) return 0;
+
+			const int time_since = time_since_interrupt_ - timings.first_delay;
+			const int lines = time_since / timings.cycles_per_line;
+			if(lines >= 192) return 0;
+
+			const int line_position = time_since % timings.cycles_per_line;
+			if(line_position >= timings.first_border - timings.first_delay) return 0;
+
+			return timings.delays[line_position & 7];
+		}
+
+	private:
+		int time_since_interrupt_ = 0;
 };
 
 }

--- a/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
+++ b/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
@@ -219,6 +219,18 @@ template<Model model> class ConcreteMachine:
 						update_audio();
 						GI::AY38910::Utility::write_data(ay_, *cycle.value);
 					}
+
+					if constexpr (model == Model::Plus3) {
+						switch(address) {
+							default: break;
+							case 0x3ffd:
+								// TODO: floppy data register.
+							break;
+							case 0x2ffd:
+								// TODO: floppy status register.
+							break;
+						}
+					}
 				break;
 
 				case PartialMachineCycle::Input:

--- a/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
+++ b/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
@@ -169,7 +169,7 @@ template<Model model> class ConcreteMachine:
 
 				case PartialMachineCycle::Write:
 					// Flush video if this access modifies screen contents.
-					if(address >= video_base_ && address < video_base_ + 6912) {
+					if(is_video_[address >> 14] && (address & 0x3fff) < 6912) {
 						video_.flush();
 					}
 					write_pointers_[address >> 14][address] = *cycle.value;
@@ -386,7 +386,7 @@ template<Model model> class ConcreteMachine:
 		uint8_t *write_pointers_[4];
 		uint8_t pages_[4];
 		bool is_contended_[4];
-		int video_base_ = 0x4000;
+		bool is_video_[4];
 
 		uint8_t port1ffd_ = 0;
 		uint8_t port7ffd_ = 0;
@@ -459,12 +459,10 @@ template<Model model> class ConcreteMachine:
 
 		void update_video_base() {
 			const uint8_t video_page = (port7ffd_ & 0x08) ? 7 : 5;
-			video_base_ = 0x1'0000;	// i.e. not in memory.
-
-			if(pages_[0] == video_page) video_base_ = 0x0000;
-			else if(pages_[1] == video_page) video_base_ = 0x4000;
-			else if(pages_[2] == video_page) video_base_ = 0x8000;
-			else if(pages_[3] == video_page) video_base_ = 0xc000;
+			is_video_[0] = pages_[0] == video_page;
+			is_video_[1] = pages_[1] == video_page;
+			is_video_[2] = pages_[2] == video_page;
+			is_video_[3] = pages_[3] == video_page;
 		}
 
 		// MARK: - Audio.

--- a/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
+++ b/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
@@ -198,6 +198,12 @@ template<Model model> class ConcreteMachine:
 					// The below patches over the 'LD-BYTES' routine from the 48kb ROM.
 					if(use_fast_tape_hack_ && address == 0x0556 && read_pointers_[0] == &rom_[0xc000]) {
 						if(perform_rom_ld_bytes()) {
+							// Stop pressing enter, if neccessry.
+							if(duration_to_press_enter_ > Cycles(0)) {
+								duration_to_press_enter_ = Cycles(0);
+								keyboard_.set_key_state(ZX::Keyboard::KeyEnter, false);
+							}
+
 							*cycle.value = 0xc9; // i.e. RET.
 							break;
 						}

--- a/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
+++ b/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
@@ -189,13 +189,15 @@ template<Model model> class ConcreteMachine:
 
 					// Test for classic 128kb paging register.
 					if((address & 0xc002) == 0x4000) {
-						disable_paging_ |= *cycle.value & 0x20;
-
 						// Set the proper video base pointer.
 						set_video_address();
 
 						port7ffd_ = *cycle.value;
 						update_memory_map();
+
+						// Potentially lock paging, _after_ the current
+						// port values have taken effect.
+						disable_paging_ |= *cycle.value & 0x20;
 					}
 
 					// Test for +2a/+3 paging.

--- a/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
+++ b/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
@@ -224,6 +224,9 @@ template<Model model> class ConcreteMachine:
 				return;
 			}
 
+			// Set the proper video base pointer.
+			video_->set_video_source(&ram_[((port7ffd_ & 0x08) ? 7 : 5) * 16384]);
+
 			if(port1ffd_ & 1) {
 				// "Special paging mode", i.e. one of four fixed
 				// RAM configurations, port 7ffd doesn't matter.

--- a/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
+++ b/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
@@ -26,6 +26,8 @@
 
 #include "../../../Analyser/Static/ZXSpectrum/Target.hpp"
 
+#include "../../Utility/MemoryFuzzer.hpp"
+
 #include "../../../ClockReceiver/JustInTime.hpp"
 
 #include <array>
@@ -60,6 +62,7 @@ template<Model model> class ConcreteMachine:
 
 			// Set up initial memory map.
 			update_memory_map();
+			Memory::Fuzz(ram_);
 
 			// TODO: insert media.
 			(void)target;

--- a/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
+++ b/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
@@ -204,20 +204,16 @@ template<Model model> class ConcreteMachine:
 						update_memory_map();
 					}
 
-					switch(address) {
-						default: break;
+					if((address & 0xc002) == 0xc000) {
+						// Select AY register.
+						update_audio();
+						GI::AY38910::Utility::select_register(ay_, *cycle.value);
+					}
 
-						case 0xfffd:
-							// Select AY register.
-							update_audio();
-							GI::AY38910::Utility::select_register(ay_, *cycle.value);
-						break;
-
-						case 0xbffd:
-							// Write to AY register.
-							update_audio();
-							GI::AY38910::Utility::write_data(ay_, *cycle.value);
-						break;
+					if((address & 0xc002) == 0x8000) {
+						// Write to AY register.
+						update_audio();
+						GI::AY38910::Utility::write_data(ay_, *cycle.value);
 					}
 				break;
 
@@ -252,14 +248,10 @@ template<Model model> class ConcreteMachine:
 						}
 					}
 
-					switch(address) {
-						default: break;
-
-						case 0xfffd:
-							// Read from AY register.
-							update_audio();
-							*cycle.value &= GI::AY38910::Utility::read_data(ay_);
-						break;
+					if((address & 0xc002) == 0xc000) {
+						// Read from AY register.
+						update_audio();
+						*cycle.value &= GI::AY38910::Utility::read_data(ay_);
 					}
 				break;
 			}

--- a/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
+++ b/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
@@ -41,6 +41,7 @@ using Model = Analyser::Static::ZXSpectrum::Target::Model;
 template<Model model> class ConcreteMachine:
 	public Configurable::Device,
 	public Machine,
+	public MachineTypes::AudioProducer,
 	public MachineTypes::MappedKeyboardMachine,
 	public MachineTypes::MediaTarget,
 	public MachineTypes::ScanProducer,
@@ -341,6 +342,12 @@ template<Model model> class ConcreteMachine:
 			set_use_automatic_tape_motor_control(options->automatic_tape_motor_control);
 			allow_fast_tape_hack_ = options->quickload;
 			set_use_fast_tape();
+		}
+
+		// MARK: - AudioProducer.
+
+		Outputs::Speaker::Speaker *get_speaker() override {
+			return &speaker_;
 		}
 
 	private:

--- a/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
+++ b/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
@@ -82,6 +82,7 @@ template<Model model> class ConcreteMachine:
 		}
 
 		void flush() {
+			video_.flush();
 			update_audio();
 			audio_queue_.perform();
 		}
@@ -101,6 +102,11 @@ template<Model model> class ConcreteMachine:
 
 		forceinline HalfCycles perform_machine_cycle(const CPU::Z80::PartialMachineCycle &cycle) {
 			time_since_audio_update_ += cycle.length;
+
+			video_ += cycle.length;
+			if(video_.did_flush()) {
+				z80_.set_interrupt_line(video_.last_valid()->get_interrupt_line());
+			}
 
 			// Ignore all but terminal cycles.
 			// TODO: I doubt this is correct for timing.
@@ -287,7 +293,7 @@ template<Model model> class ConcreteMachine:
 
 		// MARK: - Video.
 		static constexpr VideoTiming video_timing = VideoTiming::Plus3;
-		Video<video_timing> video_;
+		JustInTimeActor<Video<video_timing>> video_;
 };
 
 

--- a/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
+++ b/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
@@ -8,6 +8,8 @@
 
 #include "ZXSpectrum.hpp"
 
+#include "Video.hpp"
+
 #define LOG_PREFIX "[Spectrum] "
 
 #include "../../MachineTypes.hpp"
@@ -23,6 +25,8 @@
 #include "../../../Outputs/Speaker/Implementation/SampleSource.hpp"
 
 #include "../../../Analyser/Static/ZXSpectrum/Target.hpp"
+
+#include "../../../ClockReceiver/JustInTime.hpp"
 
 #include <array>
 
@@ -280,6 +284,10 @@ template<Model model> class ConcreteMachine:
 		void update_audio() {
 			speaker_.run_for(audio_queue_, time_since_audio_update_.divide_cycles(Cycles(2)));
 		}
+
+		// MARK: - Video.
+		static constexpr VideoTiming video_timing = VideoTiming::Plus3;
+		Video<video_timing> video_;
 };
 
 

--- a/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
+++ b/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
@@ -118,6 +118,10 @@ template<Model model> class ConcreteMachine:
 						// TODO: rest of port FE.
 						update_audio();
 						audio_toggle_.set_output(*cycle.value & 0x10);
+
+						// b0–b2: border colour
+						// b3: enable tape input (?)
+						// b4: tape and speaker output
 					}
 
 					switch(address) {
@@ -157,6 +161,10 @@ template<Model model> class ConcreteMachine:
 				case PartialMachineCycle::Input:
 					if(!(address&1)) {
 						// TODO: port FE.
+
+						// address b8+: mask of keyboard lines to select
+						// result: b0–b4: mask of keys pressed
+						// b6: tape input
 					}
 
 					switch(address) {

--- a/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
+++ b/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
@@ -26,10 +26,6 @@
 
 #include <array>
 
-namespace {
-	const unsigned int ClockRate = 3'500'000;
-}
-
 
 namespace Sinclair {
 namespace ZXSpectrum {
@@ -48,8 +44,8 @@ template<Model model> class ConcreteMachine:
 			mixer_(ay_, audio_toggle_),
 			speaker_(mixer_)
 		{
-			set_clock_rate(ClockRate);
-			speaker_.set_input_rate(float(ClockRate) / 2.0f);
+			set_clock_rate(clock_rate());
+			speaker_.set_input_rate(float(clock_rate()) / 2.0f);
 
 			// With only the +2a and +3 currently supported, the +3 ROM is always
 			// the one required.
@@ -67,6 +63,12 @@ template<Model model> class ConcreteMachine:
 
 		~ConcreteMachine() {
 			audio_queue_.flush();
+		}
+
+		static constexpr unsigned int clock_rate() {
+//			constexpr unsigned int ClockRate = 3'500'000;
+			constexpr unsigned int Plus3ClockRate = 3'546'900;
+			return Plus3ClockRate;
 		}
 
 		// MARK: - TimedMachine
@@ -114,8 +116,8 @@ template<Model model> class ConcreteMachine:
 				break;
 
 				case PartialMachineCycle::Output:
+					// Test for port FE.
 					if(!(address&1)) {
-						// TODO: rest of port FE.
 						update_audio();
 						audio_toggle_.set_output(*cycle.value & 0x10);
 
@@ -123,6 +125,14 @@ template<Model model> class ConcreteMachine:
 						// b3: enable tape input (?)
 						// b4: tape and speaker output
 					}
+
+					// Test for classic 128kb paging.
+//					if(!(address&0x8002)) {
+//					}
+
+					// Test for +2a/+3 paging.
+//					if((address & 0xc002) == 0x4000) {
+//					}
 
 					switch(address) {
 						default: break;

--- a/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
+++ b/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
@@ -90,12 +90,11 @@ template<Model model> class ConcreteMachine:
 		// MARK: - ScanProducer
 
 		void set_scan_target(Outputs::Display::ScanTarget *scan_target) final {
-			(void)scan_target;
+			video_->set_scan_target(scan_target);
 		}
 
 		Outputs::Display::ScanStatus get_scaled_scan_status() const final {
-			// TODO.
-			return Outputs::Display::ScanStatus();
+			return video_->get_scaled_scan_status();
 		}
 
 		// MARK: - BusHandler

--- a/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
+++ b/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
@@ -213,17 +213,13 @@ template<Model model> class ConcreteMachine:
 						case 0xfffd:
 							// Select AY register.
 							update_audio();
-							ay_.set_control_lines(GI::AY38910::ControlLines(GI::AY38910::BDIR | GI::AY38910::BC2 | GI::AY38910::BC1));
-							ay_.set_data_input(*cycle.value);
-							ay_.set_control_lines(GI::AY38910::ControlLines(0));
+							GI::AY38910::Utility::select_register(ay_, *cycle.value);
 						break;
 
 						case 0xbffd:
 							// Write to AY register.
 							update_audio();
-							ay_.set_control_lines(GI::AY38910::ControlLines(GI::AY38910::BDIR | GI::AY38910::BC2));
-							ay_.set_data_input(*cycle.value);
-							ay_.set_control_lines(GI::AY38910::ControlLines(0));
+							GI::AY38910::Utility::write_data(ay_, *cycle.value);
 						break;
 					}
 				break;
@@ -265,9 +261,7 @@ template<Model model> class ConcreteMachine:
 						case 0xfffd:
 							// Read from AY register.
 							update_audio();
-							ay_.set_control_lines(GI::AY38910::ControlLines(GI::AY38910::BC2 | GI::AY38910::BC1));
-							*cycle.value &= ay_.get_data_output();
-							ay_.set_control_lines(GI::AY38910::ControlLines(0));
+							*cycle.value &= GI::AY38910::Utility::read_data(ay_);
 						break;
 					}
 				break;

--- a/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
+++ b/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
@@ -82,7 +82,32 @@ template<Model model> class ConcreteMachine:
 
 		static constexpr unsigned int clock_rate() {
 //			constexpr unsigned int ClockRate = 3'500'000;
-			constexpr unsigned int Plus3ClockRate = 3'546'900;
+			constexpr unsigned int Plus3ClockRate = 3'546'875;	// See notes below; this is a guess.
+
+			// Notes on timing for the +2a and +3:
+			//
+			// Standard PAL produces 283.7516 colour cycles per line, each line being 64µs.
+			// The oft-quoted 3.5469 Mhz would seem to imply 227.0016 clock cycles per line.
+			// Since those Spectrums actually produce 228 cycles per line, but software like
+			// Chromatrons seems to assume a fixed phase relationship, I guess that the real
+			// clock speed is whatever gives:
+			//
+			// 228 / [cycles per line] * 283.7516 = [an integer].
+			//
+			// i.e. 228 * 283.7516 = [an integer] * [cycles per line], such that cycles per line ~= 227
+			// ... which would imply that 'an integer' is probably 285, i.e.
+			//
+			// 228 / [cycles per line] * 283.7516 = 285
+			// => 227.00128 = [cycles per line]
+			// => clock rate = 3.546895 Mhz?
+			//
+			// That is... unless I'm mistaken about the PAL colour subcarrier and it's actually 283.75,
+			// which would give exactly 227 cycles/line and therefore 3.546875 Mhz.
+			//
+			// A real TV would be likely to accept either, I guess. But it does seem like
+			// the Spectrum is a PAL machine with a fixed colour phase relationship. For
+			// this emulator's world, that's a first!
+
 			return Plus3ClockRate;
 		}
 

--- a/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
+++ b/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
@@ -130,6 +130,8 @@ template<Model model> class ConcreteMachine:
 						update_audio();
 						audio_toggle_.set_output(*cycle.value & 0x10);
 
+						video_->set_border_colour(*cycle.value & 7);
+
 						// b0–b2: border colour
 						// b3: enable tape input (?)
 						// b4: tape and speaker output

--- a/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
+++ b/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
@@ -183,6 +183,8 @@ template<Model model> class ConcreteMachine:
 				break;
 
 				case PartialMachineCycle::Input:
+					*cycle.value = 0xff;
+
 					if(!(address&1)) {
 						// TODO: port FE.
 

--- a/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
+++ b/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
@@ -30,8 +30,7 @@
 
 #include "../../../ClockReceiver/JustInTime.hpp"
 
-// TODO: Factor this file into an appropriate place and namespace.
-#include "../ZX8081/Keyboard.hpp"
+#include "../Keyboard/Keyboard.hpp"
 
 #include <array>
 
@@ -52,7 +51,8 @@ template<Model model> class ConcreteMachine:
 			audio_toggle_(audio_queue_),
 			mixer_(ay_, audio_toggle_),
 			speaker_(mixer_),
-			keyboard_(true)
+			keyboard_(Sinclair::ZX::Keyboard::Machine::ZXSpectrum),
+			keyboard_mapper_(Sinclair::ZX::Keyboard::Machine::ZXSpectrum)
 		{
 			set_clock_rate(clock_rate());
 			speaker_.set_input_rate(float(clock_rate()) / 2.0f);
@@ -355,8 +355,8 @@ template<Model model> class ConcreteMachine:
 		JustInTimeActor<Video<video_timing>> video_;
 
 		// MARK: - Keyboard.
-		Sinclair::ZX8081::Keyboard keyboard_;
-		ZX8081::KeyboardMapper keyboard_mapper_;
+		Sinclair::ZX::Keyboard::Keyboard keyboard_;
+		Sinclair::ZX::Keyboard::KeyboardMapper keyboard_mapper_;
 };
 
 

--- a/Machines/Sinclair/ZXSpectrum/ZXSpectrum.hpp
+++ b/Machines/Sinclair/ZXSpectrum/ZXSpectrum.hpp
@@ -22,8 +22,28 @@ namespace ZXSpectrum {
 class Machine {
 	public:
 		virtual ~Machine();
-
 		static Machine *ZXSpectrum(const Analyser::Static::Target *target, const ROMMachine::ROMFetcher &rom_fetcher);
+
+		virtual void set_tape_is_playing(bool is_playing) = 0;
+		virtual bool get_tape_is_playing() = 0;
+
+		class Options: public Reflection::StructImpl<Options>, public Configurable::DisplayOption<Options>, public Configurable::QuickloadOption<Options> {
+			friend Configurable::DisplayOption<Options>;
+			friend Configurable::QuickloadOption<Options>;
+			public:
+				bool automatic_tape_motor_control;
+
+				Options(Configurable::OptionsType type) :
+					Configurable::DisplayOption<Options>(type == Configurable::OptionsType::UserFriendly ? Configurable::Display::RGB : Configurable::Display::CompositeColour),
+					Configurable::QuickloadOption<Options>(type == Configurable::OptionsType::UserFriendly)
+				{
+					if(needs_declare()) {
+						DeclareField(automatic_tape_motor_control);
+						declare_display_option();
+						declare_quickload_option();
+					}
+				}
+		};
 };
 
 

--- a/Machines/Sinclair/ZXSpectrum/ZXSpectrum.hpp
+++ b/Machines/Sinclair/ZXSpectrum/ZXSpectrum.hpp
@@ -35,7 +35,8 @@ class Machine {
 
 				Options(Configurable::OptionsType type) :
 					Configurable::DisplayOption<Options>(type == Configurable::OptionsType::UserFriendly ? Configurable::Display::RGB : Configurable::Display::CompositeColour),
-					Configurable::QuickloadOption<Options>(type == Configurable::OptionsType::UserFriendly)
+					Configurable::QuickloadOption<Options>(type == Configurable::OptionsType::UserFriendly),
+					automatic_tape_motor_control(type == Configurable::OptionsType::UserFriendly)
 				{
 					if(needs_declare()) {
 						DeclareField(automatic_tape_motor_control);

--- a/Machines/Utility/MachineForTarget.cpp
+++ b/Machines/Utility/MachineForTarget.cpp
@@ -39,6 +39,7 @@
 #include "../../Analyser/Static/Oric/Target.hpp"
 #include "../../Analyser/Static/Sega/Target.hpp"
 #include "../../Analyser/Static/ZX8081/Target.hpp"
+#include "../../Analyser/Static/ZXSpectrum/Target.hpp"
 
 #include "../../Analyser/Dynamic/MultiMachine/MultiMachine.hpp"
 #include "TypedDynamicMachine.hpp"
@@ -132,6 +133,7 @@ std::string Machine::ShortNameForTargetMachine(const Analyser::Machine machine) 
 		case Analyser::Machine::Oric:			return "Oric";
 		case Analyser::Machine::Vic20:			return "Vic20";
 		case Analyser::Machine::ZX8081:			return "ZX8081";
+		case Analyser::Machine::ZXSpectrum:		return "ZXSpectrum";
 
 		default:	return "";
 	}
@@ -152,6 +154,7 @@ std::string Machine::LongNameForTargetMachine(Analyser::Machine machine) {
 		case Analyser::Machine::Oric:			return "Oric";
 		case Analyser::Machine::Vic20:			return "Vic 20";
 		case Analyser::Machine::ZX8081:			return "ZX80/81";
+		case Analyser::Machine::ZXSpectrum:		return "ZX Spectrum";
 
 		default:	return "";
 	}
@@ -203,6 +206,7 @@ std::map<std::string, std::unique_ptr<Reflection::Struct>> Machine::AllOptionsBy
 	Emplace(Oric, Oric::Machine);
 	Emplace(Vic20, Commodore::Vic20::Machine);
 	Emplace(ZX8081, Sinclair::ZX8081::Machine);
+	Emplace(ZXSpectrum, Sinclair::ZXSpectrum::Machine);
 
 #undef Emplace
 
@@ -226,6 +230,7 @@ std::map<std::string, std::unique_ptr<Analyser::Static::Target>> Machine::Target
 	Add(Oric);
 	AddMapped(Vic20, Commodore);
 	Add(ZX8081);
+	Add(ZXSpectrum);
 
 	if(!meaningful_without_media_only) {
 		Add(Atari2600);
@@ -234,7 +239,7 @@ std::map<std::string, std::unique_ptr<Analyser::Static::Target>> Machine::Target
 	}
 
 #undef Add
-#undef AddTwo
+#undef AddMapped
 
 	return options;
 }

--- a/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
@@ -128,10 +128,10 @@
 		4B0F1BDE2602FF9900B85C66 /* Video.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0F1BCD2602F17B00B85C66 /* Video.cpp */; };
 		4B0F1BE22602FF9C00B85C66 /* ZX8081.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0F1BCC2602F17B00B85C66 /* ZX8081.cpp */; };
 		4B0F1BE62602FF9D00B85C66 /* ZX8081.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0F1BCC2602F17B00B85C66 /* ZX8081.cpp */; };
-		4B0F1BEA2602FFA000B85C66 /* Keyboard.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0F1BCF2602F17B00B85C66 /* Keyboard.cpp */; };
-		4B0F1BEB2602FFA100B85C66 /* Keyboard.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0F1BCF2602F17B00B85C66 /* Keyboard.cpp */; };
 		4B0F1BFC260300D900B85C66 /* ZXSpectrum.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0F1BFA260300D900B85C66 /* ZXSpectrum.cpp */; };
 		4B0F1BFD260300D900B85C66 /* ZXSpectrum.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0F1BFA260300D900B85C66 /* ZXSpectrum.cpp */; };
+		4B0F1C1C2604EA1000B85C66 /* Keyboard.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0F1C1B2604EA1000B85C66 /* Keyboard.cpp */; };
+		4B0F1C1D2604EA1000B85C66 /* Keyboard.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0F1C1B2604EA1000B85C66 /* Keyboard.cpp */; };
 		4B0F94FE208C1A1600FE41D9 /* NIB.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0F94FC208C1A1600FE41D9 /* NIB.cpp */; };
 		4B0F94FF208C1A1600FE41D9 /* NIB.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0F94FC208C1A1600FE41D9 /* NIB.cpp */; };
 		4B121F9B1E06293F00BFDA12 /* PCMSegmentEventSourceTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4B121F9A1E06293F00BFDA12 /* PCMSegmentEventSourceTests.mm */; };
@@ -1061,16 +1061,16 @@
 		4B0E61061FF34737002A9DBD /* MSX.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = MSX.hpp; path = Parsers/MSX.hpp; sourceTree = "<group>"; };
 		4B0F1BB02602645900B85C66 /* StaticAnalyser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StaticAnalyser.cpp; sourceTree = "<group>"; };
 		4B0F1BB12602645900B85C66 /* StaticAnalyser.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = StaticAnalyser.hpp; sourceTree = "<group>"; };
-		4B0F1BCB2602F17B00B85C66 /* Keyboard.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Keyboard.hpp; sourceTree = "<group>"; };
 		4B0F1BCC2602F17B00B85C66 /* ZX8081.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ZX8081.cpp; sourceTree = "<group>"; };
 		4B0F1BCD2602F17B00B85C66 /* Video.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Video.cpp; sourceTree = "<group>"; };
 		4B0F1BCE2602F17B00B85C66 /* Video.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Video.hpp; sourceTree = "<group>"; };
-		4B0F1BCF2602F17B00B85C66 /* Keyboard.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Keyboard.cpp; sourceTree = "<group>"; };
 		4B0F1BD02602F17B00B85C66 /* ZX8081.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = ZX8081.hpp; sourceTree = "<group>"; };
 		4B0F1BFA260300D900B85C66 /* ZXSpectrum.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ZXSpectrum.cpp; sourceTree = "<group>"; };
 		4B0F1BFB260300D900B85C66 /* ZXSpectrum.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = ZXSpectrum.hpp; sourceTree = "<group>"; };
 		4B0F1C04260391F100B85C66 /* Target.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Target.hpp; sourceTree = "<group>"; };
 		4B0F1C092603BA5F00B85C66 /* Video.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Video.hpp; sourceTree = "<group>"; };
+		4B0F1C1A2604EA1000B85C66 /* Keyboard.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = Keyboard.hpp; sourceTree = "<group>"; };
+		4B0F1C1B2604EA1000B85C66 /* Keyboard.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Keyboard.cpp; sourceTree = "<group>"; };
 		4B0F94FC208C1A1600FE41D9 /* NIB.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NIB.cpp; sourceTree = "<group>"; };
 		4B0F94FD208C1A1600FE41D9 /* NIB.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = NIB.hpp; sourceTree = "<group>"; };
 		4B0F9500208C42A300FE41D9 /* Target.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = Target.hpp; path = AppleII/Target.hpp; sourceTree = "<group>"; };
@@ -2177,6 +2177,7 @@
 		4B0F1BC92602F17B00B85C66 /* Sinclair */ = {
 			isa = PBXGroup;
 			children = (
+				4B0F1C192604EA1000B85C66 /* Keyboard */,
 				4B0F1BCA2602F17B00B85C66 /* ZX8081 */,
 				4B0F1BF9260300D900B85C66 /* ZXSpectrum */,
 			);
@@ -2186,11 +2187,9 @@
 		4B0F1BCA2602F17B00B85C66 /* ZX8081 */ = {
 			isa = PBXGroup;
 			children = (
-				4B0F1BCB2602F17B00B85C66 /* Keyboard.hpp */,
 				4B0F1BCC2602F17B00B85C66 /* ZX8081.cpp */,
 				4B0F1BCD2602F17B00B85C66 /* Video.cpp */,
 				4B0F1BCE2602F17B00B85C66 /* Video.hpp */,
-				4B0F1BCF2602F17B00B85C66 /* Keyboard.cpp */,
 				4B0F1BD02602F17B00B85C66 /* ZX8081.hpp */,
 			);
 			path = ZX8081;
@@ -2204,6 +2203,15 @@
 				4B0F1C092603BA5F00B85C66 /* Video.hpp */,
 			);
 			path = ZXSpectrum;
+			sourceTree = "<group>";
+		};
+		4B0F1C192604EA1000B85C66 /* Keyboard */ = {
+			isa = PBXGroup;
+			children = (
+				4B0F1C1A2604EA1000B85C66 /* Keyboard.hpp */,
+				4B0F1C1B2604EA1000B85C66 /* Keyboard.cpp */,
+			);
+			path = Keyboard;
 			sourceTree = "<group>";
 		};
 		4B1414561B58879D00E04248 /* 6502 */ = {
@@ -5094,7 +5102,6 @@
 				4B65086122F4CFE0009C1100 /* Keyboard.cpp in Sources */,
 				4BBB70A9202014E2002FE009 /* MultiProducer.cpp in Sources */,
 				4B2E86BF25D74F160024F1E9 /* Mouse.cpp in Sources */,
-				4B0F1BEB2602FFA100B85C66 /* Keyboard.cpp in Sources */,
 				4B6ED2F1208E2F8A0047B343 /* WOZ.cpp in Sources */,
 				4B5D5C9825F56FC7001B4623 /* Spectrum.cpp in Sources */,
 				4B2E86D025D8D8C70024F1E9 /* Keyboard.cpp in Sources */,
@@ -5141,6 +5148,7 @@
 				4B055A9E1FAE85DA0060FFFF /* G64.cpp in Sources */,
 				4B055AB81FAE860F0060FFFF /* ZX80O81P.cpp in Sources */,
 				4B055AB01FAE86070060FFFF /* PulseQueuedTape.cpp in Sources */,
+				4B0F1C1D2604EA1000B85C66 /* Keyboard.cpp in Sources */,
 				4B055AAC1FAE85FD0060FFFF /* PCMSegment.cpp in Sources */,
 				4BB307BC235001C300457D33 /* 6850.cpp in Sources */,
 				4B055AB31FAE860F0060FFFF /* CSW.cpp in Sources */,
@@ -5291,6 +5299,7 @@
 				4B0E04EA1FC9E5DA00F43484 /* CAS.cpp in Sources */,
 				4B7A90ED20410A85008514A2 /* StaticAnalyser.cpp in Sources */,
 				4B58601E1F806AB200AEE2E3 /* MFMSectorDump.cpp in Sources */,
+				4B0F1C1C2604EA1000B85C66 /* Keyboard.cpp in Sources */,
 				4B228CD924DA12C60077EF25 /* CSScanTargetView.m in Sources */,
 				4B6AAEAD230E40250078E864 /* Target.cpp in Sources */,
 				4B448E841F1C4C480009ABD6 /* PulseQueuedTape.cpp in Sources */,
@@ -5436,7 +5445,6 @@
 				4B0ACC02237756ED008902D0 /* Line.cpp in Sources */,
 				4B89453A201967B4007DE474 /* StaticAnalyser.cpp in Sources */,
 				4BB697CB1D4B6D3E00248BDF /* TimedEventLoop.cpp in Sources */,
-				4B0F1BEA2602FFA000B85C66 /* Keyboard.cpp in Sources */,
 				4BDACBEC22FFA5D20045EF7E /* ncr5380.cpp in Sources */,
 				4B54C0C21F8D91CD0050900F /* Keyboard.cpp in Sources */,
 				4BD0FBC3233706A200148981 /* CSApplication.m in Sources */,

--- a/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
@@ -132,6 +132,8 @@
 		4B0F1BFD260300D900B85C66 /* ZXSpectrum.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0F1BFA260300D900B85C66 /* ZXSpectrum.cpp */; };
 		4B0F1C1C2604EA1000B85C66 /* Keyboard.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0F1C1B2604EA1000B85C66 /* Keyboard.cpp */; };
 		4B0F1C1D2604EA1000B85C66 /* Keyboard.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0F1C1B2604EA1000B85C66 /* Keyboard.cpp */; };
+		4B0F1C232605996900B85C66 /* ZXSpectrumTAP.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0F1C212605996900B85C66 /* ZXSpectrumTAP.cpp */; };
+		4B0F1C242605996900B85C66 /* ZXSpectrumTAP.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0F1C212605996900B85C66 /* ZXSpectrumTAP.cpp */; };
 		4B0F94FE208C1A1600FE41D9 /* NIB.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0F94FC208C1A1600FE41D9 /* NIB.cpp */; };
 		4B0F94FF208C1A1600FE41D9 /* NIB.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0F94FC208C1A1600FE41D9 /* NIB.cpp */; };
 		4B121F9B1E06293F00BFDA12 /* PCMSegmentEventSourceTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4B121F9A1E06293F00BFDA12 /* PCMSegmentEventSourceTests.mm */; };
@@ -1071,6 +1073,8 @@
 		4B0F1C092603BA5F00B85C66 /* Video.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Video.hpp; sourceTree = "<group>"; };
 		4B0F1C1A2604EA1000B85C66 /* Keyboard.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = Keyboard.hpp; sourceTree = "<group>"; };
 		4B0F1C1B2604EA1000B85C66 /* Keyboard.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Keyboard.cpp; sourceTree = "<group>"; };
+		4B0F1C212605996900B85C66 /* ZXSpectrumTAP.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ZXSpectrumTAP.cpp; sourceTree = "<group>"; };
+		4B0F1C222605996900B85C66 /* ZXSpectrumTAP.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = ZXSpectrumTAP.hpp; sourceTree = "<group>"; };
 		4B0F94FC208C1A1600FE41D9 /* NIB.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NIB.cpp; sourceTree = "<group>"; };
 		4B0F94FD208C1A1600FE41D9 /* NIB.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = NIB.hpp; sourceTree = "<group>"; };
 		4B0F9500208C42A300FE41D9 /* Target.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = Target.hpp; path = AppleII/Target.hpp; sourceTree = "<group>"; };
@@ -2862,6 +2866,7 @@
 				4B69FB421C4D941400B5F0AA /* TapeUEF.cpp */,
 				4B448E7F1F1C45A00009ABD6 /* TZX.cpp */,
 				4B1497861EE4A1DA00CE2596 /* ZX80O81P.cpp */,
+				4B0F1C212605996900B85C66 /* ZXSpectrumTAP.cpp */,
 				4B0E04E91FC9E5DA00F43484 /* CAS.hpp */,
 				4BC91B821D1F160E00884B76 /* CommodoreTAP.hpp */,
 				4B3BF5AF1F146264005B6C36 /* CSW.hpp */,
@@ -2870,6 +2875,7 @@
 				4B69FB431C4D941400B5F0AA /* TapeUEF.hpp */,
 				4B448E801F1C45A00009ABD6 /* TZX.hpp */,
 				4B1497871EE4A1DA00CE2596 /* ZX80O81P.hpp */,
+				4B0F1C222605996900B85C66 /* ZXSpectrumTAP.hpp */,
 				4B69FB451C4D950F00B5F0AA /* libz.tbd */,
 			);
 			path = Formats;
@@ -5269,6 +5275,7 @@
 				4BEDA3C125B25563000C2DBD /* Decoder.cpp in Sources */,
 				4BB0A65C2044FD3000FB3688 /* SN76489.cpp in Sources */,
 				4B595FAE2086DFBA0083CAA8 /* AudioToggle.cpp in Sources */,
+				4B0F1C242605996900B85C66 /* ZXSpectrumTAP.cpp in Sources */,
 				4B055AB91FAE86170060FFFF /* Acorn.cpp in Sources */,
 				4B302185208A550100773308 /* DiskII.cpp in Sources */,
 				4B0F1BB32602645900B85C66 /* StaticAnalyser.cpp in Sources */,
@@ -5376,6 +5383,7 @@
 				4B0ACC2E23775819008902D0 /* TIA.cpp in Sources */,
 				4B2E86B725D7490E0024F1E9 /* ReactiveDevice.cpp in Sources */,
 				4B74CF85231370BC00500CE8 /* MacintoshVolume.cpp in Sources */,
+				4B0F1C232605996900B85C66 /* ZXSpectrumTAP.cpp in Sources */,
 				4B4518A51F75FD1C00926311 /* SSD.cpp in Sources */,
 				4B55CE5F1C3B7D960093A61B /* MachineDocument.swift in Sources */,
 				4B1B58FF246E19FD009C171E /* State.cpp in Sources */,

--- a/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
@@ -132,6 +132,8 @@
 		4B0F1BEB2602FFA100B85C66 /* Keyboard.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0F1BCF2602F17B00B85C66 /* Keyboard.cpp */; };
 		4B0F1BFC260300D900B85C66 /* ZXSpectrum.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0F1BFA260300D900B85C66 /* ZXSpectrum.cpp */; };
 		4B0F1BFD260300D900B85C66 /* ZXSpectrum.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0F1BFA260300D900B85C66 /* ZXSpectrum.cpp */; };
+		4B0F1C0A2603BA5F00B85C66 /* Video.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0F1C082603BA5F00B85C66 /* Video.cpp */; };
+		4B0F1C0B2603BA5F00B85C66 /* Video.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0F1C082603BA5F00B85C66 /* Video.cpp */; };
 		4B0F94FE208C1A1600FE41D9 /* NIB.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0F94FC208C1A1600FE41D9 /* NIB.cpp */; };
 		4B0F94FF208C1A1600FE41D9 /* NIB.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0F94FC208C1A1600FE41D9 /* NIB.cpp */; };
 		4B121F9B1E06293F00BFDA12 /* PCMSegmentEventSourceTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4B121F9A1E06293F00BFDA12 /* PCMSegmentEventSourceTests.mm */; };
@@ -1070,6 +1072,8 @@
 		4B0F1BFA260300D900B85C66 /* ZXSpectrum.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ZXSpectrum.cpp; sourceTree = "<group>"; };
 		4B0F1BFB260300D900B85C66 /* ZXSpectrum.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = ZXSpectrum.hpp; sourceTree = "<group>"; };
 		4B0F1C04260391F100B85C66 /* Target.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Target.hpp; sourceTree = "<group>"; };
+		4B0F1C082603BA5F00B85C66 /* Video.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Video.cpp; sourceTree = "<group>"; };
+		4B0F1C092603BA5F00B85C66 /* Video.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Video.hpp; sourceTree = "<group>"; };
 		4B0F94FC208C1A1600FE41D9 /* NIB.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NIB.cpp; sourceTree = "<group>"; };
 		4B0F94FD208C1A1600FE41D9 /* NIB.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = NIB.hpp; sourceTree = "<group>"; };
 		4B0F9500208C42A300FE41D9 /* Target.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = Target.hpp; path = AppleII/Target.hpp; sourceTree = "<group>"; };
@@ -2200,6 +2204,8 @@
 			children = (
 				4B0F1BFA260300D900B85C66 /* ZXSpectrum.cpp */,
 				4B0F1BFB260300D900B85C66 /* ZXSpectrum.hpp */,
+				4B0F1C082603BA5F00B85C66 /* Video.cpp */,
+				4B0F1C092603BA5F00B85C66 /* Video.hpp */,
 			);
 			path = ZXSpectrum;
 			sourceTree = "<group>";
@@ -5152,6 +5158,7 @@
 				4B055AED1FAE9BA20060FFFF /* Z80Storage.cpp in Sources */,
 				4B1B88BC202E2EC100B67DFF /* MultiKeyboardMachine.cpp in Sources */,
 				4BC890D4230F86020025A55A /* DirectAccessDevice.cpp in Sources */,
+				4B0F1C0B2603BA5F00B85C66 /* Video.cpp in Sources */,
 				4B2E86C925D892EF0024F1E9 /* DAT.cpp in Sources */,
 				4B6AAEAE230E40250078E864 /* Target.cpp in Sources */,
 				4BF437EF209D0F7E008CBD6B /* SegmentParser.cpp in Sources */,
@@ -5297,6 +5304,7 @@
 				4B0CCC451C62D0B3001CAC5F /* CRT.cpp in Sources */,
 				4BC23A2C2467600F001A6030 /* OPLL.cpp in Sources */,
 				4B80CD76256CA16400176FCC /* 2MG.cpp in Sources */,
+				4B0F1C0A2603BA5F00B85C66 /* Video.cpp in Sources */,
 				4B8DF505254E3C9D00F3433C /* ADB.cpp in Sources */,
 				4B322E041F5A2E3C004EB04C /* Z80Base.cpp in Sources */,
 				4B0ACC2623775819008902D0 /* AtariST.cpp in Sources */,

--- a/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
@@ -1075,6 +1075,7 @@
 		4B0F1C1B2604EA1000B85C66 /* Keyboard.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Keyboard.cpp; sourceTree = "<group>"; };
 		4B0F1C212605996900B85C66 /* ZXSpectrumTAP.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ZXSpectrumTAP.cpp; sourceTree = "<group>"; };
 		4B0F1C222605996900B85C66 /* ZXSpectrumTAP.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = ZXSpectrumTAP.hpp; sourceTree = "<group>"; };
+		4B0F1C3D26095AC600B85C66 /* FDC.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = FDC.hpp; path = AmstradCPC/FDC.hpp; sourceTree = "<group>"; };
 		4B0F94FC208C1A1600FE41D9 /* NIB.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NIB.cpp; sourceTree = "<group>"; };
 		4B0F94FD208C1A1600FE41D9 /* NIB.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = NIB.hpp; sourceTree = "<group>"; };
 		4B0F9500208C42A300FE41D9 /* Target.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = Target.hpp; path = AppleII/Target.hpp; sourceTree = "<group>"; };
@@ -2504,6 +2505,7 @@
 				4B54C0C11F8D91CD0050900F /* Keyboard.cpp */,
 				4B38F3471F2EC11D00D9235D /* AmstradCPC.hpp */,
 				4B54C0C01F8D91CD0050900F /* Keyboard.hpp */,
+				4B0F1C3D26095AC600B85C66 /* FDC.hpp */,
 			);
 			name = AmstradCPC;
 			sourceTree = "<group>";

--- a/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
@@ -132,8 +132,6 @@
 		4B0F1BEB2602FFA100B85C66 /* Keyboard.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0F1BCF2602F17B00B85C66 /* Keyboard.cpp */; };
 		4B0F1BFC260300D900B85C66 /* ZXSpectrum.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0F1BFA260300D900B85C66 /* ZXSpectrum.cpp */; };
 		4B0F1BFD260300D900B85C66 /* ZXSpectrum.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0F1BFA260300D900B85C66 /* ZXSpectrum.cpp */; };
-		4B0F1C0A2603BA5F00B85C66 /* Video.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0F1C082603BA5F00B85C66 /* Video.cpp */; };
-		4B0F1C0B2603BA5F00B85C66 /* Video.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0F1C082603BA5F00B85C66 /* Video.cpp */; };
 		4B0F94FE208C1A1600FE41D9 /* NIB.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0F94FC208C1A1600FE41D9 /* NIB.cpp */; };
 		4B0F94FF208C1A1600FE41D9 /* NIB.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0F94FC208C1A1600FE41D9 /* NIB.cpp */; };
 		4B121F9B1E06293F00BFDA12 /* PCMSegmentEventSourceTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4B121F9A1E06293F00BFDA12 /* PCMSegmentEventSourceTests.mm */; };
@@ -1072,7 +1070,6 @@
 		4B0F1BFA260300D900B85C66 /* ZXSpectrum.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ZXSpectrum.cpp; sourceTree = "<group>"; };
 		4B0F1BFB260300D900B85C66 /* ZXSpectrum.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = ZXSpectrum.hpp; sourceTree = "<group>"; };
 		4B0F1C04260391F100B85C66 /* Target.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Target.hpp; sourceTree = "<group>"; };
-		4B0F1C082603BA5F00B85C66 /* Video.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Video.cpp; sourceTree = "<group>"; };
 		4B0F1C092603BA5F00B85C66 /* Video.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Video.hpp; sourceTree = "<group>"; };
 		4B0F94FC208C1A1600FE41D9 /* NIB.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NIB.cpp; sourceTree = "<group>"; };
 		4B0F94FD208C1A1600FE41D9 /* NIB.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = NIB.hpp; sourceTree = "<group>"; };
@@ -2204,7 +2201,6 @@
 			children = (
 				4B0F1BFA260300D900B85C66 /* ZXSpectrum.cpp */,
 				4B0F1BFB260300D900B85C66 /* ZXSpectrum.hpp */,
-				4B0F1C082603BA5F00B85C66 /* Video.cpp */,
 				4B0F1C092603BA5F00B85C66 /* Video.hpp */,
 			);
 			path = ZXSpectrum;
@@ -5158,7 +5154,6 @@
 				4B055AED1FAE9BA20060FFFF /* Z80Storage.cpp in Sources */,
 				4B1B88BC202E2EC100B67DFF /* MultiKeyboardMachine.cpp in Sources */,
 				4BC890D4230F86020025A55A /* DirectAccessDevice.cpp in Sources */,
-				4B0F1C0B2603BA5F00B85C66 /* Video.cpp in Sources */,
 				4B2E86C925D892EF0024F1E9 /* DAT.cpp in Sources */,
 				4B6AAEAE230E40250078E864 /* Target.cpp in Sources */,
 				4BF437EF209D0F7E008CBD6B /* SegmentParser.cpp in Sources */,
@@ -5304,7 +5299,6 @@
 				4B0CCC451C62D0B3001CAC5F /* CRT.cpp in Sources */,
 				4BC23A2C2467600F001A6030 /* OPLL.cpp in Sources */,
 				4B80CD76256CA16400176FCC /* 2MG.cpp in Sources */,
-				4B0F1C0A2603BA5F00B85C66 /* Video.cpp in Sources */,
 				4B8DF505254E3C9D00F3433C /* ADB.cpp in Sources */,
 				4B322E041F5A2E3C004EB04C /* Z80Base.cpp in Sources */,
 				4B0ACC2623775819008902D0 /* AtariST.cpp in Sources */,

--- a/OSBindings/Mac/Clock Signal/Machine/StaticAnalyser/CSStaticAnalyser.h
+++ b/OSBindings/Mac/Clock Signal/Machine/StaticAnalyser/CSStaticAnalyser.h
@@ -62,6 +62,11 @@ typedef NS_ENUM(NSInteger, CSMachineOricDiskInterface) {
 	CSMachineOricDiskInterfaceBD500
 };
 
+typedef NS_ENUM(NSInteger, CSMachineSpectrumModel) {
+	CSMachineSpectrumModelPlus2a,
+	CSMachineSpectrumModelPlus3,
+};
+
 typedef NS_ENUM(NSInteger, CSMachineVic20Region) {
 	CSMachineVic20RegionAmerican,
 	CSMachineVic20RegionEuropean,
@@ -90,6 +95,7 @@ typedef int Kilobytes;
 - (instancetype)initWithMacintoshModel:(CSMachineMacintoshModel)model;
 - (instancetype)initWithMSXRegion:(CSMachineMSXRegion)region hasDiskDrive:(BOOL)hasDiskDrive;
 - (instancetype)initWithOricModel:(CSMachineOricModel)model diskInterface:(CSMachineOricDiskInterface)diskInterface;
+- (instancetype)initWithSpectrumModel:(CSMachineSpectrumModel)model;
 - (instancetype)initWithVic20Region:(CSMachineVic20Region)region memorySize:(Kilobytes)memorySize hasC1540:(BOOL)hasC1540;
 - (instancetype)initWithZX80MemorySize:(Kilobytes)memorySize useZX81ROM:(BOOL)useZX81ROM;
 - (instancetype)initWithZX81MemorySize:(Kilobytes)memorySize;

--- a/OSBindings/Mac/Clock Signal/Machine/StaticAnalyser/CSStaticAnalyser.mm
+++ b/OSBindings/Mac/Clock Signal/Machine/StaticAnalyser/CSStaticAnalyser.mm
@@ -23,6 +23,7 @@
 #include "../../../../../Analyser/Static/MSX/Target.hpp"
 #include "../../../../../Analyser/Static/Oric/Target.hpp"
 #include "../../../../../Analyser/Static/ZX8081/Target.hpp"
+#include "../../../../../Analyser/Static/ZXSpectrum/Target.hpp"
 
 #import "Clock_Signal-Swift.h"
 
@@ -181,6 +182,20 @@
 			case CSMachineOricDiskInterfacePravetz:		target->disk_interface = Target::DiskInterface::Pravetz;	break;
 			case CSMachineOricDiskInterfaceJasmin:		target->disk_interface = Target::DiskInterface::Jasmin;		break;
 			case CSMachineOricDiskInterfaceBD500:		target->disk_interface = Target::DiskInterface::BD500;		break;
+		}
+		_targets.push_back(std::move(target));
+	}
+	return self;
+}
+
+- (instancetype)initWithSpectrumModel:(CSMachineSpectrumModel)model {
+	self = [super init];
+	if(self) {
+		using Target = Analyser::Static::ZXSpectrum::Target;
+		auto target = std::make_unique<Target>();
+		switch(model) {
+			case CSMachineSpectrumModelPlus2a:	target->model = Target::Model::Plus2a;	break;
+			case CSMachineSpectrumModelPlus3:	target->model = Target::Model::Plus3;	break;
 		}
 		_targets.push_back(std::move(target));
 	}

--- a/OSBindings/Mac/Clock Signal/Machine/StaticAnalyser/CSStaticAnalyser.mm
+++ b/OSBindings/Mac/Clock Signal/Machine/StaticAnalyser/CSStaticAnalyser.mm
@@ -263,6 +263,7 @@ static Analyser::Static::ZX8081::Target::MemoryModel ZX8081MemoryModelFromSize(K
 		case Analyser::Machine::Oric:			return @"OricOptions";
 		case Analyser::Machine::Vic20:			return @"QuickLoadCompositeOptions";
 		case Analyser::Machine::ZX8081:			return @"ZX8081Options";
+		case Analyser::Machine::ZXSpectrum:		return @"QuickLoadCompositeOptions"; // TODO: @"ZXSpectrumOptions";
 		default: return nil;
 	}
 }

--- a/OSBindings/Mac/Clock Signal/MachinePicker/Base.lproj/MachinePicker.xib
+++ b/OSBindings/Mac/Clock Signal/MachinePicker/Base.lproj/MachinePicker.xib
@@ -17,14 +17,14 @@
         <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" titleVisibility="hidden" id="QvC-M9-y7g">
             <windowStyleMask key="styleMask" titled="YES" documentModal="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="196" y="240" width="810" height="205"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1440"/>
+            <rect key="contentRect" x="196" y="240" width="881" height="205"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="900"/>
             <view key="contentView" wantsLayer="YES" id="EiT-Mj-1SZ">
-                <rect key="frame" x="0.0" y="0.0" width="810" height="205"/>
+                <rect key="frame" x="0.0" y="0.0" width="881" height="205"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                 <subviews>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hKn-1l-OSN">
-                        <rect key="frame" x="716" y="13" width="81" height="32"/>
+                        <rect key="frame" x="787" y="13" width="81" height="32"/>
                         <buttonCell key="cell" type="push" title="Choose" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="MnM-xo-4Qa">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -37,7 +37,7 @@ DQ
                         </connections>
                     </button>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="JQy-Cj-AOK">
-                        <rect key="frame" x="643" y="13" width="76" height="32"/>
+                        <rect key="frame" x="714" y="13" width="76" height="32"/>
                         <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="sub-rB-Req">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -59,7 +59,7 @@ Gw
                         </textFieldCell>
                     </textField>
                     <tabView translatesAutoresizingMaskIntoConstraints="NO" id="VUb-QG-x7c">
-                        <rect key="frame" x="13" y="50" width="784" height="141"/>
+                        <rect key="frame" x="13" y="50" width="855" height="141"/>
                         <font key="font" metaFont="system"/>
                         <tabViewItems>
                             <tabViewItem label="Apple II" identifier="appleii" id="P59-QG-LOa">
@@ -195,7 +195,7 @@ Gw
                             </tabViewItem>
                             <tabViewItem label="Amstrad CPC" identifier="cpc" id="JmB-OF-xcM">
                                 <view key="view" id="5zS-Nj-Ynx">
-                                    <rect key="frame" x="10" y="33" width="764" height="95"/>
+                                    <rect key="frame" x="10" y="33" width="835" height="95"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="00d-sg-Krh">
@@ -457,9 +457,46 @@ Gw
                                     </constraints>
                                 </view>
                             </tabViewItem>
+                            <tabViewItem label="Spectrum" identifier="spectrum" id="HQv-oF-k8b">
+                                <view key="view" id="bMx-F6-JUb">
+                                    <rect key="frame" x="10" y="33" width="835" height="95"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <subviews>
+                                        <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gFZ-d4-WFv">
+                                            <rect key="frame" x="63" y="66" width="62" height="25"/>
+                                            <popUpButtonCell key="cell" type="push" title="+2a" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" tag="21" imageScaling="axesIndependently" inset="2" selectedItem="Fo7-NL-Kv5" id="tYs-sA-oek">
+                                                <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="menu"/>
+                                                <menu key="menu" id="8lt-dk-zPr">
+                                                    <items>
+                                                        <menuItem title="+2a" tag="21" id="Fo7-NL-Kv5"/>
+                                                        <menuItem title="+3" tag="3" id="jwx-fZ-vXp"/>
+                                                    </items>
+                                                </menu>
+                                            </popUpButtonCell>
+                                        </popUpButton>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fJ3-ma-Byy">
+                                            <rect key="frame" x="18" y="72" width="42" height="16"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Model" id="JId-Tp-LrE">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="gFZ-d4-WFv" secondAttribute="trailing" constant="20" symbolic="YES" id="90E-uI-MQg"/>
+                                        <constraint firstItem="fJ3-ma-Byy" firstAttribute="leading" secondItem="bMx-F6-JUb" secondAttribute="leading" constant="20" symbolic="YES" id="9kE-iQ-dxd"/>
+                                        <constraint firstItem="fJ3-ma-Byy" firstAttribute="centerY" secondItem="gFZ-d4-WFv" secondAttribute="centerY" id="LxG-5E-Q5Y"/>
+                                        <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="gFZ-d4-WFv" secondAttribute="bottom" constant="5" id="d8S-vX-B5e"/>
+                                        <constraint firstItem="gFZ-d4-WFv" firstAttribute="leading" secondItem="fJ3-ma-Byy" secondAttribute="trailing" constant="8" symbolic="YES" id="hKS-47-R2y"/>
+                                        <constraint firstItem="gFZ-d4-WFv" firstAttribute="top" secondItem="bMx-F6-JUb" secondAttribute="top" constant="5" id="wsX-Wq-iPt"/>
+                                    </constraints>
+                                </view>
+                            </tabViewItem>
                             <tabViewItem label="Vic-20" identifier="vic20" id="cyO-PU-hSU">
                                 <view key="view" id="fLI-XB-QCr">
-                                    <rect key="frame" x="10" y="33" width="764" height="95"/>
+                                    <rect key="frame" x="10" y="33" width="819" height="95"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ueK-gq-gaF">
@@ -638,7 +675,7 @@ Gw
                     <constraint firstItem="VUb-QG-x7c" firstAttribute="top" secondItem="EiT-Mj-1SZ" secondAttribute="top" constant="20" id="zT3-Ea-QQJ"/>
                 </constraints>
             </view>
-            <point key="canvasLocation" x="94.5" y="90.5"/>
+            <point key="canvasLocation" x="129.5" y="90.5"/>
         </window>
         <customObject id="192-Eb-Rpg" customClass="MachinePicker" customModule="Clock_Signal" customModuleProvider="target">
             <connections>
@@ -658,6 +695,7 @@ Gw
                 <outlet property="msxRegionButton" destination="LG6-mP-SeG" id="3a9-VG-6Wf"/>
                 <outlet property="oricDiskInterfaceButton" destination="fYL-p6-wyn" id="aAt-wM-hRZ"/>
                 <outlet property="oricModelTypeButton" destination="ENP-hI-BVZ" id="n9i-Ym-miE"/>
+                <outlet property="spectrumModelTypeButton" destination="gFZ-d4-WFv" id="tdX-Cv-Swe"/>
                 <outlet property="vic20HasC1540Button" destination="Lrf-gL-6EI" id="21g-dJ-mOo"/>
                 <outlet property="vic20MemorySizeButton" destination="2eV-Us-eEv" id="5j4-jw-89d"/>
                 <outlet property="vic20RegionButton" destination="ueK-gq-gaF" id="qMq-uP-y4r"/>

--- a/OSBindings/Mac/Clock Signal/MachinePicker/Base.lproj/MachinePicker.xib
+++ b/OSBindings/Mac/Clock Signal/MachinePicker/Base.lproj/MachinePicker.xib
@@ -64,7 +64,7 @@ Gw
                         <tabViewItems>
                             <tabViewItem label="Apple II" identifier="appleii" id="P59-QG-LOa">
                                 <view key="view" id="dHz-Yv-GNq">
-                                    <rect key="frame" x="10" y="33" width="764" height="95"/>
+                                    <rect key="frame" x="10" y="33" width="835" height="95"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="V5Z-dX-Ns4">
@@ -464,12 +464,12 @@ Gw
                                     <subviews>
                                         <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gFZ-d4-WFv">
                                             <rect key="frame" x="63" y="66" width="62" height="25"/>
-                                            <popUpButtonCell key="cell" type="push" title="+2a" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" tag="21" imageScaling="axesIndependently" inset="2" selectedItem="Fo7-NL-Kv5" id="tYs-sA-oek">
+                                            <popUpButtonCell key="cell" type="push" title="+2a" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="21" imageScaling="axesIndependently" inset="2" selectedItem="Fo7-NL-Kv5" id="tYs-sA-oek">
                                                 <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                                 <font key="font" metaFont="menu"/>
                                                 <menu key="menu" id="8lt-dk-zPr">
                                                     <items>
-                                                        <menuItem title="+2a" tag="21" id="Fo7-NL-Kv5"/>
+                                                        <menuItem title="+2a" state="on" tag="21" id="Fo7-NL-Kv5"/>
                                                         <menuItem title="+3" tag="3" id="jwx-fZ-vXp"/>
                                                     </items>
                                                 </menu>

--- a/OSBindings/Mac/Clock Signal/MachinePicker/MachinePicker.swift
+++ b/OSBindings/Mac/Clock Signal/MachinePicker/MachinePicker.swift
@@ -40,6 +40,9 @@ class MachinePicker: NSObject {
 	@IBOutlet var oricModelTypeButton: NSPopUpButton!
 	@IBOutlet var oricDiskInterfaceButton: NSPopUpButton!
 
+	// MARK: - Spectrum properties
+	@IBOutlet var spectrumModelTypeButton: NSPopUpButton!
+
 	// MARK: - Vic-20 properties
 	@IBOutlet var vic20RegionButton: NSPopUpButton!
 	@IBOutlet var vic20MemorySizeButton: NSPopUpButton!
@@ -98,6 +101,9 @@ class MachinePicker: NSObject {
 		oricDiskInterfaceButton.selectItem(withTag: standardUserDefaults.integer(forKey: "new.oricDiskInterface"))
 		oricModelTypeButton.selectItem(withTag: standardUserDefaults.integer(forKey: "new.oricModel"))
 
+		// Spectrum settings
+		spectrumModelTypeButton.selectItem(withTag: standardUserDefaults.integer(forKey: "new.spectrumModel"))
+
 		// Vic-20 settings
 		vic20RegionButton.selectItem(withTag: standardUserDefaults.integer(forKey: "new.vic20Region"))
 		vic20MemorySizeButton.selectItem(withTag: standardUserDefaults.integer(forKey: "new.vic20MemorySize"))
@@ -144,6 +150,9 @@ class MachinePicker: NSObject {
 		// Oric settings
 		standardUserDefaults.set(oricDiskInterfaceButton.selectedTag(), forKey: "new.oricDiskInterface")
 		standardUserDefaults.set(oricModelTypeButton.selectedTag(), forKey: "new.oricModel")
+
+		// Spectrum settings
+		standardUserDefaults.set(spectrumModelTypeButton.selectedTag(), forKey: "new.spectrumModel")
 
 		// Vic-20 settings
 		standardUserDefaults.set(vic20RegionButton.selectedTag(), forKey: "new.vic20Region")
@@ -241,17 +250,27 @@ class MachinePicker: NSObject {
 					case 2:		diskInterface = .pravetz
 					case 3:		diskInterface = .jasmin
 					case 4:		diskInterface = .BD500
-					default:	break;
+					default:	break
 
 				}
 				var model: CSMachineOricModel = .oric1
 				switch oricModelTypeButton.selectedItem!.tag {
 					case 1:		model = .oricAtmos
 					case 2:		model = .pravetz
-					default:	break;
+					default:	break
 				}
 
 				return CSStaticAnalyser(oricModel: model, diskInterface: diskInterface)
+
+			case "spectrum":
+				var model: CSMachineSpectrumModel = .plus2a
+				switch oricModelTypeButton.selectedItem!.tag {
+					case 21:	model = .plus2a
+					case 3:		model = .plus3
+					default:	break
+				}
+
+				return CSStaticAnalyser(spectrumModel: model)
 
 			case "vic20":
 				let memorySize = Kilobytes(vic20MemorySizeButton.selectedItem!.tag)

--- a/OSBindings/Mac/Clock Signal/MachinePicker/MachinePicker.swift
+++ b/OSBindings/Mac/Clock Signal/MachinePicker/MachinePicker.swift
@@ -264,7 +264,7 @@ class MachinePicker: NSObject {
 
 			case "spectrum":
 				var model: CSMachineSpectrumModel = .plus2a
-				switch oricModelTypeButton.selectedItem!.tag {
+				switch spectrumModelTypeButton.selectedItem!.tag {
 					case 21:	model = .plus2a
 					case 3:		model = .plus3
 					default:	break

--- a/OSBindings/Qt/ClockSignal.pro
+++ b/OSBindings/Qt/ClockSignal.pro
@@ -89,6 +89,7 @@ SOURCES += \
 	$$SRC/Machines/MSX/*.cpp \
 	$$SRC/Machines/Oric/*.cpp \
 	$$SRC/Machines/Utility/*.cpp \
+	$$SRC/Machines/Sinclair/Keyboard/*.cpp \
 	$$SRC/Machines/Sinclair/ZX8081/*.cpp \
 	$$SRC/Machines/Sinclair/ZXSpectrum/*.cpp \
 \
@@ -215,6 +216,7 @@ HEADERS += \
 	$$SRC/Machines/MSX/*.hpp \
 	$$SRC/Machines/Oric/*.hpp \
 	$$SRC/Machines/Utility/*.hpp \
+	$$SRC/Machines/Sinclair/Keyboard/*.hpp \
 	$$SRC/Machines/Sinclair/ZX8081/*.hpp \
 	$$SRC/Machines/Sinclair/ZXSpectrum/*.hpp \
 \

--- a/OSBindings/Qt/mainwindow.h
+++ b/OSBindings/Qt/mainwindow.h
@@ -19,7 +19,7 @@
 #include "../../Activity/Observer.hpp"
 
 // There are machine-specific controls for the following:
-#include "../../Machines/ZX8081/ZX8081.hpp"
+#include "../../Machines/Sinclair/ZX8081/ZX8081.hpp"
 #include "../../Machines/Atari/2600/Atari2600.hpp"
 
 QT_BEGIN_NAMESPACE
@@ -92,6 +92,7 @@ class MainWindow : public QMainWindow, public Outputs::Speaker::Speaker::Delegat
 		void start_macintosh();
 		void start_msx();
 		void start_oric();
+		void start_spectrum();
 		void start_vic20();
 		void start_zx80();
 		void start_zx81();

--- a/OSBindings/Qt/mainwindow.ui
+++ b/OSBindings/Qt/mainwindow.ui
@@ -533,6 +533,55 @@
         </item>
        </layout>
       </widget>
+      <widget class="QWidget" name="spectrumTab">
+       <attribute name="title">
+        <string>Spectrum</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="spectrumLayout">
+        <item>
+         <layout class="QHBoxLayout" name="spectrumHorizontalLayout">
+          <item>
+           <layout class="QFormLayout" name="spectrumFormLayout">
+            <item row="0" column="0">
+             <widget class="QLabel" name="spectrumModelLabel">
+              <property name="text">
+               <string>Model:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QComboBox" name="spectrumModelComboBox">
+              <item>
+               <property name="text">
+                <string>+2a</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>+3</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <spacer name="spectrumHSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
       <widget class="QWidget" name="vic20Tab">
        <attribute name="title">
         <string>Vic-20</string>

--- a/OSBindings/SDL/SConstruct
+++ b/OSBindings/SDL/SConstruct
@@ -83,6 +83,7 @@ SOURCES += glob.glob('../../Machines/MasterSystem/*.cpp')
 SOURCES += glob.glob('../../Machines/MSX/*.cpp')
 SOURCES += glob.glob('../../Machines/Oric/*.cpp')
 SOURCES += glob.glob('../../Machines/Utility/*.cpp')
+SOURCES += glob.glob('../../Machines/Sinclair/Keyboard/*.cpp')
 SOURCES += glob.glob('../../Machines/Sinclair/ZX8081/*.cpp')
 SOURCES += glob.glob('../../Machines/Sinclair/ZXSpectrum/*.cpp')
 

--- a/Outputs/CRT/CRT.hpp
+++ b/Outputs/CRT/CRT.hpp
@@ -61,7 +61,7 @@ class CRT {
 		int64_t phase_denominator_ = 1;
 		int64_t phase_numerator_ = 0;
 		int64_t colour_cycle_numerator_ = 1;
-		bool is_alernate_line_ = false, phase_alternates_ = false;
+		bool is_alernate_line_ = false, phase_alternates_ = false, should_be_alternate_line_ = false;
 
 		void advance_cycles(int number_of_cycles, bool hsync_requested, bool vsync_requested, const Scan::Type type, int number_of_samples);
 		Flywheel::SyncEvent get_next_vertical_sync_event(bool vsync_is_requested, int cycles_to_run_for, int *cycles_advanced);
@@ -207,7 +207,7 @@ class CRT {
 			@param amplitude The amplitude of the colour burst in 1/255ths of the amplitude of the
 			positive portion of the wave.
 		*/
-		void output_colour_burst(int number_of_cycles, uint8_t phase, uint8_t amplitude = DefaultAmplitude);
+		void output_colour_burst(int number_of_cycles, uint8_t phase, bool is_alternate_line = false, uint8_t amplitude = DefaultAmplitude);
 
 		/*! Outputs a colour burst exactly in phase with CRT expectations using the idiomatic amplitude.
 

--- a/Storage/Disk/DiskImage/Formats/CPCDSK.cpp
+++ b/Storage/Disk/DiskImage/Formats/CPCDSK.cpp
@@ -200,12 +200,12 @@ std::size_t CPCDSK::index_for_track(::Storage::Disk::Track::Address address) {
 
 std::shared_ptr<Track> CPCDSK::get_track_at_position(::Storage::Disk::Track::Address address) {
 	// Given that thesea are interleaved images, determine which track, chronologically, is being requested.
-	std::size_t chronological_track = index_for_track(address);
+	const std::size_t chronological_track = index_for_track(address);
 
 	// Return a nullptr if out of range or not provided.
 	if(chronological_track >= tracks_.size()) return nullptr;
 
-	Track *track = tracks_[chronological_track].get();
+	Track *const track = tracks_[chronological_track].get();
 	if(!track) return nullptr;
 
 	std::vector<const Storage::Encodings::MFM::Sector *> sectors;
@@ -228,7 +228,7 @@ void CPCDSK::set_tracks(const std::map<::Storage::Disk::Track::Address, std::sha
 				is_double_density);
 
 		// Find slot for track, making it if neccessary.
-		std::size_t chronological_track = index_for_track(pair.first);
+		const std::size_t chronological_track = index_for_track(pair.first);
 		if(chronological_track >= tracks_.size()) {
 			tracks_.resize(chronological_track+1);
 			head_position_count_ = pair.first.position.as_int();
@@ -310,7 +310,7 @@ void CPCDSK::set_tracks(const std::map<::Storage::Disk::Track::Address, std::sha
 	// Output each track.
 	for(std::size_t index = 0; index < size_t(head_position_count_ * head_count_); ++index) {
 		if(index >= tracks_.size()) continue;
-		Track *track = tracks_[index].get();
+		Track *const track = tracks_[index].get();
 		if(!track) continue;
 
 		// Output track header.

--- a/Storage/Tape/Formats/ZXSpectrumTAP.cpp
+++ b/Storage/Tape/Formats/ZXSpectrumTAP.cpp
@@ -22,19 +22,15 @@ ZXSpectrumTAP::ZXSpectrumTAP(const std::string &file_name) :
 	file_(file_name)
 {
 	// Check for a continuous series of blocks through to
-	// file end, alternating header and data.
-	uint8_t next_block_type = 0x00;
+	// exactly file end.
+	//
+	// To consider: could also check those blocks of type 0
+	// and type ff for valid checksums?
 	while(true) {
 		const uint16_t block_length = file_.get16le();
-		const uint8_t block_type = file_.get8();
 		if(file_.eof()) throw ErrorNotZXSpectrumTAP;
 
-		if(block_type != next_block_type) {
-			throw ErrorNotZXSpectrumTAP;
-		}
-		next_block_type ^= 0xff;
-
-		file_.seek(block_length - 1, SEEK_CUR);
+		file_.seek(block_length, SEEK_CUR);
 		if(file_.tell() == file_.stats().st_size) break;
 	}
 

--- a/Storage/Tape/Formats/ZXSpectrumTAP.cpp
+++ b/Storage/Tape/Formats/ZXSpectrumTAP.cpp
@@ -10,6 +10,14 @@
 
 using namespace Storage::Tape;
 
+/*
+	The understanding of idiomatic Spectrum data encoding below
+	is taken from the TZX specifications at
+	https://worldofspectrum.net/features/TZXformat.html ;
+	specifics of the TAP encoding were gained from
+	https://sinclair.wiki.zxnet.co.uk/wiki/TAP_format
+*/
+
 ZXSpectrumTAP::ZXSpectrumTAP(const std::string &file_name) :
 	file_(file_name)
 {
@@ -34,14 +42,85 @@ ZXSpectrumTAP::ZXSpectrumTAP(const std::string &file_name) :
 }
 
 bool ZXSpectrumTAP::is_at_end() {
-	return false;
+	return file_.tell() == file_.stats().st_size;
 }
 
 void ZXSpectrumTAP::virtual_reset() {
 	file_.seek(0, SEEK_SET);
-	block_length_ = file_.get16le();
+	read_next_block();
 }
 
 Tape::Pulse ZXSpectrumTAP::virtual_get_next_pulse() {
-	return Pulse();
+	// Adopt a general pattern of high then low.
+	Pulse pulse;
+	pulse.type = (distance_into_phase_ & 1) ? Pulse::Type::High : Pulse::Type::Low;
+
+	switch(phase_) {
+		default: break;
+
+		case Phase::PilotTone: {
+			// Output: pulses of length 2168;
+			// 8063 pulses if block type is 0, otherwise 3223;
+			// then a 667-length pulse followed by a 735-length pulse.
+
+			pulse.length = Time(271, 437'500);	// i.e. 2168 / 3'500'000
+			++distance_into_phase_;
+
+			// Check whether in the last two.
+			if(distance_into_phase_ >= (block_type_ ? 8063 : 3223)) {
+				pulse.length = (distance_into_phase_ & 1) ? Time(667, 3'500'000) : Time(735, 3'500'000);
+
+				// Check whether this is the last one.
+				if(distance_into_phase_ == (block_type_ ? 8064 : 3224)) {
+					distance_into_phase_ = 0;
+					phase_ = Phase::Data;
+				}
+			}
+		} break;
+
+		case Phase::Data: {
+			// Output two pulses of length 855 for a 0; two of length 1710 for a 1,
+			// from MSB to LSB.
+			pulse.length = (data_byte_ & 0x80) ? Time(1710, 3'500'000) : Time(855, 3'500'000);
+			++distance_into_phase_;
+
+			if(!(distance_into_phase_ & 1)) {
+				data_byte_ <<= 1;
+			}
+
+			if(!(distance_into_phase_ & 15)) {
+				if((distance_into_phase_ >> 4) == block_length_) {
+					if(block_type_) {
+						distance_into_phase_ = 0;
+						phase_ = Phase::Gap;
+					} else {
+						read_next_block();
+					}
+				} else {
+					data_byte_ = file_.get8();
+				}
+			}
+		} break;
+
+		case Phase::Gap:
+			Pulse gap;
+			gap.type = Pulse::Type::Zero;
+			gap.length = Time(1);
+
+			read_next_block();
+		return gap;
+	}
+
+	return pulse;
+}
+
+void ZXSpectrumTAP::read_next_block() {
+	if(is_at_end()) {
+		phase_ = Phase::Gap;
+	} else {
+		block_length_ = file_.get16le();
+		data_byte_ = block_type_ = file_.get8();
+		phase_ = Phase::PilotTone;
+	}
+	distance_into_phase_ = 0;
 }

--- a/Storage/Tape/Formats/ZXSpectrumTAP.cpp
+++ b/Storage/Tape/Formats/ZXSpectrumTAP.cpp
@@ -1,0 +1,47 @@
+//
+//  SpectrumTAP.cpp
+//  Clock Signal
+//
+//  Created by Thomas Harte on 19/03/2021.
+//  Copyright © 2021 Thomas Harte. All rights reserved.
+//
+
+#include "ZXSpectrumTAP.hpp"
+
+using namespace Storage::Tape;
+
+ZXSpectrumTAP::ZXSpectrumTAP(const std::string &file_name) :
+	file_(file_name)
+{
+	// Check for a continuous series of blocks through to
+	// file end, alternating header and data.
+	uint8_t next_block_type = 0x00;
+	while(true) {
+		const uint16_t block_length = file_.get16le();
+		const uint8_t block_type = file_.get8();
+		if(file_.eof()) throw ErrorNotZXSpectrumTAP;
+
+		if(block_type != next_block_type) {
+			throw ErrorNotZXSpectrumTAP;
+		}
+		next_block_type ^= 0xff;
+
+		file_.seek(block_length - 1, SEEK_CUR);
+		if(file_.tell() == file_.stats().st_size) break;
+	}
+
+	virtual_reset();
+}
+
+bool ZXSpectrumTAP::is_at_end() {
+	return false;
+}
+
+void ZXSpectrumTAP::virtual_reset() {
+	file_.seek(0, SEEK_SET);
+	block_length_ = file_.get16le();
+}
+
+Tape::Pulse ZXSpectrumTAP::virtual_get_next_pulse() {
+	return Pulse();
+}

--- a/Storage/Tape/Formats/ZXSpectrumTAP.hpp
+++ b/Storage/Tape/Formats/ZXSpectrumTAP.hpp
@@ -39,6 +39,15 @@ class ZXSpectrumTAP: public Tape {
 		Storage::FileHolder file_;
 
 		uint16_t block_length_ = 0;
+		uint8_t block_type_ = 0;
+		uint8_t data_byte_ = 0;
+		enum Phase {
+			PilotTone,
+			Data,
+			Gap
+		} phase_ = Phase::PilotTone;
+		int distance_into_phase_ = 0;
+		void read_next_block();
 
 		// Implemented to satisfy @c Tape.
 		bool is_at_end() override;

--- a/Storage/Tape/Formats/ZXSpectrumTAP.hpp
+++ b/Storage/Tape/Formats/ZXSpectrumTAP.hpp
@@ -1,0 +1,53 @@
+//
+//  SpectrumTAP.hpp
+//  Clock Signal
+//
+//  Created by Thomas Harte on 19/03/2021.
+//  Copyright © 2021 Thomas Harte. All rights reserved.
+//
+
+#ifndef SpectrumTAP_hpp
+#define SpectrumTAP_hpp
+
+#include "../Tape.hpp"
+#include "../../FileHolder.hpp"
+
+#include <cstdint>
+#include <string>
+
+namespace Storage {
+namespace Tape {
+
+/*!
+	Provides a @c Tape containing an Spectrum-format tape image, which contains a series of
+	header and data blocks.
+*/
+class ZXSpectrumTAP: public Tape {
+	public:
+		/*!
+			Constructs a @c ZXSpectrumTAP containing content from the file with name @c file_name.
+
+			@throws ErrorNotZXSpectrumTAP if this file could not be opened and recognised as a valid Spectrum-format TAP.
+		*/
+		ZXSpectrumTAP(const std::string &file_name);
+
+		enum {
+			ErrorNotZXSpectrumTAP
+		};
+
+	private:
+		Storage::FileHolder file_;
+
+		uint16_t block_length_ = 0;
+
+		// Implemented to satisfy @c Tape.
+		bool is_at_end() override;
+		void virtual_reset() override;
+		Pulse virtual_get_next_pulse() override;
+};
+
+
+}
+}
+
+#endif /* SpectrumTAP_hpp */


### PR DESCRIPTION
Logical advantages of adding a Spectrum:

- the earlier Spectrums, if I roll back to them, seem to have contended memory logic that could test additional parts of my Z80 signalling; and
- the platform is heavily invested in state snapshots, possibly giving me a reason to pull my finger out on that.