### PR TITLE
Minor pokes to the test files code.

### DIFF
--- a/OSBindings/Mac/Clock SignalTests/68000ComparativeTests.mm
+++ b/OSBindings/Mac/Clock SignalTests/68000ComparativeTests.mm
@@ -43,7 +43,7 @@
 	// Issue each test file.
 	for(NSURL *url in tests) {
 		// Compare against a file set if one has been supplied.
-		if(_fileSet && ![_fileSet containsObject:[[url path] lastPathComponent]]) continue;
+		if(_fileSet && ![_fileSet containsObject:[url lastPathComponent]]) continue;
 		NSLog(@"Testing %@", url);
 		[self testJSONAtURL:url];
 	}

--- a/OSBindings/Mac/Clock SignalTests/EmuTOSTests.mm
+++ b/OSBindings/Mac/Clock SignalTests/EmuTOSTests.mm
@@ -107,7 +107,7 @@ class EmuTOS: public ComparativeBusHandler {
 	const std::vector<ROMMachine::ROM> rom_names = {{"AtariST", "", image.UTF8String, 0, 0 }};
 	const auto roms = CSROMFetcher()(rom_names);
 	NSString *const traceLocation = [[NSBundle bundleForClass:[self class]] pathForResource:trace ofType:@"trace.txt.gz"];
-	_machine = std::make_unique<EmuTOS>(*roms[0], traceLocation.UTF8String);
+	_machine = std::make_unique<EmuTOS>(*roms[0], traceLocation.fileSystemRepresentation);
 	_machine->run_for(HalfCycles(length));
 }
 


### PR DESCRIPTION
Use `-fileSystermRepresentation` instead of `-UTF8String` when dealing with file manipulation.