### PR TITLE
Further tweaks Spectrum timing.

### DIFF
--- a/Machines/Sinclair/ZXSpectrum/Video.hpp
+++ b/Machines/Sinclair/ZXSpectrum/Video.hpp
@@ -53,13 +53,13 @@ template <VideoTiming timing> class Video {
 			// Number of lines comprising a whole frame. Will be 311 or 312.
 			int lines_per_frame;
 
-			// Number of cycles after first pixel fetch at which interrupt is first signalled.
-			int interrupt_time;
-
 			// Number of cycles before first pixel fetch that contention starts to be applied.
 			int contention_leadin;
 			// Period in a line for which contention is applied.
 			int contention_duration;
+
+			// Number of cycles after first pixel fetch at which interrupt is first signalled.
+			int interrupt_time;
 
 			// Contention to apply, in half-cycles, as a function of number of half cycles since
 			// contention began.

--- a/Machines/Sinclair/ZXSpectrum/Video.hpp
+++ b/Machines/Sinclair/ZXSpectrum/Video.hpp
@@ -88,19 +88,14 @@ template <VideoTiming timing> class Video {
 				.cycles_per_line = 228 * 2,
 				.lines_per_frame = 311,
 
-				// i.e. video fetching begins five cycles after the start of the
+				// i.e. video fetching begins six cycles after the start of the
 				// contended memory pattern below; that should put a clear two
 				// cycles between a Z80 access and the first video fetch.
-				.contention_leadin = 5 * 2,
+				.contention_leadin = 6 * 2,
 				.contention_duration = 129 * 2,
 
-				// i.e. interrupt is first signalled
-				// 311*228 - 5 - 56543 = 14364 cycles before the beginning of
-				// contended accesses.
-				//
-				// (which, as above, include a bit of guesswork as to the meaning of
-				// 'time since interrupt' in the commonly-cited documentation)
-				.interrupt_time = 56543 * 2,
+				// i.e. interrupt is first signalled 14368 cycles before the first video fetch.
+				.interrupt_time = (228*311 - 14368) * 2,
 
 				.delays = {
 					2, 1,

--- a/Machines/Sinclair/ZXSpectrum/Video.hpp
+++ b/Machines/Sinclair/ZXSpectrum/Video.hpp
@@ -88,13 +88,19 @@ template <VideoTiming timing> class Video {
 				.cycles_per_line = 228 * 2,
 				.lines_per_frame = 311,
 
-				.interrupt_time = 56542 * 2,
-
 				// i.e. video fetching begins five cycles after the start of the
 				// contended memory pattern below; that should put a clear two
 				// cycles between a Z80 access and the first video fetch.
 				.contention_leadin = 5 * 2,
 				.contention_duration = 129 * 2,
+
+				// i.e. interrupt is first signalled
+				// 311*228 - 5 - 56543 = 14364 cycles before the beginning of
+				// contended accesses.
+				//
+				// (which, as above, include a bit of guesswork as to the meaning of
+				// 'time since interrupt' in the commonly-cited documentation)
+				.interrupt_time = 56543 * 2,
 
 				.delays = {
 					2, 1,

--- a/Machines/Sinclair/ZXSpectrum/Video.hpp
+++ b/Machines/Sinclair/ZXSpectrum/Video.hpp
@@ -88,9 +88,12 @@ template <VideoTiming timing> class Video {
 				.cycles_per_line = 228 * 2,
 				.lines_per_frame = 311,
 
-				.interrupt_time = 56545 * 2,
+				.interrupt_time = 56542 * 2,
 
-				.contention_leadin = 2 * 2,		// TODO: is this 2? Or 4? Or... ?
+				// i.e. video fetching begins five cycles after the start of the
+				// contended memory pattern below; that should put a clear two
+				// cycles between a Z80 access and the first video fetch.
+				.contention_leadin = 5 * 2,
 				.contention_duration = 129 * 2,
 
 				.delays = {
@@ -311,7 +314,9 @@ template <VideoTiming timing> class Video {
 			}
 
 			const int time_into_line = delay_time % timings.cycles_per_line;
-			if(time_into_line >= timings.contention_duration) return 0;
+			if(time_into_line >= timings.contention_duration) {
+				return 0;
+			}
 
 			return timings.delays[time_into_line & 15];
 		}

--- a/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
+++ b/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
@@ -206,8 +206,8 @@ template<Model model> class ConcreteMachine:
 			// the read/write, then complete the bus cycle. Only via the 48/128k Spectrum contended
 			// timings am I now learning what happens with MREQ during extended read/write bus cycles
 			// (i.e. those longer than 3 cycles)
-			if(cycle.length > HalfCycles(5)) {
-				advance(HalfCycles(5));
+			if(cycle.length > HalfCycles(3)) {
+				advance(HalfCycles(3));
 			} else {
 				advance(cycle.length);
 			}
@@ -368,8 +368,8 @@ template<Model model> class ConcreteMachine:
 				break;
 			}
 
-			if(cycle.length > HalfCycles(5)) {
-				advance(cycle.length - HalfCycles(5));
+			if(cycle.length > HalfCycles(3)) {
+				advance(cycle.length - HalfCycles(3));
 			}
 			return HalfCycles(0);
 		}

--- a/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
+++ b/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
@@ -206,7 +206,11 @@ template<Model model> class ConcreteMachine:
 			// the read/write, then complete the bus cycle. Only via the 48/128k Spectrum contended
 			// timings am I now learning what happens with MREQ during extended read/write bus cycles
 			// (i.e. those longer than 3 cycles)
-			advance(cycle.length);
+			if(cycle.length > HalfCycles(5)) {
+				advance(HalfCycles(5));
+			} else {
+				advance(cycle.length);
+			}
 
 			switch(cycle.operation) {
 				default: break;
@@ -364,6 +368,9 @@ template<Model model> class ConcreteMachine:
 				break;
 			}
 
+			if(cycle.length > HalfCycles(5)) {
+				advance(cycle.length - HalfCycles(5));
+			}
 			return HalfCycles(0);
 		}
 


### PR DESCRIPTION
Primary target was proper intersection with the floating bus; using the 48/128 timings as a portal into otherwise-undocumented Z80 behaviour* will have to wait.

\* specifically:
* what's on the address bus during non-access cycles; and
* how MREQ is signalled during long accessing machine cycles (such as those in LDIR).