### PR TITLE
Introduces a new grammar for ROM requests.

### DIFF
--- a/Components/9918/9918.cpp
+++ b/Components/9918/9918.cpp
@@ -750,7 +750,7 @@ HalfCycles TMS9918::get_next_sequence_point() {
 	if(next_line_interrupt_row == -1) {
 		return generate_interrupts_ ?
 			half_cycles_before_internal_cycles(time_until_frame_interrupt) :
-			HalfCycles(-1);
+			HalfCycles::max();
 	}
 
 	// Figure out the number of internal cycles until the next line interrupt, which is the amount

--- a/Machines/AmstradCPC/AmstradCPC.cpp
+++ b/Machines/AmstradCPC/AmstradCPC.cpp
@@ -798,10 +798,12 @@ template <bool has_fdc> class ConcreteMachine:
 				case Analyser::Static::AmstradCPC::Target::Model::CPC664:
 					firmware = ROM::Name::CPC664Firmware;
 					basic = ROM::Name::CPC664BASIC;
+					has_amsdos = true;
 				break;
 				default:
 					firmware = ROM::Name::CPC6128Firmware;
 					basic = ROM::Name::CPC6128BASIC;
+					has_amsdos = true;
 				break;
 			}
 

--- a/Machines/AmstradCPC/AmstradCPC.cpp
+++ b/Machines/AmstradCPC/AmstradCPC.cpp
@@ -787,44 +787,40 @@ template <bool has_fdc> class ConcreteMachine:
 			ay_.ay().set_port_handler(&key_state_);
 
 			// construct the list of necessary ROMs
-			const std::string machine_name = "AmstradCPC";
-			std::vector<ROMMachine::ROM> required_roms = {
-				ROMMachine::ROM(machine_name, "the Amstrad Disk Operating System", "amsdos.rom", 16*1024, 0x1fe22ecd)
-			};
-			std::string model_number;
-			uint32_t crcs[2];
+			bool has_amsdos = false;
+			ROM::Name firmware, basic;
+
 			switch(target.model) {
-				default:
-					model_number = "6128";
-					has_128k_ = true;
-					crcs[0] = 0x0219bb74;
-					crcs[1] = 0xca6af63d;
-				break;
 				case Analyser::Static::AmstradCPC::Target::Model::CPC464:
-					model_number = "464";
-					has_128k_ = false;
-					crcs[0] = 0x815752df;
-					crcs[1] = 0x7d9a3bac;
+					firmware = ROM::Name::CPC464Firmware;
+					basic = ROM::Name::CPC464BASIC;
 				break;
 				case Analyser::Static::AmstradCPC::Target::Model::CPC664:
-					model_number = "664";
-					has_128k_ = false;
-					crcs[0] = 0x3f5a6dc4;
-					crcs[1] = 0x32fee492;
+					firmware = ROM::Name::CPC664Firmware;
+					basic = ROM::Name::CPC664BASIC;
+				break;
+				default:
+					firmware = ROM::Name::CPC6128Firmware;
+					basic = ROM::Name::CPC6128BASIC;
 				break;
 			}
-			required_roms.emplace_back(machine_name, "the CPC " + model_number + " firmware", "os" + model_number + ".rom", 16*1024, crcs[0]);
-			required_roms.emplace_back(machine_name, "the CPC " + model_number + " BASIC ROM", "basic" + model_number + ".rom", 16*1024, crcs[1]);
 
-			// fetch and verify the ROMs
-			const auto roms = rom_fetcher(required_roms);
-
-			for(std::size_t index = 0; index < roms.size(); ++index) {
-				auto &data = roms[index];
-				if(!data) throw ROMMachine::Error::MissingROMs;
-				roms_[index] = std::move(*data);
-				roms_[index].resize(16384);
+			ROM::Request request = ROM::Request(firmware) && ROM::Request(basic);
+			if(has_amsdos) {
+				request = request && ROM::Request(ROM::Name::AMSDOS);
 			}
+
+			// Fetch and verify the ROMs.
+			const auto roms = rom_fetcher(request);
+			if(!request.validate(roms)) {
+				throw ROMMachine::Error::MissingROMs;
+			}
+
+			if(has_amsdos) {
+				roms_[ROMType::AMSDOS] = *roms.find(ROM::Name::AMSDOS);
+			}
+			roms_[ROMType::OS] = *roms.find(firmware);
+			roms_[ROMType::BASIC] = *roms.find(basic);
 
 			// Establish default memory map
 			upper_rom_is_paged_ = true;

--- a/Machines/AmstradCPC/AmstradCPC.cpp
+++ b/Machines/AmstradCPC/AmstradCPC.cpp
@@ -811,7 +811,7 @@ template <bool has_fdc> class ConcreteMachine:
 			}
 
 			// Fetch and verify the ROMs.
-			const auto roms = rom_fetcher(request);
+			auto roms = rom_fetcher(request);
 			if(!request.validate(roms)) {
 				throw ROMMachine::Error::MissingROMs;
 			}

--- a/Machines/AmstradCPC/AmstradCPC.cpp
+++ b/Machines/AmstradCPC/AmstradCPC.cpp
@@ -817,10 +817,10 @@ template <bool has_fdc> class ConcreteMachine:
 			}
 
 			if(has_amsdos) {
-				roms_[ROMType::AMSDOS] = *roms.find(ROM::Name::AMSDOS);
+				roms_[ROMType::AMSDOS] = roms.find(ROM::Name::AMSDOS)->second;
 			}
-			roms_[ROMType::OS] = *roms.find(firmware);
-			roms_[ROMType::BASIC] = *roms.find(basic);
+			roms_[ROMType::OS] = roms.find(firmware)->second;
+			roms_[ROMType::BASIC] = roms.find(basic)->second;
 
 			// Establish default memory map
 			upper_rom_is_paged_ = true;

--- a/Machines/Apple/AppleII/AppleII.cpp
+++ b/Machines/Apple/AppleII/AppleII.cpp
@@ -418,8 +418,8 @@ template <Analyser::Static::AppleII::Target::Model model> class ConcreteMachine:
 				install_card(6, new Apple::II::DiskIICard(roms, is_sixteen_sector));
 			}
 
-			rom_ = std::move(*roms.find(system));
-			video_.set_character_rom(*roms.find(character));
+			rom_ = std::move(roms.find(system)->second);
+			video_.set_character_rom(roms.find(character)->second);
 
 			// Set up the default memory blocks. On a II or II+ these values will never change.
 			// On a IIe they'll be affected by selection of auxiliary RAM.

--- a/Machines/Apple/AppleII/AppleII.cpp
+++ b/Machines/Apple/AppleII/AppleII.cpp
@@ -419,6 +419,12 @@ template <Analyser::Static::AppleII::Target::Model model> class ConcreteMachine:
 			}
 
 			rom_ = std::move(roms.find(system)->second);
+			// The IIe and Enhanced IIe ROMs often distributed are oversized; trim if necessary.
+			if(system == ROM::Name::AppleIIe || system == ROM::Name::AppleIIEnhancedE) {
+				if(rom_.size() > 16128) {
+					rom_.erase(rom_.begin(), rom_.end() - off_t(16128));
+				}
+			}
 			video_.set_character_rom(roms.find(character)->second);
 
 			// Set up the default memory blocks. On a II or II+ these values will never change.

--- a/Machines/Apple/AppleII/DiskIICard.hpp
+++ b/Machines/Apple/AppleII/DiskIICard.hpp
@@ -25,7 +25,8 @@ namespace II {
 
 class DiskIICard: public Card, public ClockingHint::Observer {
 	public:
-		DiskIICard(const ROMMachine::ROMFetcher &rom_fetcher, bool is_16_sector);
+		static ROM::Request rom_request(bool is_16_sector);
+		DiskIICard(ROM::Map &, bool is_16_sector);
 
 		void perform_bus_operation(Select select, bool is_read, uint16_t address, uint8_t *value) final;
 		void run_for(Cycles cycles, int stretches) final;

--- a/Machines/Apple/AppleII/VideoSwitches.hpp
+++ b/Machines/Apple/AppleII/VideoSwitches.hpp
@@ -228,36 +228,6 @@ template <typename TimeUnit> class VideoSwitches {
 			return external_.annunciator_3;
 		}
 
-		enum class CharacterROM {
-			/// The ROM that shipped with both the Apple II and the II+.
-			II,
-			/// The ROM that shipped with the original IIe.
-			IIe,
-			/// The ROM that shipped with the Enhanced IIe.
-			EnhancedIIe,
-			/// The ROM that shipped with the IIgs.
-			IIgs
-		};
-
-		/// @returns A file-level description of @c rom.
-		static ROMMachine::ROM rom_description(CharacterROM rom) {
-			const std::string machine_name = "AppleII";
-			switch(rom) {
-				case CharacterROM::II:
-					return ROMMachine::ROM(machine_name, "the basic Apple II character ROM", "apple2-character.rom", 2*1024, 0x64f415c6);
-
-				case CharacterROM::IIe:
-					return ROMMachine::ROM(machine_name, "the Apple IIe character ROM", "apple2eu-character.rom", 4*1024, 0x816a86f1);
-
-				default:	// To appease GCC.
-				case CharacterROM::EnhancedIIe:
-					return ROMMachine::ROM(machine_name, "the Enhanced Apple IIe character ROM", "apple2e-character.rom", 4*1024, 0x2651014d);
-
-				case CharacterROM::IIgs:
-					return ROMMachine::ROM(machine_name, "the Apple IIgs character ROM", "apple2gs.chr", 4*1024, 0x91e53cd8);
-			}
-		}
-
 		/// Set the character ROM for this video output.
 		void set_character_rom(const std::vector<uint8_t> &rom) {
 			character_rom_ = rom;

--- a/Machines/Apple/AppleIIgs/AppleIIgs.cpp
+++ b/Machines/Apple/AppleIIgs/AppleIIgs.cpp
@@ -189,31 +189,23 @@ class ConcreteMachine:
 			speaker_.set_input_rate(float(CLOCK_RATE) / float(audio_divider));
 
 			using Target = Analyser::Static::AppleIIgs::Target;
-			std::vector<ROMMachine::ROM> rom_descriptions;
-			const std::string machine_name = "AppleIIgs";
+			ROM::Name system;
 			switch(target.model) {
-				case Target::Model::ROM00:
-					/* TODO */
-				case Target::Model::ROM01:
-					rom_descriptions.emplace_back(machine_name, "the Apple IIgs ROM01", "apple2gs.rom", 128*1024, 0x42f124b0);
-				break;
-
-				case Target::Model::ROM03:
-					rom_descriptions.emplace_back(machine_name, "the Apple IIgs ROM03", "apple2gs.rom2", 256*1024, 0xde7ddf29);
-				break;
+				case Target::Model::ROM00:	system = ROM::Name::AppleIIgsROM00;	break;
+				case Target::Model::ROM01:	system = ROM::Name::AppleIIgsROM01;	break;
+				case Target::Model::ROM03:	system = ROM::Name::AppleIIgsROM03;	break;
 			}
-			rom_descriptions.push_back(video_->rom_description(Video::Video::CharacterROM::EnhancedIIe));
+			constexpr ROM::Name characters = ROM::Name::AppleIIEnhancedECharacter;
+			constexpr ROM::Name microcontroller = ROM::Name::AppleIIgsMicrocontrollerROM03;
 
-			// TODO: pick a different ADB ROM for earlier machine revisions?
-			rom_descriptions.emplace_back(machine_name, "the Apple IIgs ADB microcontroller ROM", "341s0632-2", 4*1024, 0xe1c11fb0);
-
-			const auto roms = rom_fetcher(rom_descriptions);
-			if(!roms[0] || !roms[1] || !roms[2]) {
+			ROM::Request request = ROM::Request(system) && ROM::Request(characters) && ROM::Request(microcontroller);
+			auto roms = rom_fetcher(request);
+			if(!request.validate(roms)) {
 				throw ROMMachine::Error::MissingROMs;
 			}
-			rom_ = *roms[0];
-			video_->set_character_rom(*roms[1]);
-			adb_glu_->set_microcontroller_rom(*roms[2]);
+			rom_ = roms.find(system)->second;
+			video_->set_character_rom(roms.find(characters)->second);
+			adb_glu_->set_microcontroller_rom(roms.find(microcontroller)->second);
 
 			// Run only the currently-interesting self test.
 //			rom_[0x36402] = 2;

--- a/Machines/Apple/AppleIIgs/AppleIIgs.cpp
+++ b/Machines/Apple/AppleIIgs/AppleIIgs.cpp
@@ -193,7 +193,7 @@ class ConcreteMachine:
 			switch(target.model) {
 				case Target::Model::ROM00:	system = ROM::Name::AppleIIgsROM00;	break;
 				case Target::Model::ROM01:	system = ROM::Name::AppleIIgsROM01;	break;
-				case Target::Model::ROM03:	system = ROM::Name::AppleIIgsROM03;	break;
+				default:					system = ROM::Name::AppleIIgsROM03;	break;
 			}
 			constexpr ROM::Name characters = ROM::Name::AppleIIEnhancedECharacter;
 			constexpr ROM::Name microcontroller = ROM::Name::AppleIIgsMicrocontrollerROM03;

--- a/Machines/Apple/Macintosh/Macintosh.cpp
+++ b/Machines/Apple/Macintosh/Macintosh.cpp
@@ -123,7 +123,7 @@ template <Analyser::Static::Macintosh::Target::Model model> class ConcreteMachin
 
 			// Grab a copy of the ROM and convert it into big-endian data.
 			ROM::Request request(rom_name);
-			const auto roms = rom_fetcher(request);
+			auto roms = rom_fetcher(request);
 			if(!request.validate(roms)) {
 				throw ROMMachine::Error::MissingROMs;
 			}

--- a/Machines/Atari/ST/AtariST.cpp
+++ b/Machines/Atari/ST/AtariST.cpp
@@ -76,7 +76,7 @@ class ConcreteMachine:
 
 			constexpr ROM::Name rom_name = ROM::Name::AtariSTTOS100;
 			ROM::Request request(rom_name);
-			const auto roms = rom_fetcher(request);
+			auto roms = rom_fetcher(request);
 			if(!request.validate(roms)) {
 				throw ROMMachine::Error::MissingROMs;
 			}

--- a/Machines/Atari/ST/AtariST.cpp
+++ b/Machines/Atari/ST/AtariST.cpp
@@ -74,15 +74,13 @@ class ConcreteMachine:
 			video_->set_ram(reinterpret_cast<uint16_t *>(ram_.data()), ram_.size());
 			Memory::Fuzz(ram_);
 
-			std::vector<ROMMachine::ROM> rom_descriptions = {
-				{"AtariST", "the UK TOS 1.00 ROM", "tos100.img", 192*1024, 0x1a586c64}
-//				{"AtariST", "the UK TOS 1.04 ROM", "tos104.img", 192*1024, 0xa50d1d43}
-			};
-			const auto roms = rom_fetcher(rom_descriptions);
-			if(!roms[0]) {
+			constexpr ROM::Name rom_name = ROM::Name::AtariSTTOS100;
+			ROM::Request request(rom_name);
+			const auto roms = rom_fetcher(request);
+			if(!request.validate(roms)) {
 				throw ROMMachine::Error::MissingROMs;
 			}
-			Memory::PackBigEndian16(*roms[0], rom_);
+			Memory::PackBigEndian16(roms.find(rom_name)->second, rom_);
 
 			// Set up basic memory map.
 			memory_map_[0] = BusDevice::MostlyRAM;

--- a/Machines/ColecoVision/ColecoVision.cpp
+++ b/Machines/ColecoVision/ColecoVision.cpp
@@ -129,7 +129,7 @@ class ConcreteMachine:
 
 			constexpr ROM::Name rom_name = ROM::Name::ColecoVisionBIOS;
 			const ROM::Request request(rom_name);
-			const auto roms = rom_fetcher(request);
+			auto roms = rom_fetcher(request);
 			if(!request.validate(roms)) {
 				throw ROMMachine::Error::MissingROMs;
 			}

--- a/Machines/ColecoVision/ColecoVision.cpp
+++ b/Machines/ColecoVision/ColecoVision.cpp
@@ -127,15 +127,13 @@ class ConcreteMachine:
 			joysticks_.emplace_back(new Joystick);
 			joysticks_.emplace_back(new Joystick);
 
-			const auto roms = rom_fetcher(
-				{ {"ColecoVision", "the ColecoVision BIOS", "coleco.rom", 8*1024, 0x3aa93ef3} });
-
-			if(!roms[0]) {
+			constexpr ROM::Name rom_name = ROM::Name::ColecoVisionBIOS;
+			const ROM::Request request(rom_name);
+			const auto roms = rom_fetcher(request);
+			if(!request.validate(roms)) {
 				throw ROMMachine::Error::MissingROMs;
 			}
-
-			bios_ = *roms[0];
-			bios_.resize(8192);
+			bios_ = roms.find(rom_name)->second;
 
 			if(!target.media.cartridges.empty()) {
 				const auto &segment = target.media.cartridges.front()->get_segments().front();

--- a/Machines/Commodore/1540/C1540.hpp
+++ b/Machines/Commodore/1540/C1540.hpp
@@ -41,7 +41,8 @@ namespace C1540 {
 */
 class Machine final: public MachineBase {
 	public:
-		Machine(Personality personality, const ROMMachine::ROMFetcher &rom_fetcher);
+		static ROM::Request rom_request(Personality personality);
+		Machine(Personality personality, const ROM::Map &roms);
 
 		/*!
 			Sets the serial bus to which this drive should attach itself.

--- a/Machines/Commodore/1540/Implementation/C1540.cpp
+++ b/Machines/Commodore/1540/Implementation/C1540.cpp
@@ -16,7 +16,7 @@
 
 using namespace Commodore::C1540;
 
-ROM::Request MachineBase::rom_request(Personality personality) {
+ROM::Request Machine::rom_request(Personality personality) {
 	switch(personality) {
 		case Personality::C1540:	return ROM::Request(ROM::Name::Commodore1540);
 		case Personality::C1541:	return ROM::Request(ROM::Name::Commodore1541);

--- a/Machines/Commodore/1540/Implementation/C1540.cpp
+++ b/Machines/Commodore/1540/Implementation/C1540.cpp
@@ -18,6 +18,7 @@ using namespace Commodore::C1540;
 
 ROM::Request Machine::rom_request(Personality personality) {
 	switch(personality) {
+		default:
 		case Personality::C1540:	return ROM::Request(ROM::Name::Commodore1540);
 		case Personality::C1541:	return ROM::Request(ROM::Name::Commodore1541);
 	}
@@ -48,6 +49,7 @@ MachineBase::MachineBase(Personality personality, const ROM::Map &roms) :
 
 	ROM::Name rom_name;
 	switch(personality) {
+		default:
 		case Personality::C1540:	rom_name = ROM::Name::Commodore1540;	break;
 		case Personality::C1541:	rom_name = ROM::Name::Commodore1541;	break;
 	}

--- a/Machines/Commodore/1540/Implementation/C1540Base.hpp
+++ b/Machines/Commodore/1540/Implementation/C1540Base.hpp
@@ -127,7 +127,7 @@ class MachineBase:
 	public Storage::Disk::Controller {
 
 	public:
-		MachineBase(Personality personality, const ROMMachine::ROMFetcher &rom_fetcher);
+		MachineBase(Personality personality, const ROM::Map &roms);
 
 		// to satisfy CPU::MOS6502::Processor
 		Cycles perform_bus_operation(CPU::MOS6502::BusOperation operation, uint16_t address, uint8_t *value);

--- a/Machines/Commodore/Vic-20/Vic20.cpp
+++ b/Machines/Commodore/Vic-20/Vic20.cpp
@@ -316,53 +316,48 @@ class ConcreteMachine:
 			// Install a joystick.
 			joysticks_.emplace_back(new Joystick(*user_port_via_port_handler_, *keyboard_via_port_handler_));
 
-			const std::string machine_name = "Vic20";
-			std::vector<ROMMachine::ROM> rom_names = {
-				{machine_name, "the VIC-20 BASIC ROM", "basic.bin", 8*1024, 0xdb4c43c1}
-			};
+			ROM::Request request(ROM::Name::Vic20BASIC);
+			ROM::Name kernel, character;
 			switch(target.region) {
 				default:
-					rom_names.emplace_back(machine_name, "the English-language VIC-20 character ROM", "characters-english.bin", 4*1024, 0x83e032a6);
-					rom_names.emplace_back(machine_name, "the English-language PAL VIC-20 kernel ROM", "kernel-pal.bin", 8*1024, 0x4be07cb4);
+					character = ROM::Name::Vic20EnglishCharacters;
+					kernel = ROM::Name::Vic20EnglishPALKernel;
 				break;
 				case Analyser::Static::Commodore::Target::Region::American:
-					rom_names.emplace_back(machine_name, "the English-language VIC-20 character ROM", "characters-english.bin", 4*1024, 0x83e032a6);
-					rom_names.emplace_back(machine_name, "the English-language NTSC VIC-20 kernel ROM", "kernel-ntsc.bin", 8*1024, 0xe5e7c174);
+					character = ROM::Name::Vic20EnglishCharacters;
+					kernel = ROM::Name::Vic20EnglishNTSCKernel;
 				break;
 				case Analyser::Static::Commodore::Target::Region::Danish:
-					rom_names.emplace_back(machine_name, "the Danish VIC-20 character ROM", "characters-danish.bin", 4*1024, 0x7fc11454);
-					rom_names.emplace_back(machine_name, "the Danish VIC-20 kernel ROM", "kernel-danish.bin", 8*1024, 0x02adaf16);
+					character = ROM::Name::Vic20DanishCharacters;
+					kernel = ROM::Name::Vic20DanishKernel;
 				break;
 				case Analyser::Static::Commodore::Target::Region::Japanese:
-					rom_names.emplace_back(machine_name, "the Japanese VIC-20 character ROM", "characters-japanese.bin", 4*1024, 0xfcfd8a4b);
-					rom_names.emplace_back(machine_name, "the Japanese VIC-20 kernel ROM", "kernel-japanese.bin", 8*1024, 0x336900d7);
+					character = ROM::Name::Vic20JapaneseCharacters;
+					kernel = ROM::Name::Vic20JapaneseKernel;
 				break;
 				case Analyser::Static::Commodore::Target::Region::Swedish:
-					rom_names.emplace_back(machine_name, "the Swedish VIC-20 character ROM", "characters-swedish.bin", 4*1024, 0xd808551d);
-					rom_names.emplace_back(machine_name, "the Swedish VIC-20 kernel ROM", "kernel-swedish.bin", 8*1024, 0xb2a60662);
+					character = ROM::Name::Vic20SwedishCharacters;
+					kernel = ROM::Name::Vic20SwedishKernel;
 				break;
 			}
 
-			const auto roms = rom_fetcher(rom_names);
+			if(target.has_c1540) {
+				request = request && Commodore::C1540::Machine::rom_request(Commodore::C1540::Personality::C1540);
+			}
+			request = request && ROM::Request(character) && ROM::Request(kernel);
 
-			for(const auto &rom: roms) {
-				if(!rom) {
-					throw ROMMachine::Error::MissingROMs;
-				}
+			auto roms = rom_fetcher(request);
+			if(!request.validate(roms)) {
+				throw ROMMachine::Error::MissingROMs;
 			}
 
-			basic_rom_ = std::move(*roms[0]);
-			character_rom_ = std::move(*roms[1]);
-			kernel_rom_ = std::move(*roms[2]);
-
-			// Characters ROMs should be 4kb.
-			character_rom_.resize(4096);
-			// Kernel ROMs and the BASIC ROM should be 8kb.
-			kernel_rom_.resize(8192);
+			basic_rom_ = std::move(roms.find(ROM::Name::Vic20BASIC)->second);
+			character_rom_ = std::move(roms.find(character)->second);
+			kernel_rom_ = std::move(roms.find(kernel)->second);
 
 			if(target.has_c1540) {
 				// construct the 1540
-				c1540_ = std::make_unique<::Commodore::C1540::Machine>(Commodore::C1540::Personality::C1540, rom_fetcher);
+				c1540_ = std::make_unique<::Commodore::C1540::Machine>(Commodore::C1540::Personality::C1540, roms);
 
 				// attach it to the serial bus
 				c1540_->set_serial_bus(serial_bus_);

--- a/Machines/Electron/Electron.cpp
+++ b/Machines/Electron/Electron.cpp
@@ -69,37 +69,25 @@ template <bool has_scsi_bus> class ConcreteMachine:
 			speaker_.set_input_rate(2000000 / SoundGenerator::clock_rate_divider);
 			speaker_.set_high_frequency_cutoff(6000);
 
-			const std::string machine_name = "Electron";
-			std::vector<ROMMachine::ROM> required_roms = {
-				{machine_name, "the Acorn BASIC II ROM", "basic.rom", 16*1024, 0x79434781},
-				{machine_name, "the Electron MOS ROM", "os.rom", 16*1024, 0xbf63fb1f}
-			};
-			const size_t pres_adfs_rom_position = required_roms.size();
+			::ROM::Request request = ::ROM::Request(::ROM::Name::AcornBASICII) && ::ROM::Request(::ROM::Name::AcornElectronMOS100);
 			if(target.has_pres_adfs) {
-				required_roms.emplace_back(machine_name, "the E00 ADFS ROM, first slot", "ADFS-E00_1.rom", 16*1024, 0x51523993);
-				required_roms.emplace_back(machine_name, "the E00 ADFS ROM, second slot", "ADFS-E00_2.rom", 16*1024, 0x8d17de0e);
+				request = request && ::ROM::Request(::ROM::Name::PRESADFSSlot1) && ::ROM::Request(::ROM::Name::PRESADFSSlot2);
 			}
-			const size_t acorn_adfs_rom_position = required_roms.size();
 			if(target.has_acorn_adfs) {
-				required_roms.emplace_back(machine_name, "the Acorn ADFS ROM", "adfs.rom", 16*1024, 0x3289bdc6);
+				request = request && ::ROM::Request(::ROM::Name::AcornADFS);
 			}
-			const size_t dfs_rom_position = required_roms.size();
 			if(target.has_dfs) {
-				required_roms.emplace_back(machine_name, "the 1770 DFS ROM", "DFS-1770-2.20.rom", 16*1024, 0xf3dc9bc5);
+				request = request && ::ROM::Request(::ROM::Name::Acorn1770DFS);
 			}
-			const size_t ap6_rom_position = required_roms.size();
 			if(target.has_ap6_rom) {
-				required_roms.emplace_back(machine_name, "the 8kb Advanced Plus 6 ROM", "AP6v133.rom", 8*1024, 0xe0013cfc);
+				request = request && ::ROM::Request(::ROM::Name::PRESAdvancedPlus6);
 			}
-			const auto roms = rom_fetcher(required_roms);
-
-			for(const auto &rom: roms) {
-				if(!rom) {
-					throw ROMMachine::Error::MissingROMs;
-				}
+			const auto roms = rom_fetcher(request);
+			if(!request.validate(roms)) {
+				throw ROMMachine::Error::MissingROMs;
 			}
-			set_rom(ROM::BASIC, *roms[0], false);
-			set_rom(ROM::OS, *roms[1], false);
+			set_rom(ROM::BASIC, roms.find(::ROM::Name::AcornBASICII)->second, false);
+			set_rom(ROM::OS, roms.find(::ROM::Name::AcornElectronMOS100)->second, false);
 
 			/*
 				ROM slot mapping applied:
@@ -115,19 +103,18 @@ template <bool has_scsi_bus> class ConcreteMachine:
 				plus3_ = std::make_unique<Plus3>();
 
 				if(target.has_dfs) {
-					set_rom(ROM::Slot0, *roms[dfs_rom_position], true);
+					set_rom(ROM::Slot0, roms.find(::ROM::Name::Acorn1770DFS)->second, true);
 				}
 				if(target.has_pres_adfs) {
-					set_rom(ROM::Slot4, *roms[pres_adfs_rom_position], true);
-					set_rom(ROM::Slot5, *roms[pres_adfs_rom_position+1], true);
+					set_rom(ROM::Slot4, roms.find(::ROM::Name::PRESADFSSlot1)->second, true);
+					set_rom(ROM::Slot5, roms.find(::ROM::Name::PRESADFSSlot2)->second, true);
 				}
 				if(target.has_acorn_adfs) {
-					set_rom(ROM::Slot6, *roms[acorn_adfs_rom_position], true);
+					set_rom(ROM::Slot6, roms.find(::ROM::Name::AcornADFS)->second, true);
 				}
 			}
-
 			if(target.has_ap6_rom) {
-				set_rom(ROM::Slot15, *roms[ap6_rom_position], true);
+				set_rom(ROM::Slot15, roms.find(::ROM::Name::PRESAdvancedPlus6)->second, true);
 			}
 
 			if(target.has_sideways_ram) {

--- a/Machines/Electron/Electron.cpp
+++ b/Machines/Electron/Electron.cpp
@@ -82,7 +82,7 @@ template <bool has_scsi_bus> class ConcreteMachine:
 			if(target.has_ap6_rom) {
 				request = request && ::ROM::Request(::ROM::Name::PRESAdvancedPlus6);
 			}
-			const auto roms = rom_fetcher(request);
+			auto roms = rom_fetcher(request);
 			if(!request.validate(roms)) {
 				throw ROMMachine::Error::MissingROMs;
 			}

--- a/Machines/MSX/MSX.cpp
+++ b/Machines/MSX/MSX.cpp
@@ -182,6 +182,7 @@ class ConcreteMachine:
 
 			// TODO: CRCs below are incomplete, at best.
 			switch(target.region) {
+				default:
 				case Target::Region::Japan:
 					regional_bios_name = ROM::Name::MSXJapaneseBIOS;
 					vdp_->set_tv_standard(TI::TMS::TVStandard::NTSC);

--- a/Machines/MSX/MSX.cpp
+++ b/Machines/MSX/MSX.cpp
@@ -219,7 +219,7 @@ class ConcreteMachine:
 				request = bios_request;
 			}
 
-			const auto roms = rom_fetcher(request);
+			auto roms = rom_fetcher(request);
 			if(!request.validate(roms)) {
 				throw ROMMachine::Error::MissingROMs;
 			}

--- a/Machines/MasterSystem/MasterSystem.cpp
+++ b/Machines/MasterSystem/MasterSystem.cpp
@@ -143,7 +143,8 @@ class ConcreteMachine:
 			const bool is_japanese = target.region == Target::Region::Japan;
 			const ROM::Name bios_name = is_japanese ? ROM::Name::MasterSystemJapaneseBIOS : ROM::Name::MasterSystemWesternBIOS;
 			ROM::Request request(bios_name, true);
-			const auto roms = rom_fetcher(request);
+			auto roms = rom_fetcher(request);
+			request.validate(roms);
 
 			const auto rom = roms.find(bios_name);
 			if(rom == roms.end()) {

--- a/Machines/Oric/Oric.cpp
+++ b/Machines/Oric/Oric.cpp
@@ -307,8 +307,9 @@ template <Analyser::Static::Oric::Target::DiskInterface disk_interface, CPU::MOS
 			::ROM::Request request = ::ROM::Request(::ROM::Name::OricColourROM, true);
 			::ROM::Name basic;
 			switch(target.rom) {
-				case Analyser::Static::Oric::Target::ROM::BASIC10:	basic = ::ROM::Name::OricBASIC10;			break;
-				case Analyser::Static::Oric::Target::ROM::BASIC11:	basic = ::ROM::Name::OricBASIC11;			break;
+				case Analyser::Static::Oric::Target::ROM::BASIC10:	basic = ::ROM::Name::OricBASIC10;		break;
+				default:
+				case Analyser::Static::Oric::Target::ROM::BASIC11:	basic = ::ROM::Name::OricBASIC11;		break;
 				case Analyser::Static::Oric::Target::ROM::Pravetz:	basic = ::ROM::Name::OricPravetzBASIC;	break;
 			}
 			request = request && ::ROM::Request(basic);

--- a/Machines/Oric/Oric.cpp
+++ b/Machines/Oric/Oric.cpp
@@ -330,7 +330,7 @@ template <Analyser::Static::Oric::Target::DiskInterface disk_interface, CPU::MOS
 				break;
 			}
 
-			const auto roms = rom_fetcher(request);
+			auto roms = rom_fetcher(request);
 			if(!request.validate(roms)) {
 				throw ROMMachine::Error::MissingROMs;
 			}

--- a/Machines/Oric/Oric.cpp
+++ b/Machines/Oric/Oric.cpp
@@ -304,73 +304,63 @@ template <Analyser::Static::Oric::Target::DiskInterface disk_interface, CPU::MOS
 				ram_[c] |= 0x40;
 			}
 
-			const std::string machine_name = "Oric";
-			std::vector<ROMMachine::ROM> rom_names = { {machine_name, "the Oric colour ROM", "colour.rom", 128, 0xd50fca65} };
+			::ROM::Request request = ::ROM::Request(::ROM::Name::OricColourROM, true);
+			::ROM::Name basic;
 			switch(target.rom) {
-				case Analyser::Static::Oric::Target::ROM::BASIC10:
-					rom_names.emplace_back(machine_name, "Oric BASIC 1.0", "basic10.rom", 16*1024, 0xf18710b4);
-				break;
-				case Analyser::Static::Oric::Target::ROM::BASIC11:
-					rom_names.emplace_back(machine_name, "Oric BASIC 1.1", "basic11.rom", 16*1024, 0xc3a92bef);
-				break;
-				case Analyser::Static::Oric::Target::ROM::Pravetz:
-					rom_names.emplace_back(machine_name, "Pravetz BASIC", "pravetz.rom", 16*1024, 0x58079502);
-				break;
+				case Analyser::Static::Oric::Target::ROM::BASIC10:	basic = ::ROM::Name::OricBASIC10;			break;
+				case Analyser::Static::Oric::Target::ROM::BASIC11:	basic = ::ROM::Name::OricBASIC11;			break;
+				case Analyser::Static::Oric::Target::ROM::Pravetz:	basic = ::ROM::Name::OricPravetzBASIC;	break;
 			}
-			size_t diskii_state_machine_index = 0;
+			request = request && ::ROM::Request(basic);
+
 			switch(disk_interface) {
 				default: break;
 				case DiskInterface::BD500:
-					rom_names.emplace_back(machine_name, "the Oric Byte Drive 500 ROM", "bd500.rom", 8*1024, 0x61952e34);
+					request = request && ::ROM::Request(::ROM::Name::OricByteDrive500);
 				break;
 				case DiskInterface::Jasmin:
-					rom_names.emplace_back(machine_name, "the Oric Jasmin ROM", "jasmin.rom", 2*1024, 0x37220e89);
+					request = request && ::ROM::Request(::ROM::Name::OricJasmin);
 				break;
 				case DiskInterface::Microdisc:
-					rom_names.emplace_back(machine_name, "the Oric Microdisc ROM", "microdisc.rom", 8*1024, 0xa9664a9c);
+					request = request && ::ROM::Request(::ROM::Name::OricMicrodisc);
 				break;
 				case DiskInterface::Pravetz:
-					rom_names.emplace_back(machine_name, "the 8DOS boot ROM", "8dos.rom", 512, 0x49a74c06);
-					// These ROM details are coupled with those in the DiskIICard.
-					diskii_state_machine_index = rom_names.size();
-					rom_names.push_back({"DiskII", "the Disk II 16-sector state machine ROM", "state-machine-16.rom", 256, { 0x9796a238, 0xb72a2c70 }});
+					request = request && ::ROM::Request(::ROM::Name::Oric8DOSBoot) && ::ROM::Request(::ROM::Name::DiskIIStateMachine16Sector);
 				break;
 			}
 
-			const auto roms = rom_fetcher(rom_names);
-
-			for(std::size_t index = 0; index < roms.size(); ++index) {
-				if(!roms[index]) {
-					throw ROMMachine::Error::MissingROMs;
-				}
+			const auto roms = rom_fetcher(request);
+			if(!request.validate(roms)) {
+				throw ROMMachine::Error::MissingROMs;
 			}
 
-			video_->set_colour_rom(*roms[0]);
-			rom_ = std::move(*roms[1]);
+			// The colour ROM is optional; an alternative composite encoding can be used if
+			// it is absent.
+			const auto colour_rom = roms.find(::ROM::Name::OricColourROM);
+			if(colour_rom != roms.end()) {
+				video_->set_colour_rom(colour_rom->second);
+			}
+			rom_ = std::move(roms.find(basic)->second);
 
 			switch(disk_interface) {
 				default: break;
 				case DiskInterface::BD500:
-					disk_rom_ = std::move(*roms[2]);
-					disk_rom_.resize(8192);
+					disk_rom_ = std::move(roms.find(::ROM::Name::OricByteDrive500)->second);
 				break;
 				case DiskInterface::Jasmin:
-					disk_rom_ = std::move(*roms[2]);
-					disk_rom_.resize(2048);
+					disk_rom_ = std::move(roms.find(::ROM::Name::OricJasmin)->second);
 				break;
 				case DiskInterface::Microdisc:
-					disk_rom_ = std::move(*roms[2]);
-					disk_rom_.resize(8192);
+					disk_rom_ = std::move(roms.find(::ROM::Name::OricMicrodisc)->second);
 				break;
 				case DiskInterface::Pravetz: {
-					pravetz_rom_ = std::move(*roms[2]);
+					pravetz_rom_ = std::move(roms.find(::ROM::Name::Oric8DOSBoot)->second);
 					pravetz_rom_.resize(512);
 
-					diskii_->set_state_machine(*roms[diskii_state_machine_index]);
+					diskii_->set_state_machine(roms.find(::ROM::Name::DiskIIStateMachine16Sector)->second);
 				} break;
 			}
 
-			rom_.resize(16384);
 			paged_rom_ = rom_.data();
 
 			switch(target.disk_interface) {

--- a/Machines/Oric/Video.cpp
+++ b/Machines/Oric/Video.cpp
@@ -54,7 +54,7 @@ void VideoOutput::set_display_type(Outputs::Display::DisplayType display_type) {
 
 #ifdef SUPPLY_COMPOSITE
 	const auto data_type =
-		(display_type == Outputs::Display::DisplayType::RGB) ?
+		(!has_colour_rom_ || display_type == Outputs::Display::DisplayType::RGB) ?
 			Outputs::Display::InputDataType::Red1Green1Blue1 :
 			Outputs::Display::InputDataType::PhaseLinkedLuminance8;
 #else
@@ -80,6 +80,7 @@ Outputs::Display::ScanStatus VideoOutput::get_scaled_scan_status() const {
 }
 
 void VideoOutput::set_colour_rom(const std::vector<uint8_t> &rom) {
+	has_colour_rom_ = true;
 	for(std::size_t c = 0; c < 8; c++) {
 		colour_forms_[c] = 0;
 

--- a/Machines/Oric/Video.hpp
+++ b/Machines/Oric/Video.hpp
@@ -37,6 +37,7 @@ class VideoOutput {
 		Outputs::CRT::CRT crt_;
 		Outputs::CRT::CRTFrequencyMismatchWarner<VideoOutput> frequency_mismatch_warner_;
 		bool crt_is_60Hz_ = false;
+		bool has_colour_rom_ = false;
 
 		void update_crt_frequency();
 

--- a/Machines/ROMMachine.hpp
+++ b/Machines/ROMMachine.hpp
@@ -10,37 +10,15 @@
 #define ROMMachine_hpp
 
 #include <functional>
+#include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
+#include "Utility/ROMCatalogue.hpp"
+
 namespace ROMMachine {
-
-/*!
-	Describes a ROM image; this term is used in this emulator strictly in the sense of firmware —
-	system software that is an inherent part of a machine.
-*/
-struct ROM {
-	/// The machine with which this ROM is associated, in a form that is safe for using as
-	/// part of a file name.
-	std::string machine_name;
-	/// A descriptive name for this ROM, suitable for use in a bullet-point list, a bracket
-	/// clause, etc, e.g. "the Electron MOS 1.0".
-	std::string descriptive_name;
-	/// An idiomatic file name for this ROM, e.g. "os10.rom".
-	std::string file_name;
-	/// The expected size of this ROM in bytes, e.g. 32768.
-	size_t size = 0;
-	/// CRC32s for all known acceptable copies of this ROM; intended to allow a host platform
-	/// to test user-provided ROMs of unknown provenance. **Not** intended to be used
-	/// to exclude ROMs where the user's intent is otherwise clear.
-	std::vector<uint32_t> crc32s;
-
-	ROM(std::string machine_name, std::string descriptive_name, std::string file_name, size_t size, uint32_t crc32) :
-		machine_name(machine_name), descriptive_name(descriptive_name), file_name(file_name), size(size), crc32s({crc32}) {}
-	ROM(std::string machine_name, std::string descriptive_name, std::string file_name, size_t size, std::initializer_list<uint32_t> crc32s) :
-		machine_name(machine_name), descriptive_name(descriptive_name), file_name(file_name), size(size), crc32s(crc32s) {}
-};
 
 /*!
 	Defines the signature for a function that must be supplied by the host environment in order to give machines
@@ -50,7 +28,7 @@ struct ROM {
 	return a vector of unique_ptrs that either contain the contents of the ROM from @c names that corresponds by
 	index, or else are @c nullptr.
 */
-typedef std::function<std::vector<std::unique_ptr<std::vector<uint8_t>>>(const std::vector<ROM> &roms)> ROMFetcher;
+typedef std::function<ROM::Map(const ROM::Request &request)> ROMFetcher;
 
 enum class Error {
 	MissingROMs

--- a/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
+++ b/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
@@ -146,33 +146,24 @@ template<Model model> class ConcreteMachine:
 			set_clock_rate(clock_rate());
 			speaker_.set_input_rate(float(clock_rate()) / 2.0f);
 
-			// With only the +2a and +3 currently supported, the +3 ROM is always
-			// the one required.
-			std::vector<ROMMachine::ROM> rom_names;
-			const std::string machine = "ZXSpectrum";
+			ROM::Name rom_name;
 			switch(model) {
 				case Model::SixteenK:
-				case Model::FortyEightK:
-					rom_names.emplace_back(machine, "the 48kb ROM", "48.rom", 16 * 1024, 0xddee531f);
-				break;
-
-				case Model::OneTwoEightK:
-					rom_names.emplace_back(machine, "the 128kb ROM", "128.rom", 32 * 1024, 0x2cbe8995);
-				break;
-
-				case Model::Plus2:
-					rom_names.emplace_back(machine, "the +2 ROM", "plus2.rom", 32 * 1024, 0xe7a517dc);
-				break;
-
+				case Model::FortyEightK:	rom_name = ROM::Name::Spectrum48k;		break;
+				case Model::OneTwoEightK:	rom_name = ROM::Name::Spectrum128k;		break;
+				case Model::Plus2:			rom_name = ROM::Name::SpecrumPlus2;		break;
 				case Model::Plus2a:
-				case Model::Plus3: {
-					const std::initializer_list<uint32_t> crc32s = { 0x96e3c17a, 0xbe0d9ec4 };
-					rom_names.emplace_back(machine, "the +2a/+3 ROM", "plus3.rom", 64 * 1024, crc32s);
-				} break;
+				case Model::Plus3: 			rom_name = ROM::Name::SpectrumPlus3;	break;
+				// TODO: possibly accept the +3 ROM in multiple parts?
 			}
-			const auto roms = rom_fetcher(rom_names);
-			if(!roms[0]) throw ROMMachine::Error::MissingROMs;
-			memcpy(rom_.data(), roms[0]->data(), std::min(rom_.size(), roms[0]->size()));
+			const auto request = ROM::Request(rom_name);
+			const auto roms = rom_fetcher(request);
+			if(!request.validate(roms)) {
+				throw ROMMachine::Error::MissingROMs;
+			}
+
+			const auto &rom = roms.find(rom_name)->second;
+			memcpy(rom_.data(), rom.data(), std::min(rom_.size(), rom.size()));
 
 			// Register for sleeping notifications.
 			tape_player_.set_clocking_hint_observer(this);

--- a/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
+++ b/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
@@ -157,7 +157,7 @@ template<Model model> class ConcreteMachine:
 				// TODO: possibly accept the +3 ROM in multiple parts?
 			}
 			const auto request = ROM::Request(rom_name);
-			const auto roms = rom_fetcher(request);
+			auto roms = rom_fetcher(request);
 			if(!request.validate(roms)) {
 				throw ROMMachine::Error::MissingROMs;
 			}

--- a/Machines/Utility/ROMCatalogue.cpp
+++ b/Machines/Utility/ROMCatalogue.cpp
@@ -1,0 +1,379 @@
+//
+//  ROMCatalogue.cpp
+//  Clock Signal
+//
+//  Created by Thomas Harte on 01/06/2021.
+//  Copyright © 2021 Thomas Harte. All rights reserved.
+//
+
+#include "ROMCatalogue.hpp"
+
+#include <cassert>
+
+using namespace ROM;
+
+Request::Request(Name name, bool optional) :
+	node.name(name), node.is_optional(optional) {}
+
+Request::Request() {}
+
+Request Request::operator &&(const Request &rhs) {
+	return *this;
+}
+
+Request Request::operator ||(const Request &rhs) {
+	return *this;
+}
+
+bool Request::validate(const Map &) const {
+	/* TODO. */
+	return true;
+}
+
+std::vector<ROM::Description> Request::all_descriptions() const {
+	std::vector<Description>() result;
+	node.add_descriptions(result);
+	return result;
+}
+
+void Request::Node::add_descriptions(std::vector<Description> &result) {
+	if(type == Type::One) {
+		result.push_back(name);
+		return;
+	}
+
+	for(const auto &node: children) {
+		node.add_descriptions(result);
+	}
+}
+
+Description::Description(Name name) {
+	switch(name) {
+		default: assert(false);	break;
+
+		case Name::AMSDOS:
+			*this = Request("AmstradCPC", "the Amstrad Disk Operating System", "amsdos.rom", 16*1024, 0x1fe22ecdu);
+		break;
+		case Name::CPC464Firmware:
+			*this = Request("AmstradCPC", "the CPC 464 firmware", "os464.rom", 16*1024, 0x815752dfu);
+		break;
+		case Name::CPC464BASIC:
+			*this = Request("AmstradCPC", "the CPC 464 BASIC ROM", "basic464.rom", 16*1024, 0x7d9a3bacu);
+		break;
+		case Name::CPC664Firmware:
+			*this = Request("AmstradCPC", "the CPC 664 firmware", "os664.rom", 16*1024, 0x3f5a6dc4u);
+		break;
+		case Name::CPC664BASIC:
+			*this = Request("AmstradCPC", "the CPC 664 BASIC ROM", "basic664.rom", 16*1024, 0x32fee492u);
+		break;
+		case Name::CPC6128Firmware:
+			*this = Request("AmstradCPC", "the CPC 6128 firmware", "os664.rom", 16*1024, 0x0219bb74u);
+		break;
+		case Name::CPC6128BASIC:
+			*this = Request("AmstradCPC", "the CPC 6128 BASIC ROM", "basic664.rom", 16*1024, 0xca6af63du);
+		break;
+
+//"AppleII"
+	AppleIIOriginal,
+	AppleIIPlus,
+	AppleIICharacter,
+	AppleIIe,
+	AppleIIeCharacter,
+	AppleIIEnhancedE,
+	AppleIIEnhancedECharacter,
+	}
+
+//					rom_descriptions.push_back(video_.rom_description(Video::VideoBase::CharacterROM::EnhancedIIe));
+//					rom_descriptions.emplace_back(machine_name, "the Enhanced Apple IIe ROM", "apple2e.rom", 32*1024, 0x65989942u);
+//					rom_descriptions.push_back(video_.rom_description(Video::VideoBase::CharacterROM::IIe));
+//					rom_descriptions.emplace_back(machine_name, "the Apple IIe ROM", "apple2eu.rom", 32*1024, 0xe12be18du);
+//					rom_descriptions.push_back(video_.rom_description(Video::VideoBase::CharacterROM::II));
+//					rom_descriptions.emplace_back(machine_name, "the Apple II+ ROM", "apple2.rom", 12*1024, 0xf66f9c26u);
+//					rom_descriptions.push_back(video_.rom_description(Video::VideoBase::CharacterROM::II));
+//					rom_descriptions.emplace_back(machine_name, "the original Apple II ROM", "apple2o.rom", 12*1024, 0xba210588u);
+
+//		roms = rom_fetcher({
+//			{"DiskII", "the Disk II 16-sector boot ROM", "boot-16.rom", 256, 0xce7144f6},
+//			{"DiskII", "the Disk II 16-sector state machine ROM", "state-machine-16.rom", 256, { 0x9796a238, 0xb72a2c70 } }
+//		});
+//		roms = rom_fetcher({
+//			{"DiskII", "the Disk II 13-sector boot ROM", "boot-13.rom", 256, 0xd34eb2ff},
+//			{"DiskII", "the Disk II 16-sector state machine ROM", "state-machine-16.rom", 256, { 0x9796a238, 0xb72a2c70 } }
+////			{"DiskII", "the Disk II 13-sector state machine ROM", "state-machine-13.rom", 256, 0x62e22620 }
+//		});
+
+
+//		enum class CharacterROM {
+//			/// The ROM that shipped with both the Apple II and the II+.
+//			II,
+//			/// The ROM that shipped with the original IIe.
+//			IIe,
+//			/// The ROM that shipped with the Enhanced IIe.
+//			EnhancedIIe,
+//			/// The ROM that shipped with the IIgs.
+//			IIgs
+//		};
+//
+//		/// @returns A file-level description of @c rom.
+//		static ROM::Name rom_name(CharacterROM rom) {
+//			const std::string machine_name = "AppleII";
+//			switch(rom) {
+//				case CharacterROM::II:
+//					return ROMMachine::ROM(machine_name, "the basic Apple II character ROM", "apple2-character.rom", 2*1024, 0x64f415c6);
+//
+//				case CharacterROM::IIe:
+//					return ROMMachine::ROM(machine_name, "the Apple IIe character ROM", "apple2eu-character.rom", 4*1024, 0x816a86f1);
+//
+//				default:	// To appease GCC.
+//				case CharacterROM::EnhancedIIe:
+//					return ROMMachine::ROM(machine_name, "the Enhanced Apple IIe character ROM", "apple2e-character.rom", 4*1024, 0x2651014d);
+//
+//				case CharacterROM::IIgs:
+//					return ROMMachine::ROM(machine_name, "the Apple IIgs character ROM", "apple2gs.chr", 4*1024, 0x91e53cd8);
+//			}
+//		}
+}
+
+
+//			const std::string machine_name = "AppleIIgs";
+//			switch(target.model) {
+//				case Target::Model::ROM00:
+//					/* TODO */
+//				case Target::Model::ROM01:
+//					rom_descriptions.emplace_back(machine_name, "the Apple IIgs ROM01", "apple2gs.rom", 128*1024, 0x42f124b0u);
+//				break;
+//
+//				case Target::Model::ROM03:
+//					rom_descriptions.emplace_back(machine_name, "the Apple IIgs ROM03", "apple2gs.rom2", 256*1024, 0xde7ddf29u);
+//				break;
+//			}
+//			rom_descriptions.push_back(video_->rom_description(Video::Video::CharacterROM::EnhancedIIe));
+//
+//			// TODO: pick a different ADB ROM for earlier machine revisions?
+//			rom_descriptions.emplace_back(machine_name, "the Apple IIgs ADB microcontroller ROM", "341s0632-2", 4*1024, 0xe1c11fb0u);
+
+
+//			switch(model) {
+//				default:
+//				case Model::Mac128k:
+//					ram_size = 128*1024;
+//					rom_size = 64*1024;
+//					rom_descriptions.emplace_back(machine_name, "the Macintosh 128k ROM", "mac128k.rom", 64*1024, 0x6d0c8a28);
+//				break;
+//				case Model::Mac512k:
+//					ram_size = 512*1024;
+//					rom_size = 64*1024;
+//					rom_descriptions.emplace_back(machine_name, "the Macintosh 512k ROM", "mac512k.rom", 64*1024, 0xcf759e0d);
+//				break;
+//				case Model::Mac512ke:
+//				case Model::MacPlus: {
+//					ram_size = ((model == Model::MacPlus) ? 4096 : 512)*1024;
+//					rom_size = 128*1024;
+//					const std::initializer_list<uint32_t> crc32s = { 0x4fa5b399, 0x7cacd18f, 0xb2102e8e };
+//					rom_descriptions.emplace_back(machine_name, "the Macintosh Plus ROM", "macplus.rom", 128*1024, crc32s);
+//				} break;
+//			}
+
+
+
+//			std::vector<ROMMachine::ROM> rom_descriptions = {
+//				{"AtariST", "the UK TOS 1.00 ROM", "tos100.img", 192*1024, 0x1a586c64}
+////				{"AtariST", "the UK TOS 1.04 ROM", "tos104.img", 192*1024, 0xa50d1d43}
+//			};
+
+
+// 			rom_list.emplace_back(new ROMMachine::ROM("ColecoVision", "the ColecoVision BIOS", std::vector<std::string>{ "coleco.rom" }, 8*1024, 0x3aa93ef3u));
+
+
+//			if(use_zx81_rom) {
+//				rom_list.emplace_back(new ROMMachine::ROM("ZX8081", "the ZX81 BASIC ROM", std::vector<std::string>{ "zx81.rom" }, 8 * 1024, 0x4b1dd6ebu));
+//			} else {
+//				rom_list.emplace_back(new ROMMachine::ROM("ZX8081", "the ZX80 BASIC ROM", std::vector<std::string>{ "zx80.rom" }, 4 * 1024, 0x4c7fc597u));
+//			}
+
+
+
+//			const std::string machine = "ZXSpectrum";
+//			switch(model) {
+//				case Model::SixteenK:
+//				case Model::FortyEightK:
+//					rom_names.emplace_back(machine, "the 48kb ROM", "48.rom", 16 * 1024, 0xddee531fu);
+//				break;
+//
+//				case Model::OneTwoEightK:
+//					rom_names.emplace_back(machine, "the 128kb ROM", "128.rom", 32 * 1024, 0x2cbe8995u);
+//				break;
+//
+//				case Model::Plus2:
+//					rom_names.emplace_back(machine, "the +2 ROM", "plus2.rom", 32 * 1024, 0xe7a517dcu);
+//				break;
+//
+//				case Model::Plus2a:
+//				case Model::Plus3: {
+//					const std::initializer_list<uint32_t> crc32s = { 0x96e3c17a, 0xbe0d9ec4 };
+//					rom_names.emplace_back(machine, "the +2a/+3 ROM", "plus3.rom", 64 * 1024, crc32s);
+//				} break;
+//			}
+
+
+
+//			const std::string machine_name = "Electron";
+//			std::vector<ROMMachine::ROM> required_roms = {
+//				{machine_name, "the Acorn BASIC II ROM", "basic.rom", 16*1024, 0x79434781},
+//				{machine_name, "the Electron MOS ROM", "os.rom", 16*1024, 0xbf63fb1f}
+//			};
+//			const size_t pres_adfs_rom_position = required_roms.size();
+//			if(target.has_pres_adfs) {
+//				required_roms.emplace_back(machine_name, "the E00 ADFS ROM, first slot", "ADFS-E00_1.rom", 16*1024, 0x51523993);
+//				required_roms.emplace_back(machine_name, "the E00 ADFS ROM, second slot", "ADFS-E00_2.rom", 16*1024, 0x8d17de0e);
+//			}
+//			const size_t acorn_adfs_rom_position = required_roms.size();
+//			if(target.has_acorn_adfs) {
+//				required_roms.emplace_back(machine_name, "the Acorn ADFS ROM", "adfs.rom", 16*1024, 0x3289bdc6);
+//			}
+//			const size_t dfs_rom_position = required_roms.size();
+//			if(target.has_dfs) {
+//				required_roms.emplace_back(machine_name, "the 1770 DFS ROM", "DFS-1770-2.20.rom", 16*1024, 0xf3dc9bc5);
+//			}
+//			const size_t ap6_rom_position = required_roms.size();
+//			if(target.has_ap6_rom) {
+//				required_roms.emplace_back(machine_name, "the 8kb Advanced Plus 6 ROM", "AP6v133.rom", 8*1024, 0xe0013cfc);
+//			}
+
+
+//				new ROMMachine::ROM("MasterSystem",
+//					is_japanese ? "the Japanese Master System BIOS" : "the European/US Master System BIOS",
+//					is_japanese ? "japanese-bios.sms" : "bios.sms",
+//					8*1024,
+//					is_japanese ? 0x48d44a13u : 0x0072ed54u,
+//					true
+//				)
+
+
+//	switch(personality) {
+//		case Personality::C1540:
+//			device_name = "1540";
+//			crc = 0x718d42b1;
+//		break;
+//		case Personality::C1541:
+//			device_name = "1541";
+//			crc = 0xfb760019;
+//		break;
+//	}
+//
+//	auto roms = rom_fetcher({ {"Commodore1540", "the " + device_name + " ROM", device_name + ".bin", 16*1024, crc} });
+
+
+//			const std::string machine_name = "Vic20";
+//			std::vector<ROMMachine::ROM> rom_names = {
+//				{machine_name, "the VIC-20 BASIC ROM", "basic.bin", 8*1024, 0xdb4c43c1u}
+//			};
+//			switch(target.region) {
+//				default:
+//					rom_names.emplace_back(machine_name, "the English-language VIC-20 character ROM", "characters-english.bin", 4*1024, 0x83e032a6u);
+//					rom_names.emplace_back(machine_name, "the English-language PAL VIC-20 kernel ROM", "kernel-pal.bin", 8*1024, 0x4be07cb4u);
+//				break;
+//				case Analyser::Static::Commodore::Target::Region::American:
+//					rom_names.emplace_back(machine_name, "the English-language VIC-20 character ROM", "characters-english.bin", 4*1024, 0x83e032a6u);
+//					rom_names.emplace_back(machine_name, "the English-language NTSC VIC-20 kernel ROM", "kernel-ntsc.bin", 8*1024, 0xe5e7c174u);
+//				break;
+//				case Analyser::Static::Commodore::Target::Region::Danish:
+//					rom_names.emplace_back(machine_name, "the Danish VIC-20 character ROM", "characters-danish.bin", 4*1024, 0x7fc11454u);
+//					rom_names.emplace_back(machine_name, "the Danish VIC-20 kernel ROM", "kernel-danish.bin", 8*1024, 0x02adaf16u);
+//				break;
+//				case Analyser::Static::Commodore::Target::Region::Japanese:
+//					rom_names.emplace_back(machine_name, "the Japanese VIC-20 character ROM", "characters-japanese.bin", 4*1024, 0xfcfd8a4bu);
+//					rom_names.emplace_back(machine_name, "the Japanese VIC-20 kernel ROM", "kernel-japanese.bin", 8*1024, 0x336900d7u);
+//				break;
+//				case Analyser::Static::Commodore::Target::Region::Swedish:
+//					rom_names.emplace_back(machine_name, "the Swedish VIC-20 character ROM", "characters-swedish.bin", 4*1024, 0xd808551du);
+//					rom_names.emplace_back(machine_name, "the Swedish VIC-20 kernel ROM", "kernel-swedish.bin", 8*1024, 0xb2a60662u);
+//				break;
+//			}
+
+
+//			const std::string machine_name = "Oric";
+//			std::vector<ROMMachine::ROM> rom_names = { {machine_name, "the Oric colour ROM", "colour.rom", 128, 0xd50fca65u, true} };
+//			switch(target.rom) {
+//				case Analyser::Static::Oric::Target::ROM::BASIC10:
+//					rom_names.emplace_back(machine_name, "Oric BASIC 1.0", "basic10.rom", 16*1024, 0xf18710b4u);
+//				break;
+//				case Analyser::Static::Oric::Target::ROM::BASIC11:
+//					rom_names.emplace_back(machine_name, "Oric BASIC 1.1", "basic11.rom", 16*1024, 0xc3a92befu);
+//				break;
+//				case Analyser::Static::Oric::Target::ROM::Pravetz:
+//					rom_names.emplace_back(machine_name, "Pravetz BASIC", "pravetz.rom", 16*1024, 0x58079502u);
+//				break;
+//			}
+//			size_t diskii_state_machine_index = 0;
+//			switch(disk_interface) {
+//				default: break;
+//				case DiskInterface::BD500:
+//					rom_names.emplace_back(machine_name, "the Oric Byte Drive 500 ROM", "bd500.rom", 8*1024, 0x61952e34u);
+//				break;
+//				case DiskInterface::Jasmin:
+//					rom_names.emplace_back(machine_name, "the Oric Jasmin ROM", "jasmin.rom", 2*1024, 0x37220e89u);
+//				break;
+//				case DiskInterface::Microdisc:
+//					rom_names.emplace_back(machine_name, "the Oric Microdisc ROM", "microdisc.rom", 8*1024, 0xa9664a9cu);
+//				break;
+//				case DiskInterface::Pravetz:
+//					rom_names.emplace_back(machine_name, "the 8DOS boot ROM", "8dos.rom", 512, 0x49a74c06u);
+//					// These ROM details are coupled with those in the DiskIICard.
+//					diskii_state_machine_index = rom_names.size();
+//					rom_names.emplace_back("DiskII", "the Disk II 16-sector state machine ROM", "state-machine-16.rom", 256, std::initializer_list<uint32_t>{ 0x9796a238u, 0xb72a2c70u });
+//				break;
+//			}
+//
+//			const auto collection = ROMMachine::ROMCollection(rom_names);
+
+
+//			const std::string machine_name = "MSX";
+//			std::vector<ROMMachine::ROM> required_roms = {
+//				{machine_name, "any MSX BIOS", "msx.rom", 32*1024, 0x94ee12f3u}
+//			};
+//
+//			bool is_ntsc = true;
+//			uint8_t character_generator = 1;	/* 0 = Japan, 1 = USA, etc, 2 = USSR */
+//			uint8_t date_format = 1;			/* 0 = Y/M/D, 1 = M/D/Y, 2 = D/M/Y */
+//			uint8_t keyboard = 1;				/* 0 = Japan, 1 = USA, 2 = France, 3 = UK, 4 = Germany, 5 = USSR, 6 = Spain */
+//
+//			// TODO: CRCs below are incomplete, at best.
+//			switch(target.region) {
+//				case Target::Region::Japan:
+//					required_roms.emplace_back(machine_name, "a Japanese MSX BIOS", "msx-japanese.rom", 32*1024, 0xee229390u);
+//					vdp_->set_tv_standard(TI::TMS::TVStandard::NTSC);
+//
+//					is_ntsc = true;
+//					character_generator = 0;
+//					date_format = 0;
+//				break;
+//				case Target::Region::USA:
+//					required_roms.emplace_back(machine_name, "an American MSX BIOS", "msx-american.rom", 32*1024, 0u);
+//					vdp_->set_tv_standard(TI::TMS::TVStandard::NTSC);
+//
+//					is_ntsc = true;
+//					character_generator = 1;
+//					date_format = 1;
+//				break;
+//				case Target::Region::Europe:
+//					required_roms.emplace_back(machine_name, "a European MSX BIOS", "msx-european.rom", 32*1024, 0u);
+//					vdp_->set_tv_standard(TI::TMS::TVStandard::PAL);
+//
+//					is_ntsc = false;
+//					character_generator = 1;
+//					date_format = 2;
+//				break;
+//			}
+//
+//			ROMMachine::ROMVector rom_list;
+//			ROMMachine::ROMCollection *bios = new ROMMachine::ROMCollection(required_roms, ROMMachine::ROMCollection::Type::Any);
+//			rom_list.emplace_back(bios);
+//
+//			// Fetch the necessary ROMs; try the region-specific ROM first,
+//			// but failing that fall back on patching the main one.
+//			size_t disk_index = 0;
+//			if(target.has_disk_drive) {
+//				disk_index = required_roms.size();
+//				rom_list.emplace_back(new ROMMachine::ROM(machine_name, "the MSX-DOS ROM", "disk.rom", 16*1024, 0x721f61dfu));
+//			}

--- a/Machines/Utility/ROMCatalogue.cpp
+++ b/Machines/Utility/ROMCatalogue.cpp
@@ -408,8 +408,9 @@ Description::Description(Name name) {
 			*this = Description(name, "Macintosh", "the Macintosh Plus ROM", "macplus.rom", 128*1024, crcs);
 		} break;
 
-		case Name::AtariSTTOS100:	*this = Description(name, "AtariST", "the UK TOS 1.00 ROM", "tos100.img", 192*1024, 0x1a586c64u);	break;
-		case Name::AtariSTTOS104:	*this = Description(name, "AtariST", "the UK TOS 1.04 ROM", "tos104.img", 192*1024, 0xa50d1d43u);	break;
+		case Name::AtariSTTOS100:		*this = Description(name, "AtariST", "the UK TOS 1.00 ROM", "tos100.img", 192*1024, 0x1a586c64u);		break;
+		case Name::AtariSTTOS104:		*this = Description(name, "AtariST", "the UK TOS 1.04 ROM", "tos104.img", 192*1024, 0xa50d1d43u);		break;
+		case Name::AtariSTEmuTOS192:	*this = Description(name, "AtariST", "the UK EmuTOS 1.92 ROM", "etos192uk.img", 192*1024, 0xfc3b9e61u);	break;
 
 		case Name::ColecoVisionBIOS:
 			*this = Description(name, "ColecoVision", "the ColecoVision BIOS", "coleco.rom", 8*1024, 0x3aa93ef3u);
@@ -469,5 +470,10 @@ Description::Description(Name name) {
 		case Name::MSXAmericanBIOS:	*this = Description(name, "MSX", "an American MSX BIOS", "msx-american.rom", 32*1024, 0u);			break;
 		case Name::MSXEuropeanBIOS:	*this = Description(name, "MSX", "a European MSX BIOS", "msx-european.rom", 32*1024, 0u);			break;
 		case Name::MSXDOS:			*this = Description(name, "MSX", "the MSX-DOS ROM", "disk.rom", 16*1024, 0x721f61dfu);				break;
+
+		case Name::SinclairQLJS:
+			*this = Description(name, "SinclairQL", "the Sinclair QL 'JS' ROM", "js.rom", 48*1024, 0x0f95aab5u);
+		break;
+
 	}
 }

--- a/Machines/Utility/ROMCatalogue.cpp
+++ b/Machines/Utility/ROMCatalogue.cpp
@@ -151,48 +151,25 @@ Description::Description(Name name) {
 		case Name::DiskIIStateMachine13Sector:
 			*this = Description(name, "DiskII", "the Disk II 13-sector state machine ROM", "state-machine-13.rom", 256, 0x62e22620u);
 		break;
+
+		case Name::Macintosh128k:	*this = Description(name, "Macintosh", "the Macintosh 128k ROM", "mac128k.rom", 64*1024, 0x6d0c8a28u);	break;
+		case Name::Macintosh512k:	*this = Description(name, "Macintosh", "the Macintosh 512k ROM", "mac512k.rom", 64*1024, 0xcf759e0d);	break;
+		case Name::MacintoshPlus: {
+			const std::initializer_list<uint32_t> crc32s = { 0x4fa5b399, 0x7cacd18f, 0xb2102e8e };
+			*this = Description(name, "Macintosh", "the Macintosh Plus ROM", "macplus.rom", 128*1024, crc32s);
+		} break;
+
+		case Name::AtariSTTOS100:	*this = Description(name, "AtariST", "the UK TOS 1.00 ROM", "tos100.img", 192*1024, 0x1a586c64u);	break;
+		case Name::AtariSTTOS104:	*this = Description(name, "AtariST", "the UK TOS 1.04 ROM", "tos104.img", 192*1024, 0xa50d1d43u);	break;
+
+		case Name::ColecoVisionBIOS:
+			*this = Description(name, "ColecoVision", "the ColecoVision BIOS", "coleco.rom", 8*1024, 0x3aa93ef3u);
+		break;
+
+		case Name::ZX80:	*this = Description(name, "ZX8081", "the ZX80 BASIC ROM", "zx80.rom", 4 * 1024, 0x4c7fc597u);	break;
+		case Name::ZX81:	*this = Description(name, "ZX8081", "the ZX81 BASIC ROM", "zx81.rom", 8 * 1024, 0x4b1dd6ebu);	break;
 	}
 }
-
-
-//			switch(model) {
-//				default:
-//				case Model::Mac128k:
-//					ram_size = 128*1024;
-//					rom_size = 64*1024;
-//					rom_descriptions.emplace_back(machine_name, "the Macintosh 128k ROM", "mac128k.rom", 64*1024, 0x6d0c8a28);
-//				break;
-//				case Model::Mac512k:
-//					ram_size = 512*1024;
-//					rom_size = 64*1024;
-//					rom_descriptions.emplace_back(machine_name, "the Macintosh 512k ROM", "mac512k.rom", 64*1024, 0xcf759e0d);
-//				break;
-//				case Model::Mac512ke:
-//				case Model::MacPlus: {
-//					ram_size = ((model == Model::MacPlus) ? 4096 : 512)*1024;
-//					rom_size = 128*1024;
-//					const std::initializer_list<uint32_t> crc32s = { 0x4fa5b399, 0x7cacd18f, 0xb2102e8e };
-//					rom_descriptions.emplace_back(machine_name, "the Macintosh Plus ROM", "macplus.rom", 128*1024, crc32s);
-//				} break;
-//			}
-
-
-
-//			std::vector<ROMMachine::ROM> rom_descriptions = {
-//				{"AtariST", "the UK TOS 1.00 ROM", "tos100.img", 192*1024, 0x1a586c64}
-////				{"AtariST", "the UK TOS 1.04 ROM", "tos104.img", 192*1024, 0xa50d1d43}
-//			};
-
-
-// 			rom_list.emplace_back(new ROMMachine::ROM("ColecoVision", "the ColecoVision BIOS", std::vector<std::string>{ "coleco.rom" }, 8*1024, 0x3aa93ef3u));
-
-
-//			if(use_zx81_rom) {
-//				rom_list.emplace_back(new ROMMachine::ROM("ZX8081", "the ZX81 BASIC ROM", std::vector<std::string>{ "zx81.rom" }, 8 * 1024, 0x4b1dd6ebu));
-//			} else {
-//				rom_list.emplace_back(new ROMMachine::ROM("ZX8081", "the ZX80 BASIC ROM", std::vector<std::string>{ "zx80.rom" }, 4 * 1024, 0x4c7fc597u));
-//			}
-
 
 
 //			const std::string machine = "ZXSpectrum";

--- a/Machines/Utility/ROMCatalogue.cpp
+++ b/Machines/Utility/ROMCatalogue.cpp
@@ -13,6 +13,10 @@
 
 using namespace ROM;
 
+namespace {
+constexpr Name MaxName = Name::SpectrumPlus3;
+}
+
 Request::Request(Name name, bool optional) {
 	node.name = name;
 	node.is_optional = optional;
@@ -173,8 +177,16 @@ void Request::Node::visit(
 	}
 }
 
+std::vector<Description> ROM::all_descriptions() {
+	std::vector<Description> result;
+	for(int name = 1; name <= MaxName; name++) {
+		result.push_back(Description(ROM::Name(name)));
+	}
+	return result;
+}
+
 std::optional<Description> Description::from_crc(uint32_t crc32) {
-	for(int name = 1; name <= SpectrumPlus3; name++) {
+	for(int name = 1; name <= MaxName; name++) {
 		const Description candidate = Description(ROM::Name(name));
 
 		const auto found_crc = std::find(candidate.crc32s.begin(), candidate.crc32s.end(), crc32);
@@ -232,8 +244,8 @@ Description::Description(Name name) {
 		case Name::Macintosh128k:	*this = Description(name, "Macintosh", "the Macintosh 128k ROM", "mac128k.rom", 64*1024, 0x6d0c8a28u);	break;
 		case Name::Macintosh512k:	*this = Description(name, "Macintosh", "the Macintosh 512k ROM", "mac512k.rom", 64*1024, 0xcf759e0d);	break;
 		case Name::MacintoshPlus: {
-			const std::initializer_list<uint32_t> crc32s = { 0x4fa5b399, 0x7cacd18f, 0xb2102e8e };
-			*this = Description(name, "Macintosh", "the Macintosh Plus ROM", "macplus.rom", 128*1024, crc32s);
+			const std::initializer_list<uint32_t> crcs = { 0x4fa5b399, 0x7cacd18f, 0xb2102e8e };
+			*this = Description(name, "Macintosh", "the Macintosh Plus ROM", "macplus.rom", 128*1024, crcs);
 		} break;
 
 		case Name::AtariSTTOS100:	*this = Description(name, "AtariST", "the UK TOS 1.00 ROM", "tos100.img", 192*1024, 0x1a586c64u);	break;
@@ -250,8 +262,8 @@ Description::Description(Name name) {
 		case Name::Spectrum128k:	*this = Description(name, "ZXSpectrum", "the 128kb ROM", "128.rom", 32 * 1024, 0x2cbe8995u);	break;
 		case Name::SpecrumPlus2:	*this = Description(name, "ZXSpectrum", "the +2 ROM", "plus2.rom", 32 * 1024, 0xe7a517dcu); 	break;
 		case Name::SpectrumPlus3: {
-			const std::initializer_list<uint32_t> crc32s = { 0x96e3c17a, 0xbe0d9ec4 };
-			*this = Description(name, "ZXSpectrum", "the +2a/+3 ROM", "plus3.rom", 64 * 1024, crc32s);
+			const std::initializer_list<uint32_t> crcs = { 0x96e3c17a, 0xbe0d9ec4 };
+			*this = Description(name, "ZXSpectrum", "the +2a/+3 ROM", "plus3.rom", 64 * 1024, crcs);
 		} break;
 
 		case Name::AcornBASICII:	*this = Description(name, "Electron", "the Acorn BASIC II ROM", "basic.rom", 16*1024, 0x79434781u); 			break;

--- a/Machines/Utility/ROMCatalogue.cpp
+++ b/Machines/Utility/ROMCatalogue.cpp
@@ -205,91 +205,20 @@ Description::Description(Name name) {
 		case Name::Vic20JapaneseKernel:		*this = Description(name, "Vic20", "the Japanese VIC-20 kernel ROM", "kernel-japanese.bin", 8*1024, 0x336900d7u);				break;
 		case Name::Vic20SwedishCharacters:	*this = Description(name, "Vic20", "the Swedish VIC-20 character ROM", "characters-swedish.bin", 4*1024, 0xd808551du);			break;
 		case Name::Vic20SwedishKernel:		*this = Description(name, "Vic20", "the Swedish VIC-20 kernel ROM", "kernel-swedish.bin", 8*1024, 0xb2a60662u);					break;
+
+		case Name::OricColourROM:		*this = Description(name, "Oric", "the Oric colour ROM", "colour.rom", 128, 0xd50fca65u);			break;
+		case Name::OricBASIC10:			*this = Description(name, "Oric", "Oric BASIC 1.0", "basic10.rom", 16*1024, 0xf18710b4u);			break;
+		case Name::OricBASIC11:			*this = Description(name, "Oric", "Oric BASIC 1.1", "basic11.rom", 16*1024, 0xc3a92befu);			break;
+		case Name::OricPravetzBASIC:	*this = Description(name, "Oric", "Pravetz BASIC", "pravetz.rom", 16*1024, 0x58079502u);			break;
+		case Name::OricByteDrive500:	*this = Description(name, "Oric", "the Oric Byte Drive 500 ROM", "bd500.rom", 8*1024, 0x61952e34u);	break;
+		case Name::OricJasmin:			*this = Description(name, "Oric", "the Oric Jasmin ROM", "jasmin.rom", 2*1024, 0x37220e89u);		break;
+		case Name::OricMicrodisc:		*this = Description(name, "Oric", "the Oric Microdisc ROM", "microdisc.rom", 8*1024, 0xa9664a9cu);	break;
+		case Name::Oric8DOSBoot:		*this = Description(name, "Oric", "the 8DOS boot ROM", "8dos.rom", 512, 0x49a74c06u);				break;
+
+		case Name::MSXGenericBIOS:	*this = Description(name, "MSX", "any MSX BIOS", "msx.rom", 32*1024, 0x94ee12f3u);					break;
+		case Name::MSXJapaneseBIOS:	*this = Description(name, "MSX", "a Japanese MSX BIOS", "msx-japanese.rom", 32*1024, 0xee229390u);	break;
+		case Name::MSXAmericanBIOS:	*this = Description(name, "MSX", "an American MSX BIOS", "msx-american.rom", 32*1024, 0u);			break;
+		case Name::MSXEuropeanBIOS:	*this = Description(name, "MSX", "a European MSX BIOS", "msx-european.rom", 32*1024, 0u);			break;
+		case Name::MSXDOS:			*this = Description(name, "MSX", "the MSX-DOS ROM", "disk.rom", 16*1024, 0x721f61dfu);				break;
 	}
 }
-
-//			const std::string machine_name = "Oric";
-//			std::vector<ROMMachine::ROM> rom_names = { {machine_name, "the Oric colour ROM", "colour.rom", 128, 0xd50fca65u, true} };
-//			switch(target.rom) {
-//				case Analyser::Static::Oric::Target::ROM::BASIC10:
-//					rom_names.emplace_back(machine_name, "Oric BASIC 1.0", "basic10.rom", 16*1024, 0xf18710b4u);
-//				break;
-//				case Analyser::Static::Oric::Target::ROM::BASIC11:
-//					rom_names.emplace_back(machine_name, "Oric BASIC 1.1", "basic11.rom", 16*1024, 0xc3a92befu);
-//				break;
-//				case Analyser::Static::Oric::Target::ROM::Pravetz:
-//					rom_names.emplace_back(machine_name, "Pravetz BASIC", "pravetz.rom", 16*1024, 0x58079502u);
-//				break;
-//			}
-//			size_t diskii_state_machine_index = 0;
-//			switch(disk_interface) {
-//				default: break;
-//				case DiskInterface::BD500:
-//					rom_names.emplace_back(machine_name, "the Oric Byte Drive 500 ROM", "bd500.rom", 8*1024, 0x61952e34u);
-//				break;
-//				case DiskInterface::Jasmin:
-//					rom_names.emplace_back(machine_name, "the Oric Jasmin ROM", "jasmin.rom", 2*1024, 0x37220e89u);
-//				break;
-//				case DiskInterface::Microdisc:
-//					rom_names.emplace_back(machine_name, "the Oric Microdisc ROM", "microdisc.rom", 8*1024, 0xa9664a9cu);
-//				break;
-//				case DiskInterface::Pravetz:
-//					rom_names.emplace_back(machine_name, "the 8DOS boot ROM", "8dos.rom", 512, 0x49a74c06u);
-//					// These ROM details are coupled with those in the DiskIICard.
-//					diskii_state_machine_index = rom_names.size();
-//					rom_names.emplace_back("DiskII", "the Disk II 16-sector state machine ROM", "state-machine-16.rom", 256, std::initializer_list<uint32_t>{ 0x9796a238u, 0xb72a2c70u });
-//				break;
-//			}
-//
-//			const auto collection = ROMMachine::ROMCollection(rom_names);
-
-
-//			const std::string machine_name = "MSX";
-//			std::vector<ROMMachine::ROM> required_roms = {
-//				{machine_name, "any MSX BIOS", "msx.rom", 32*1024, 0x94ee12f3u}
-//			};
-//
-//			bool is_ntsc = true;
-//			uint8_t character_generator = 1;	/* 0 = Japan, 1 = USA, etc, 2 = USSR */
-//			uint8_t date_format = 1;			/* 0 = Y/M/D, 1 = M/D/Y, 2 = D/M/Y */
-//			uint8_t keyboard = 1;				/* 0 = Japan, 1 = USA, 2 = France, 3 = UK, 4 = Germany, 5 = USSR, 6 = Spain */
-//
-//			// TODO: CRCs below are incomplete, at best.
-//			switch(target.region) {
-//				case Target::Region::Japan:
-//					required_roms.emplace_back(machine_name, "a Japanese MSX BIOS", "msx-japanese.rom", 32*1024, 0xee229390u);
-//					vdp_->set_tv_standard(TI::TMS::TVStandard::NTSC);
-//
-//					is_ntsc = true;
-//					character_generator = 0;
-//					date_format = 0;
-//				break;
-//				case Target::Region::USA:
-//					required_roms.emplace_back(machine_name, "an American MSX BIOS", "msx-american.rom", 32*1024, 0u);
-//					vdp_->set_tv_standard(TI::TMS::TVStandard::NTSC);
-//
-//					is_ntsc = true;
-//					character_generator = 1;
-//					date_format = 1;
-//				break;
-//				case Target::Region::Europe:
-//					required_roms.emplace_back(machine_name, "a European MSX BIOS", "msx-european.rom", 32*1024, 0u);
-//					vdp_->set_tv_standard(TI::TMS::TVStandard::PAL);
-//
-//					is_ntsc = false;
-//					character_generator = 1;
-//					date_format = 2;
-//				break;
-//			}
-//
-//			ROMMachine::ROMVector rom_list;
-//			ROMMachine::ROMCollection *bios = new ROMMachine::ROMCollection(required_roms, ROMMachine::ROMCollection::Type::Any);
-//			rom_list.emplace_back(bios);
-//
-//			// Fetch the necessary ROMs; try the region-specific ROM first,
-//			// but failing that fall back on patching the main one.
-//			size_t disk_index = 0;
-//			if(target.has_disk_drive) {
-//				disk_index = required_roms.size();
-//				rom_list.emplace_back(new ROMMachine::ROM(machine_name, "the MSX-DOS ROM", "disk.rom", 16*1024, 0x721f61dfu));
-//			}

--- a/Machines/Utility/ROMCatalogue.cpp
+++ b/Machines/Utility/ROMCatalogue.cpp
@@ -32,6 +32,7 @@ Request Request::append(Node::Type type, const Request &rhs) {
 	if(node.type == type && rhs.node.type == type) {
 		Request new_request = *this;
 		new_request.node.children.insert(new_request.node.children.end(), rhs.node.children.begin(), rhs.node.children.end());
+		new_request.node.sort();
 		return new_request;
 	}
 
@@ -39,6 +40,7 @@ Request Request::append(Node::Type type, const Request &rhs) {
 	if(node.type == type && rhs.node.type == Node::Type::One) {
 		Request new_request = *this;
 		new_request.node.children.push_back(rhs.node);
+		new_request.node.sort();
 		return new_request;
 	}
 
@@ -46,6 +48,7 @@ Request Request::append(Node::Type type, const Request &rhs) {
 	if(rhs.node.type == type && node.type == Node::Type::One) {
 		Request new_request = rhs;
 		new_request.node.children.push_back(node);
+		new_request.node.sort();
 		return new_request;
 	}
 

--- a/Machines/Utility/ROMCatalogue.cpp
+++ b/Machines/Utility/ROMCatalogue.cpp
@@ -156,8 +156,8 @@ Description::Description(Name name) {
 		case Name::CPC464BASIC:			*this = Description(name, "AmstradCPC", "the CPC 464 BASIC ROM", "basic464.rom", 16*1024, 0x7d9a3bacu);				break;
 		case Name::CPC664Firmware:		*this = Description(name, "AmstradCPC", "the CPC 664 firmware", "os664.rom", 16*1024, 0x3f5a6dc4u);					break;
 		case Name::CPC664BASIC:			*this = Description(name, "AmstradCPC", "the CPC 664 BASIC ROM", "basic664.rom", 16*1024, 0x32fee492u);				break;
-		case Name::CPC6128Firmware:		*this = Description(name, "AmstradCPC", "the CPC 6128 firmware", "os664.rom", 16*1024, 0x0219bb74u);				break;
-		case Name::CPC6128BASIC:		*this = Description(name, "AmstradCPC", "the CPC 6128 BASIC ROM", "basic664.rom", 16*1024, 0xca6af63du);			break;
+		case Name::CPC6128Firmware:		*this = Description(name, "AmstradCPC", "the CPC 6128 firmware", "os6128.rom", 16*1024, 0x0219bb74u);				break;
+		case Name::CPC6128BASIC:		*this = Description(name, "AmstradCPC", "the CPC 6128 BASIC ROM", "basic6128.rom", 16*1024, 0xca6af63du);			break;
 
 		case Name::AppleIIEnhancedE:	*this = Description(name, "AppleII", "the Enhanced Apple IIe ROM", "apple2e.rom", 32*1024, 0x65989942u);				break;
 		case Name::AppleIIe:			*this = Description(name, "AppleII", "the Apple IIe ROM", "apple2eu.rom", 32*1024, 0xe12be18du);						break;

--- a/Machines/Utility/ROMCatalogue.cpp
+++ b/Machines/Utility/ROMCatalogue.cpp
@@ -168,108 +168,45 @@ Description::Description(Name name) {
 
 		case Name::ZX80:	*this = Description(name, "ZX8081", "the ZX80 BASIC ROM", "zx80.rom", 4 * 1024, 0x4c7fc597u);	break;
 		case Name::ZX81:	*this = Description(name, "ZX8081", "the ZX81 BASIC ROM", "zx81.rom", 8 * 1024, 0x4b1dd6ebu);	break;
+
+		case Name::Spectrum48k:		*this = Description(name, "ZXSpectrum", "the 48kb ROM", "48.rom", 16 * 1024, 0xddee531fu);		break;
+		case Name::Spectrum128k:	*this = Description(name, "ZXSpectrum", "the 128kb ROM", "128.rom", 32 * 1024, 0x2cbe8995u);	break;
+		case Name::SpecrumPlus2:	*this = Description(name, "ZXSpectrum", "the +2 ROM", "plus2.rom", 32 * 1024, 0xe7a517dcu); 	break;
+		case Name::SpectrumPlus3: {
+			const std::initializer_list<uint32_t> crc32s = { 0x96e3c17a, 0xbe0d9ec4 };
+			*this = Description(name, "ZXSpectrum", "the +2a/+3 ROM", "plus3.rom", 64 * 1024, crc32s);
+		} break;
+
+		case Name::AcornBASICII:	*this = Description(name, "Electron", "the Acorn BASIC II ROM", "basic.rom", 16*1024, 0x79434781u); 			break;
+		case Name::PRESADFSSlot1:	*this = Description(name, "Electron", "the E00 ADFS ROM, first slot", "ADFS-E00_1.rom", 16*1024, 0x51523993u); 	break;
+		case Name::PRESADFSSlot2:	*this = Description(name, "Electron", "the E00 ADFS ROM, second slot", "ADFS-E00_2.rom", 16*1024, 0x8d17de0eu); break;
+		case Name::AcornADFS:		*this = Description(name, "Electron", "the Acorn ADFS ROM", "adfs.rom", 16*1024, 0x3289bdc6u); 					break;
+		case Name::Acorn1770DFS:	*this = Description(name, "Electron", "the 8kb Advanced Plus 6 ROM", "AP6v133.rom", 8*1024, 0xe0013cfcu); 		break;
+		case Name::PRESAdvancedPlus6:
+			*this = Description(name, "Electron", "the 1770 DFS ROM", "DFS-1770-2.20.rom", 16*1024, 0xf3dc9bc5u);
+		break;
+		case Name::AcornElectronMOS100:
+			*this = Description(name, "Electron", "the Electron MOS ROM v1.00", "os.rom", 16*1024, 0xbf63fb1fu);
+		break;
+
+		case Name::MasterSystemJapaneseBIOS:	*this = Description(name, "MasterSystem", "the Japanese Master System BIOS", "japanese-bios.sms", 8*1024, 0x48d44a13u); break;
+		case Name::MasterSystemWesternBIOS:		*this = Description(name, "MasterSystem", "the European/US Master System BIOS", "bios.sms", 8*1024, 0x0072ed54u); 		break;
+
+		case Name::Commodore1540:	*this = Description(name, "Commodore1540", "the 1540 ROM", "1540.bin", 16*1024, 0x718d42b1u);	break;
+		case Name::Commodore1541:	*this = Description(name, "Commodore1540", "the 1541 ROM", "1541.bin", 16*1024, 0xfb760019);	break;
+
+		case Name::Vic20BASIC:				*this = Description(name, "Vic20", "the VIC-20 BASIC ROM", "basic.bin", 8*1024, 0xdb4c43c1u);									break;
+		case Name::Vic20EnglishCharacters:	*this = Description(name, "Vic20", "the English-language VIC-20 character ROM", "characters-english.bin", 4*1024, 0x83e032a6u);	break;
+		case Name::Vic20EnglishPALKernel:	*this = Description(name, "Vic20", "the English-language PAL VIC-20 kernel ROM", "kernel-pal.bin", 8*1024, 0x4be07cb4u);		break;
+		case Name::Vic20EnglishNTSCKernel:	*this = Description(name, "Vic20", "the English-language NTSC VIC-20 kernel ROM", "kernel-ntsc.bin", 8*1024, 0xe5e7c174u);		break;
+		case Name::Vic20DanishCharacters:	*this = Description(name, "Vic20", "the Danish VIC-20 character ROM", "characters-danish.bin", 4*1024, 0x7fc11454u);			break;
+		case Name::Vic20DanishKernel:		*this = Description(name, "Vic20", "the Danish VIC-20 kernel ROM", "kernel-danish.bin", 8*1024, 0x02adaf16u);					break;
+		case Name::Vic20JapaneseCharacters:	*this = Description(name, "Vic20", "the Japanese VIC-20 character ROM", "characters-japanese.bin", 4*1024, 0xfcfd8a4bu);		break;
+		case Name::Vic20JapaneseKernel:		*this = Description(name, "Vic20", "the Japanese VIC-20 kernel ROM", "kernel-japanese.bin", 8*1024, 0x336900d7u);				break;
+		case Name::Vic20SwedishCharacters:	*this = Description(name, "Vic20", "the Swedish VIC-20 character ROM", "characters-swedish.bin", 4*1024, 0xd808551du);			break;
+		case Name::Vic20SwedishKernel:		*this = Description(name, "Vic20", "the Swedish VIC-20 kernel ROM", "kernel-swedish.bin", 8*1024, 0xb2a60662u);					break;
 	}
 }
-
-
-//			const std::string machine = "ZXSpectrum";
-//			switch(model) {
-//				case Model::SixteenK:
-//				case Model::FortyEightK:
-//					rom_names.emplace_back(machine, "the 48kb ROM", "48.rom", 16 * 1024, 0xddee531fu);
-//				break;
-//
-//				case Model::OneTwoEightK:
-//					rom_names.emplace_back(machine, "the 128kb ROM", "128.rom", 32 * 1024, 0x2cbe8995u);
-//				break;
-//
-//				case Model::Plus2:
-//					rom_names.emplace_back(machine, "the +2 ROM", "plus2.rom", 32 * 1024, 0xe7a517dcu);
-//				break;
-//
-//				case Model::Plus2a:
-//				case Model::Plus3: {
-//					const std::initializer_list<uint32_t> crc32s = { 0x96e3c17a, 0xbe0d9ec4 };
-//					rom_names.emplace_back(machine, "the +2a/+3 ROM", "plus3.rom", 64 * 1024, crc32s);
-//				} break;
-//			}
-
-
-
-//			const std::string machine_name = "Electron";
-//			std::vector<ROMMachine::ROM> required_roms = {
-//				{machine_name, "the Acorn BASIC II ROM", "basic.rom", 16*1024, 0x79434781},
-//				{machine_name, "the Electron MOS ROM", "os.rom", 16*1024, 0xbf63fb1f}
-//			};
-//			const size_t pres_adfs_rom_position = required_roms.size();
-//			if(target.has_pres_adfs) {
-//				required_roms.emplace_back(machine_name, "the E00 ADFS ROM, first slot", "ADFS-E00_1.rom", 16*1024, 0x51523993);
-//				required_roms.emplace_back(machine_name, "the E00 ADFS ROM, second slot", "ADFS-E00_2.rom", 16*1024, 0x8d17de0e);
-//			}
-//			const size_t acorn_adfs_rom_position = required_roms.size();
-//			if(target.has_acorn_adfs) {
-//				required_roms.emplace_back(machine_name, "the Acorn ADFS ROM", "adfs.rom", 16*1024, 0x3289bdc6);
-//			}
-//			const size_t dfs_rom_position = required_roms.size();
-//			if(target.has_dfs) {
-//				required_roms.emplace_back(machine_name, "the 1770 DFS ROM", "DFS-1770-2.20.rom", 16*1024, 0xf3dc9bc5);
-//			}
-//			const size_t ap6_rom_position = required_roms.size();
-//			if(target.has_ap6_rom) {
-//				required_roms.emplace_back(machine_name, "the 8kb Advanced Plus 6 ROM", "AP6v133.rom", 8*1024, 0xe0013cfc);
-//			}
-
-
-//				new ROMMachine::ROM("MasterSystem",
-//					is_japanese ? "the Japanese Master System BIOS" : "the European/US Master System BIOS",
-//					is_japanese ? "japanese-bios.sms" : "bios.sms",
-//					8*1024,
-//					is_japanese ? 0x48d44a13u : 0x0072ed54u,
-//					true
-//				)
-
-
-//	switch(personality) {
-//		case Personality::C1540:
-//			device_name = "1540";
-//			crc = 0x718d42b1;
-//		break;
-//		case Personality::C1541:
-//			device_name = "1541";
-//			crc = 0xfb760019;
-//		break;
-//	}
-//
-//	auto roms = rom_fetcher({ {"Commodore1540", "the " + device_name + " ROM", device_name + ".bin", 16*1024, crc} });
-
-
-//			const std::string machine_name = "Vic20";
-//			std::vector<ROMMachine::ROM> rom_names = {
-//				{machine_name, "the VIC-20 BASIC ROM", "basic.bin", 8*1024, 0xdb4c43c1u}
-//			};
-//			switch(target.region) {
-//				default:
-//					rom_names.emplace_back(machine_name, "the English-language VIC-20 character ROM", "characters-english.bin", 4*1024, 0x83e032a6u);
-//					rom_names.emplace_back(machine_name, "the English-language PAL VIC-20 kernel ROM", "kernel-pal.bin", 8*1024, 0x4be07cb4u);
-//				break;
-//				case Analyser::Static::Commodore::Target::Region::American:
-//					rom_names.emplace_back(machine_name, "the English-language VIC-20 character ROM", "characters-english.bin", 4*1024, 0x83e032a6u);
-//					rom_names.emplace_back(machine_name, "the English-language NTSC VIC-20 kernel ROM", "kernel-ntsc.bin", 8*1024, 0xe5e7c174u);
-//				break;
-//				case Analyser::Static::Commodore::Target::Region::Danish:
-//					rom_names.emplace_back(machine_name, "the Danish VIC-20 character ROM", "characters-danish.bin", 4*1024, 0x7fc11454u);
-//					rom_names.emplace_back(machine_name, "the Danish VIC-20 kernel ROM", "kernel-danish.bin", 8*1024, 0x02adaf16u);
-//				break;
-//				case Analyser::Static::Commodore::Target::Region::Japanese:
-//					rom_names.emplace_back(machine_name, "the Japanese VIC-20 character ROM", "characters-japanese.bin", 4*1024, 0xfcfd8a4bu);
-//					rom_names.emplace_back(machine_name, "the Japanese VIC-20 kernel ROM", "kernel-japanese.bin", 8*1024, 0x336900d7u);
-//				break;
-//				case Analyser::Static::Commodore::Target::Region::Swedish:
-//					rom_names.emplace_back(machine_name, "the Swedish VIC-20 character ROM", "characters-swedish.bin", 4*1024, 0xd808551du);
-//					rom_names.emplace_back(machine_name, "the Swedish VIC-20 kernel ROM", "kernel-swedish.bin", 8*1024, 0xb2a60662u);
-//				break;
-//			}
-
 
 //			const std::string machine_name = "Oric";
 //			std::vector<ROMMachine::ROM> rom_names = { {machine_name, "the Oric colour ROM", "colour.rom", 128, 0xd50fca65u, true} };

--- a/Machines/Utility/ROMCatalogue.cpp
+++ b/Machines/Utility/ROMCatalogue.cpp
@@ -113,106 +113,46 @@ Description::Description(Name name) {
 	switch(name) {
 		default: assert(false);	break;
 
-		case Name::AMSDOS:
-			*this = Description(name, "AmstradCPC", "the Amstrad Disk Operating System", "amsdos.rom", 16*1024, 0x1fe22ecdu);
-		break;
-		case Name::CPC464Firmware:
-			*this = Description(name, "AmstradCPC", "the CPC 464 firmware", "os464.rom", 16*1024, 0x815752dfu);
-		break;
-		case Name::CPC464BASIC:
-			*this = Description(name, "AmstradCPC", "the CPC 464 BASIC ROM", "basic464.rom", 16*1024, 0x7d9a3bacu);
-		break;
-		case Name::CPC664Firmware:
-			*this = Description(name, "AmstradCPC", "the CPC 664 firmware", "os664.rom", 16*1024, 0x3f5a6dc4u);
-		break;
-		case Name::CPC664BASIC:
-			*this = Description(name, "AmstradCPC", "the CPC 664 BASIC ROM", "basic664.rom", 16*1024, 0x32fee492u);
-		break;
-		case Name::CPC6128Firmware:
-			*this = Description(name, "AmstradCPC", "the CPC 6128 firmware", "os664.rom", 16*1024, 0x0219bb74u);
-		break;
-		case Name::CPC6128BASIC:
-			*this = Description(name, "AmstradCPC", "the CPC 6128 BASIC ROM", "basic664.rom", 16*1024, 0xca6af63du);
+		case Name::AMSDOS:				*this = Description(name, "AmstradCPC", "the Amstrad Disk Operating System", "amsdos.rom", 16*1024, 0x1fe22ecdu);	break;
+		case Name::CPC464Firmware:		*this = Description(name, "AmstradCPC", "the CPC 464 firmware", "os464.rom", 16*1024, 0x815752dfu);					break;
+		case Name::CPC464BASIC:			*this = Description(name, "AmstradCPC", "the CPC 464 BASIC ROM", "basic464.rom", 16*1024, 0x7d9a3bacu);				break;
+		case Name::CPC664Firmware:		*this = Description(name, "AmstradCPC", "the CPC 664 firmware", "os664.rom", 16*1024, 0x3f5a6dc4u);					break;
+		case Name::CPC664BASIC:			*this = Description(name, "AmstradCPC", "the CPC 664 BASIC ROM", "basic664.rom", 16*1024, 0x32fee492u);				break;
+		case Name::CPC6128Firmware:		*this = Description(name, "AmstradCPC", "the CPC 6128 firmware", "os664.rom", 16*1024, 0x0219bb74u);				break;
+		case Name::CPC6128BASIC:		*this = Description(name, "AmstradCPC", "the CPC 6128 BASIC ROM", "basic664.rom", 16*1024, 0xca6af63du);			break;
+
+		case Name::AppleIIEnhancedE:	*this = Description(name, "AppleII", "the Enhanced Apple IIe ROM", "apple2e.rom", 32*1024, 0x65989942u);				break;
+		case Name::AppleIIe:			*this = Description(name, "AppleII", "the Apple IIe ROM", "apple2eu.rom", 32*1024, 0xe12be18du);						break;
+		case Name::AppleIIPlus:			*this = Description(name, "AppleII", "the Apple II+ ROM", "apple2.rom", 12*1024, 0xf66f9c26u);							break;
+		case Name::AppleIIOriginal:		*this = Description(name, "AppleII", "the original Apple II ROM", "apple2o.rom", 12*1024, 0xba210588u);					break;
+		case Name::AppleIICharacter:	*this = Description(name, "AppleII", "the basic Apple II character ROM", "apple2-character.rom", 2*1024, 0x64f415c6u);	break;
+		case Name::AppleIIeCharacter:	*this = Description(name, "AppleII", "the Apple IIe character ROM", "apple2eu-character.rom", 4*1024, 0x816a86f1u);		break;
+		case Name::AppleIIEnhancedECharacter:
+			*this = Description(name, "AppleII", "the Enhanced Apple IIe character ROM", "apple2e-character.rom", 4*1024, 0x2651014du);
 		break;
 
-//"AppleII"
-//	AppleIIOriginal,
-//	AppleIIPlus,
-//	AppleIICharacter,
-//	AppleIIe,
-//	AppleIIeCharacter,
-//	AppleIIEnhancedE,
-//	AppleIIEnhancedECharacter,
+		case Name::AppleIIgsROM00:	/* TODO */
+		case Name::AppleIIgsROM01:		*this = Description(name, "AppleIIgs", "the Apple IIgs ROM01", "apple2gs.rom", 128*1024, 0x42f124b0u);			break;
+		case Name::AppleIIgsROM03:		*this = Description(name, "AppleIIgs", "the Apple IIgs ROM03", "apple2gs.rom2", 256*1024, 0xde7ddf29u);			break;
+		case Name::AppleIIgsCharacter:	*this = Description(name, "AppleIIgs", "the Apple IIgs character ROM", "apple2gs.chr", 4*1024, 0x91e53cd8u);	break;
+		case AppleIIgsMicrocontrollerROM03:
+			*this = Description(name, "AppleIIgs", "the Apple IIgs ROM03 ADB microcontroller ROM", "341s0632-2", 4*1024, 0xe1c11fb0u);
+		break;
+
+		case Name::DiskIIBoot16Sector:
+			*this = Description(name, "DiskII", "the Disk II 16-sector boot ROM", "boot-16.rom", 256, 0xce7144f6u);
+		break;
+		case Name::DiskIIStateMachine16Sector:
+			*this = Description(name, "DiskII", "the Disk II 16-sector state machine ROM", "state-machine-16.rom", 256, std::initializer_list<uint32_t>{ 0x9796a238, 0xb72a2c70 } );
+		break;
+		case Name::DiskIIBoot13Sector:
+			*this = Description(name, "DiskII", "the Disk II 13-sector boot ROM", "boot-13.rom", 256, 0xd34eb2ffu);
+		break;
+		case Name::DiskIIStateMachine13Sector:
+			*this = Description(name, "DiskII", "the Disk II 13-sector state machine ROM", "state-machine-13.rom", 256, 0x62e22620u);
+		break;
 	}
-
-//					rom_descriptions.push_back(video_.rom_description(Video::VideoBase::CharacterROM::EnhancedIIe));
-//					rom_descriptions.emplace_back(machine_name, "the Enhanced Apple IIe ROM", "apple2e.rom", 32*1024, 0x65989942u);
-//					rom_descriptions.push_back(video_.rom_description(Video::VideoBase::CharacterROM::IIe));
-//					rom_descriptions.emplace_back(machine_name, "the Apple IIe ROM", "apple2eu.rom", 32*1024, 0xe12be18du);
-//					rom_descriptions.push_back(video_.rom_description(Video::VideoBase::CharacterROM::II));
-//					rom_descriptions.emplace_back(machine_name, "the Apple II+ ROM", "apple2.rom", 12*1024, 0xf66f9c26u);
-//					rom_descriptions.push_back(video_.rom_description(Video::VideoBase::CharacterROM::II));
-//					rom_descriptions.emplace_back(machine_name, "the original Apple II ROM", "apple2o.rom", 12*1024, 0xba210588u);
-
-//		roms = rom_fetcher({
-//			{"DiskII", "the Disk II 16-sector boot ROM", "boot-16.rom", 256, 0xce7144f6},
-//			{"DiskII", "the Disk II 16-sector state machine ROM", "state-machine-16.rom", 256, { 0x9796a238, 0xb72a2c70 } }
-//		});
-//		roms = rom_fetcher({
-//			{"DiskII", "the Disk II 13-sector boot ROM", "boot-13.rom", 256, 0xd34eb2ff},
-//			{"DiskII", "the Disk II 16-sector state machine ROM", "state-machine-16.rom", 256, { 0x9796a238, 0xb72a2c70 } }
-////			{"DiskII", "the Disk II 13-sector state machine ROM", "state-machine-13.rom", 256, 0x62e22620 }
-//		});
-
-
-//		enum class CharacterROM {
-//			/// The ROM that shipped with both the Apple II and the II+.
-//			II,
-//			/// The ROM that shipped with the original IIe.
-//			IIe,
-//			/// The ROM that shipped with the Enhanced IIe.
-//			EnhancedIIe,
-//			/// The ROM that shipped with the IIgs.
-//			IIgs
-//		};
-//
-//		/// @returns A file-level description of @c rom.
-//		static ROM::Name rom_name(CharacterROM rom) {
-//			const std::string machine_name = "AppleII";
-//			switch(rom) {
-//				case CharacterROM::II:
-//					return ROMMachine::ROM(machine_name, "the basic Apple II character ROM", "apple2-character.rom", 2*1024, 0x64f415c6);
-//
-//				case CharacterROM::IIe:
-//					return ROMMachine::ROM(machine_name, "the Apple IIe character ROM", "apple2eu-character.rom", 4*1024, 0x816a86f1);
-//
-//				default:	// To appease GCC.
-//				case CharacterROM::EnhancedIIe:
-//					return ROMMachine::ROM(machine_name, "the Enhanced Apple IIe character ROM", "apple2e-character.rom", 4*1024, 0x2651014d);
-//
-//				case CharacterROM::IIgs:
-//					return ROMMachine::ROM(machine_name, "the Apple IIgs character ROM", "apple2gs.chr", 4*1024, 0x91e53cd8);
-//			}
-//		}
 }
-
-
-//			const std::string machine_name = "AppleIIgs";
-//			switch(target.model) {
-//				case Target::Model::ROM00:
-//					/* TODO */
-//				case Target::Model::ROM01:
-//					rom_descriptions.emplace_back(machine_name, "the Apple IIgs ROM01", "apple2gs.rom", 128*1024, 0x42f124b0u);
-//				break;
-//
-//				case Target::Model::ROM03:
-//					rom_descriptions.emplace_back(machine_name, "the Apple IIgs ROM03", "apple2gs.rom2", 256*1024, 0xde7ddf29u);
-//				break;
-//			}
-//			rom_descriptions.push_back(video_->rom_description(Video::Video::CharacterROM::EnhancedIIe));
-//
-//			// TODO: pick a different ADB ROM for earlier machine revisions?
-//			rom_descriptions.emplace_back(machine_name, "the Apple IIgs ADB microcontroller ROM", "341s0632-2", 4*1024, 0xe1c11fb0u);
 
 
 //			switch(model) {

--- a/Machines/Utility/ROMCatalogue.cpp
+++ b/Machines/Utility/ROMCatalogue.cpp
@@ -219,9 +219,9 @@ Description::Description(Name name) {
 		case Name::PRESADFSSlot1:	*this = Description(name, "Electron", "the E00 ADFS ROM, first slot", "ADFS-E00_1.rom", 16*1024, 0x51523993u); 	break;
 		case Name::PRESADFSSlot2:	*this = Description(name, "Electron", "the E00 ADFS ROM, second slot", "ADFS-E00_2.rom", 16*1024, 0x8d17de0eu); break;
 		case Name::AcornADFS:		*this = Description(name, "Electron", "the Acorn ADFS ROM", "adfs.rom", 16*1024, 0x3289bdc6u); 					break;
-		case Name::Acorn1770DFS:	*this = Description(name, "Electron", "the 8kb Advanced Plus 6 ROM", "AP6v133.rom", 8*1024, 0xe0013cfcu); 		break;
+		case Name::Acorn1770DFS:	*this = Description(name, "Electron", "the 1770 DFS ROM", "DFS-1770-2.20.rom", 16*1024, 0xf3dc9bc5u);			break;
 		case Name::PRESAdvancedPlus6:
-			*this = Description(name, "Electron", "the 1770 DFS ROM", "DFS-1770-2.20.rom", 16*1024, 0xf3dc9bc5u);
+			*this = Description(name, "Electron", "the 8kb Advanced Plus 6 ROM", "AP6v133.rom", 8*1024, 0xe0013cfcu);
 		break;
 		case Name::AcornElectronMOS100:
 			*this = Description(name, "Electron", "the Electron MOS ROM v1.00", "os.rom", 16*1024, 0xbf63fb1fu);

--- a/Machines/Utility/ROMCatalogue.cpp
+++ b/Machines/Utility/ROMCatalogue.cpp
@@ -8,20 +8,23 @@
 
 #include "ROMCatalogue.hpp"
 
+#include <algorithm>
 #include <cassert>
 
 using namespace ROM;
 
-Request::Request(Name name, bool optional) :
-	node.name(name), node.is_optional(optional) {}
-
-Request::Request() {}
+Request::Request(Name name, bool optional) {
+	node.name = name;
+	node.is_optional = optional;
+}
 
 Request Request::operator &&(const Request &rhs) {
+	(void)rhs;
 	return *this;
 }
 
 Request Request::operator ||(const Request &rhs) {
+	(void)rhs;
 	return *this;
 }
 
@@ -31,12 +34,12 @@ bool Request::validate(const Map &) const {
 }
 
 std::vector<ROM::Description> Request::all_descriptions() const {
-	std::vector<Description>() result;
+	std::vector<Description> result;
 	node.add_descriptions(result);
 	return result;
 }
 
-void Request::Node::add_descriptions(std::vector<Description> &result) {
+void Request::Node::add_descriptions(std::vector<Description> &result) const {
 	if(type == Type::One) {
 		result.push_back(name);
 		return;
@@ -47,40 +50,53 @@ void Request::Node::add_descriptions(std::vector<Description> &result) {
 	}
 }
 
+std::optional<Description> Description::from_crc(uint32_t crc32) {
+	for(int name = 1; name <= SpectrumPlus3; name++) {
+		const Description candidate = Description(ROM::Name(name));
+
+		const auto found_crc = std::find(candidate.crc32s.begin(), candidate.crc32s.end(), crc32);
+		if(found_crc != candidate.crc32s.end()) {
+			return candidate;
+		}
+	}
+
+	return std::nullopt;
+}
+
 Description::Description(Name name) {
 	switch(name) {
 		default: assert(false);	break;
 
 		case Name::AMSDOS:
-			*this = Request("AmstradCPC", "the Amstrad Disk Operating System", "amsdos.rom", 16*1024, 0x1fe22ecdu);
+			*this = Description(name, "AmstradCPC", "the Amstrad Disk Operating System", "amsdos.rom", 16*1024, 0x1fe22ecdu);
 		break;
 		case Name::CPC464Firmware:
-			*this = Request("AmstradCPC", "the CPC 464 firmware", "os464.rom", 16*1024, 0x815752dfu);
+			*this = Description(name, "AmstradCPC", "the CPC 464 firmware", "os464.rom", 16*1024, 0x815752dfu);
 		break;
 		case Name::CPC464BASIC:
-			*this = Request("AmstradCPC", "the CPC 464 BASIC ROM", "basic464.rom", 16*1024, 0x7d9a3bacu);
+			*this = Description(name, "AmstradCPC", "the CPC 464 BASIC ROM", "basic464.rom", 16*1024, 0x7d9a3bacu);
 		break;
 		case Name::CPC664Firmware:
-			*this = Request("AmstradCPC", "the CPC 664 firmware", "os664.rom", 16*1024, 0x3f5a6dc4u);
+			*this = Description(name, "AmstradCPC", "the CPC 664 firmware", "os664.rom", 16*1024, 0x3f5a6dc4u);
 		break;
 		case Name::CPC664BASIC:
-			*this = Request("AmstradCPC", "the CPC 664 BASIC ROM", "basic664.rom", 16*1024, 0x32fee492u);
+			*this = Description(name, "AmstradCPC", "the CPC 664 BASIC ROM", "basic664.rom", 16*1024, 0x32fee492u);
 		break;
 		case Name::CPC6128Firmware:
-			*this = Request("AmstradCPC", "the CPC 6128 firmware", "os664.rom", 16*1024, 0x0219bb74u);
+			*this = Description(name, "AmstradCPC", "the CPC 6128 firmware", "os664.rom", 16*1024, 0x0219bb74u);
 		break;
 		case Name::CPC6128BASIC:
-			*this = Request("AmstradCPC", "the CPC 6128 BASIC ROM", "basic664.rom", 16*1024, 0xca6af63du);
+			*this = Description(name, "AmstradCPC", "the CPC 6128 BASIC ROM", "basic664.rom", 16*1024, 0xca6af63du);
 		break;
 
 //"AppleII"
-	AppleIIOriginal,
-	AppleIIPlus,
-	AppleIICharacter,
-	AppleIIe,
-	AppleIIeCharacter,
-	AppleIIEnhancedE,
-	AppleIIEnhancedECharacter,
+//	AppleIIOriginal,
+//	AppleIIPlus,
+//	AppleIICharacter,
+//	AppleIIe,
+//	AppleIIeCharacter,
+//	AppleIIEnhancedE,
+//	AppleIIEnhancedECharacter,
 	}
 
 //					rom_descriptions.push_back(video_.rom_description(Video::VideoBase::CharacterROM::EnhancedIIe));

--- a/Machines/Utility/ROMCatalogue.cpp
+++ b/Machines/Utility/ROMCatalogue.cpp
@@ -18,14 +18,29 @@ Request::Request(Name name, bool optional) {
 	node.is_optional = optional;
 }
 
+Request Request::append(Node::Type type, const Request &rhs) {
+	// Start with the easiest case: this is already an ::All request, and
+	// so is the new thing.
+	if(node.type == type && rhs.node.type == type) {
+		Request new_request = *this;
+		new_request.node.children.insert(new_request.node.children.end(), rhs.node.children.begin(), rhs.node.children.end());
+		return new_request;
+	}
+
+	// Otherwise create a new parent node.
+	Request parent;
+	parent.node.type = type;
+	parent.node.children.push_back(this->node);
+	parent.node.children.push_back(rhs.node);
+	return parent;
+}
+
 Request Request::operator &&(const Request &rhs) {
-	(void)rhs;
-	return *this;
+	return append(Node::Type::All, rhs);
 }
 
 Request Request::operator ||(const Request &rhs) {
-	(void)rhs;
-	return *this;
+	return append(Node::Type::Any, rhs);
 }
 
 bool Request::validate(Map &map) const {

--- a/Machines/Utility/ROMCatalogue.hpp
+++ b/Machines/Utility/ROMCatalogue.hpp
@@ -156,7 +156,9 @@ struct Request {
 
 	/// Inspects the ROMMap to ensure that it satisfies this @c Request.
 	/// @c returns @c true if the request is satisfied; @c false otherwise.
-	bool validate(const Map &) const;
+	///
+	/// All ROMs in the map will be resized to their idiomatic sizes.
+	bool validate(Map &) const;
 
 	std::vector<Description> all_descriptions() const;
 
@@ -174,6 +176,7 @@ struct Request {
 			std::vector<Node> children;
 
 			void add_descriptions(std::vector<Description> &) const;
+			bool validate(Map &) const;
 		};
 		Node node;
 };

--- a/Machines/Utility/ROMCatalogue.hpp
+++ b/Machines/Utility/ROMCatalogue.hpp
@@ -55,6 +55,7 @@ enum Name {
 	// Atari ST.
 	AtariSTTOS100,
 	AtariSTTOS104,
+	AtariSTEmuTOS192,
 
 	// ColecoVision.
 	ColecoVisionBIOS,
@@ -95,6 +96,9 @@ enum Name {
 	OricMicrodisc,
 	Oric8DOSBoot,
 
+	// Sinclair QL.
+	SinclairQLJS,
+
 	// Vic-20.
 	Vic20BASIC,
 	Vic20EnglishCharacters,
@@ -116,6 +120,7 @@ enum Name {
 	Spectrum128k,
 	SpecrumPlus2,
 	SpectrumPlus3,
+
 };
 
 using Map = std::map<ROM::Name, std::vector<uint8_t>>;

--- a/Machines/Utility/ROMCatalogue.hpp
+++ b/Machines/Utility/ROMCatalogue.hpp
@@ -1,0 +1,172 @@
+//
+//  ROMCatalogue.hpp
+//  Clock Signal
+//
+//  Created by Thomas Harte on 01/06/2021.
+//  Copyright © 2021 Thomas Harte. All rights reserved.
+//
+
+#ifndef ROMCatalogue_hpp
+#define ROMCatalogue_hpp
+
+#include <vector>
+
+namespace ROM {
+
+enum Name {
+	Invalid,
+
+	// Acorn.
+	AcornBASICII,
+	AcornElectronMOS100,
+	PRESADFSSlot1,
+	PRESADFSSlot2,
+	AcornADFS,
+	PRESAdvancedPlus6,
+	Acorn1770DFS,
+
+	// Amstrad CPC.
+	AMSDOS,
+	CPC464Firmware,		CPC464BASIC,
+	CPC664Firmware,		CPC664BASIC,
+	CPC6128Firmware,	CPC6128BASIC,
+
+	// Apple II.
+	AppleIIOriginal,
+	AppleIIPlus,
+	AppleIICharacter,
+	AppleIIe,
+	AppleIIeCharacter,
+	AppleIIEnhancedE,
+	AppleIIEnhancedECharacter,
+
+	// Apple IIgs.
+	AppleIIgsROM00,
+	AppleIIgsROM01,
+	AppleIIgsROM03,
+	AppleIIgsMicrocontrollerROM03,
+
+	// Atari ST.
+	AtariSTTOS100,
+	AtariSTTOS104,
+
+	// ColecoVision.
+	ColecoVisionBIOS,
+
+	// Commodore 1540/1541.
+	Commodore1540,
+	Commodore1541,
+
+	// Disk II.
+	DiskIIStateMachine16Sector,
+	DiskIIBoot16Sector,
+	DiskIIStateMachine13Sector,
+	DiskIIBoot13Sector,
+
+	// Macintosh.
+	Macintosh128k,
+	Macintosh512k,
+	MacintoshPlus,
+
+	// Master System.
+	MasterSystemJapaneseBIOS,
+	MasterSystemWesternBIOS,
+
+	// MSX.
+	MSXGenericBIOS,
+	MSXJapaneseBIOS,
+	MSXAmericanBIOS,
+	MSXEuropeanBIOS,
+	MSXDOS,
+
+	// Oric.
+	OricColourROM,
+	OricBASIC10,
+	OricBASIC11,
+	OricPravetzBASIC,
+	OricByteDrive500,
+	OricJasmin,
+	OricMicrodisc,
+	Oric8DOSBoot,
+
+	// Vic-20.
+	Vic20BASIC,
+	Vic20EnglishCharacters,
+	Vic20EnglishPALKernel,
+	Vic20EnglishNTSCKernel,
+	Vic20DanishCharacters,
+	Vic20DanishKernel,
+	Vic20JapaneseCharacters,
+	Vic20JapaneseKernel,
+	Vic20SwedishCharacters,
+	Vic20SwedishKernel,
+
+	// ZX80/81.
+	ZX80,
+	ZX81,
+
+	// ZX Spectrum.
+	Spectrum48k,
+	Spectrum128k,
+	SpecrumPlus2,
+	SpectrumPlus3,
+};
+
+using Map = std::map<ROM::Name, std::vector<uint8_t>>;
+
+struct Description {
+	/// The ROM's enum name.
+	Name name = Name::Invalid;
+	/// The machine with which this ROM is associated, in a form that is safe for using as
+	/// part of a file name.
+	std::string machine_name;
+	/// A descriptive name for this ROM, suitable for use in a bullet-point list, a bracket
+	/// clause, etc, e.g. "the Electron MOS 1.0".
+	std::string descriptive_name;
+	/// All idiomatic file name for this ROM, e.g. "os10.rom".
+	std::vector<std::string> file_names;
+	/// The expected size of this ROM in bytes, e.g. 32768.
+	size_t size = 0;
+	/// CRC32s for all known acceptable copies of this ROM; intended to allow a host platform
+	/// to test user-provided ROMs of unknown provenance. **Not** intended to be used
+	/// to exclude ROMs where the user's intent is otherwise clear.
+	std::vector<uint32_t> crc32s;
+
+	/// Constructs the @c Description that correlates to @c name.
+	Description(Name name);
+};
+
+struct Request {
+	Request(Name name, bool optional = false);
+	Request();
+
+	Request operator &&(const Request &);
+	Request operator ||(const Request &);
+
+	/// Inspects the ROMMap to ensure that it satisfies this @c Request.
+	/// @c returns @c true if the request is satisfied; @c false otherwise.
+	bool validate(const Map &) const;
+
+	std::vector<Description> all_descriptions() const;
+
+	private:
+		struct Node {
+			enum class Type {
+				Any, All, One
+			};
+			Type type = Type::One;
+			Name name = Name::Invalid;
+			/// @c true if this ROM is optional for machine startup. Generally indicates something
+			/// that would make emulation more accurate, but not sufficiently so to make it
+			/// a necessity.
+			bool is_optional = false;
+			std::vector<Node> children;
+
+			void add_descriptions(std::vector<Description> &);
+		};
+		Node node;
+};
+
+}
+
+#endif /* ROMCatalogue_hpp */

--- a/Machines/Utility/ROMCatalogue.hpp
+++ b/Machines/Utility/ROMCatalogue.hpp
@@ -9,6 +9,7 @@
 #ifndef ROMCatalogue_hpp
 #define ROMCatalogue_hpp
 
+#include <functional>
 #include <map>
 #include <optional>
 #include <string>
@@ -144,8 +145,12 @@ struct Description {
 
 	private:
 		template <typename FileNameT, typename CRC32T> Description(
-			Name name, std::string machine_name, std::string descriptive_name, FileNameT file_names, size_t size, CRC32T crc32s
-		) : name{name}, machine_name{machine_name}, descriptive_name{descriptive_name}, file_names{file_names}, size{size}, crc32s{crc32s} {}
+			Name name, std::string machine_name, std::string descriptive_name, FileNameT file_names, size_t size, CRC32T crc32s = CRC32T(0)
+		) : name{name}, machine_name{machine_name}, descriptive_name{descriptive_name}, file_names{file_names}, size{size}, crc32s{crc32s} {
+			if(this->crc32s.size() == 1 && !this->crc32s[0]) {
+				this->crc32s.clear();
+			}
+		}
 };
 
 struct Request {

--- a/Machines/Utility/ROMCatalogue.hpp
+++ b/Machines/Utility/ROMCatalogue.hpp
@@ -213,6 +213,10 @@ struct Request {
 		const std::function<void(LineItem, ListType, int level, const ROM::Description *, bool is_optional, size_t remaining)> &add_item
 	) const;
 
+	/// @returns a full bullet-pointed list of the requirements of this request, including
+	/// appropriate conjuntives.
+	std::wstring description(int description_flags, wchar_t bullet_point);
+
 	private:
 		struct Node {
 			enum class Type {

--- a/Machines/Utility/ROMCatalogue.hpp
+++ b/Machines/Utility/ROMCatalogue.hpp
@@ -18,7 +18,7 @@
 namespace ROM {
 
 enum Name {
-	Invalid,
+	None,
 
 	// Acorn.
 	AcornBASICII,
@@ -121,7 +121,7 @@ using Map = std::map<ROM::Name, std::vector<uint8_t>>;
 
 struct Description {
 	/// The ROM's enum name.
-	Name name = Name::Invalid;
+	Name name = Name::None;
 	/// The machine with which this ROM is associated, in a form that is safe for using as
 	/// part of a file name.
 	std::string machine_name;
@@ -177,13 +177,16 @@ struct Request {
 		const std::function<void(ROM::Request::ListType type, const ROM::Description &, bool is_optional, size_t remaining)> &add_item
 	) const;
 
+	Request subtract(const ROM::Map &map) const;
+	bool empty();
+
 	private:
 		struct Node {
 			enum class Type {
 				Any, All, One
 			};
 			Type type = Type::One;
-			Name name = Name::Invalid;
+			Name name = Name::None;
 			/// @c true if this ROM is optional for machine startup. Generally indicates something
 			/// that would make emulation more accurate, but not sufficiently so to make it
 			/// a necessity.
@@ -197,6 +200,7 @@ struct Request {
 				const std::function<void(void)> &exit_list,
 				const std::function<void(ROM::Request::ListType type, const ROM::Description &, bool is_optional, size_t remaining)> &add_item
 			) const;
+			bool subtract(const ROM::Map &map);
 		};
 		Node node;
 

--- a/Machines/Utility/ROMCatalogue.hpp
+++ b/Machines/Utility/ROMCatalogue.hpp
@@ -179,6 +179,8 @@ struct Request {
 			bool validate(Map &) const;
 		};
 		Node node;
+
+		Request append(Node::Type type, const Request &rhs);
 };
 
 }

--- a/Machines/Utility/ROMCatalogue.hpp
+++ b/Machines/Utility/ROMCatalogue.hpp
@@ -201,7 +201,7 @@ struct Request {
 		Any, All, Single
 	};
 	void visit(
-		const std::function<void(ListType)> &enter_list,
+		const std::function<void(ListType, size_t size)> &enter_list,
 		const std::function<void(void)> &exit_list,
 		const std::function<void(ROM::Request::ListType type, const ROM::Description &, bool is_optional, size_t remaining)> &add_item
 	) const;
@@ -214,7 +214,8 @@ struct Request {
 	) const;
 
 	/// @returns a full bullet-pointed list of the requirements of this request, including
-	/// appropriate conjuntives.
+	/// appropriate conjuntives. This text is intended to be glued to the end of an opening
+	/// portion of a sentence, e.g. "Please supply" + request.description(0, L'*').
 	std::wstring description(int description_flags, wchar_t bullet_point);
 
 	private:
@@ -233,7 +234,7 @@ struct Request {
 			void add_descriptions(std::vector<Description> &) const;
 			bool validate(Map &) const;
 			void visit(
-				const std::function<void(ListType)> &enter_list,
+				const std::function<void(ListType, size_t)> &enter_list,
 				const std::function<void(void)> &exit_list,
 				const std::function<void(ROM::Request::ListType type, const ROM::Description &, bool is_optional, size_t remaining)> &add_item
 			) const;

--- a/Machines/Utility/ROMCatalogue.hpp
+++ b/Machines/Utility/ROMCatalogue.hpp
@@ -163,6 +163,15 @@ struct Request {
 
 	std::vector<Description> all_descriptions() const;
 
+	enum class ListType {
+		Any, All, Single
+	};
+	void visit(
+		const std::function<void(ListType)> &enter_list,
+		const std::function<void(void)> &exit_list,
+		const std::function<void(ROM::Request::ListType type, const ROM::Description &, bool is_optional, size_t remaining)> &add_item
+	) const;
+
 	private:
 		struct Node {
 			enum class Type {
@@ -178,6 +187,11 @@ struct Request {
 
 			void add_descriptions(std::vector<Description> &) const;
 			bool validate(Map &) const;
+			void visit(
+				const std::function<void(ListType)> &enter_list,
+				const std::function<void(void)> &exit_list,
+				const std::function<void(ROM::Request::ListType type, const ROM::Description &, bool is_optional, size_t remaining)> &add_item
+			) const;
 		};
 		Node node;
 

--- a/Machines/Utility/ROMCatalogue.hpp
+++ b/Machines/Utility/ROMCatalogue.hpp
@@ -48,6 +48,7 @@ enum Name {
 	AppleIIgsROM01,
 	AppleIIgsROM03,
 	AppleIIgsMicrocontrollerROM03,
+	AppleIIgsCharacter,
 
 	// Atari ST.
 	AtariSTTOS100,

--- a/Machines/Utility/ROMCatalogue.hpp
+++ b/Machines/Utility/ROMCatalogue.hpp
@@ -9,6 +9,7 @@
 #ifndef ROMCatalogue_hpp
 #define ROMCatalogue_hpp
 
+#include <algorithm>
 #include <functional>
 #include <map>
 #include <optional>
@@ -244,6 +245,19 @@ struct Request {
 				const std::function<void(ROM::Request::ListType type, const ROM::Description &, bool is_optional, size_t remaining)> &add_item
 			) const;
 			bool subtract(const ROM::Map &map);
+			void sort() {
+				// Don't do a full sort, but move anything optional to the back.
+				// This makes them print more nicely; it's a human-facing tweak only.
+				ssize_t index = ssize_t(children.size() - 1);
+				bool has_seen_non_optional = false;
+				while(index >= 0) {
+					has_seen_non_optional |= !children[size_t(index)].is_optional;
+					if(children[size_t(index)].is_optional && has_seen_non_optional) {
+						std::rotate(children.begin() + index, children.begin() + index + 1, children.end());
+					}
+					--index;
+				}
+			}
 		};
 		Node node;
 

--- a/Machines/Utility/ROMCatalogue.hpp
+++ b/Machines/Utility/ROMCatalogue.hpp
@@ -206,6 +206,13 @@ struct Request {
 		const std::function<void(ROM::Request::ListType type, const ROM::Description &, bool is_optional, size_t remaining)> &add_item
 	) const;
 
+	enum class LineItem {
+		NewList, Description
+	};
+	void visit(
+		const std::function<void(LineItem, ListType, int level, const ROM::Description *, bool is_optional, size_t remaining)> &add_item
+	) const;
+
 	private:
 		struct Node {
 			enum class Type {

--- a/Machines/Utility/ROMCatalogue.hpp
+++ b/Machines/Utility/ROMCatalogue.hpp
@@ -10,6 +10,8 @@
 #define ROMCatalogue_hpp
 
 #include <map>
+#include <optional>
+#include <string>
 #include <vector>
 
 namespace ROM {
@@ -135,11 +137,19 @@ struct Description {
 
 	/// Constructs the @c Description that correlates to @c name.
 	Description(Name name);
+
+	/// Constructs the @c Description that correlates to @c crc32.
+	static std::optional<Description> from_crc(uint32_t crc32);
+
+	private:
+		template <typename FileNameT, typename CRC32T> Description(
+			Name name, std::string machine_name, std::string descriptive_name, FileNameT file_names, size_t size, CRC32T crc32s
+		) : name{name}, machine_name{machine_name}, descriptive_name{descriptive_name}, file_names{file_names}, size{size}, crc32s{crc32s} {}
 };
 
 struct Request {
 	Request(Name name, bool optional = false);
-	Request();
+	Request() {}
 
 	Request operator &&(const Request &);
 	Request operator ||(const Request &);
@@ -163,7 +173,7 @@ struct Request {
 			bool is_optional = false;
 			std::vector<Node> children;
 
-			void add_descriptions(std::vector<Description> &);
+			void add_descriptions(std::vector<Description> &) const;
 		};
 		Node node;
 };

--- a/Machines/Utility/ROMCatalogue.hpp
+++ b/Machines/Utility/ROMCatalogue.hpp
@@ -9,6 +9,7 @@
 #ifndef ROMCatalogue_hpp
 #define ROMCatalogue_hpp
 
+#include <map>
 #include <vector>
 
 namespace ROM {

--- a/Machines/Utility/ROMCatalogue.hpp
+++ b/Machines/Utility/ROMCatalogue.hpp
@@ -12,6 +12,7 @@
 #include <functional>
 #include <map>
 #include <optional>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -135,7 +136,7 @@ struct Description {
 	/// CRC32s for all known acceptable copies of this ROM; intended to allow a host platform
 	/// to test user-provided ROMs of unknown provenance. **Not** intended to be used
 	/// to exclude ROMs where the user's intent is otherwise clear.
-	std::vector<uint32_t> crc32s;
+	std::set<uint32_t> crc32s;
 
 	/// Constructs the @c Description that correlates to @c name.
 	Description(Name name);
@@ -145,13 +146,18 @@ struct Description {
 
 	private:
 		template <typename FileNameT, typename CRC32T> Description(
-			Name name, std::string machine_name, std::string descriptive_name, FileNameT file_names, size_t size, CRC32T crc32s = CRC32T(0)
+			Name name, std::string machine_name, std::string descriptive_name, FileNameT file_names, size_t size, CRC32T crc32s = uint32_t(0)
 		) : name{name}, machine_name{machine_name}, descriptive_name{descriptive_name}, file_names{file_names}, size{size}, crc32s{crc32s} {
-			if(this->crc32s.size() == 1 && !this->crc32s[0]) {
+			// Slightly lazy: deal with the case where the constructor wasn't provided with any
+			// CRCs by spotting that the set has exactly one member, which has value 0. The alternative
+			// would be to provide a partial specialisation that never put anything into the set.
+			if(this->crc32s.size() == 1 && !*this->crc32s.begin()) {
 				this->crc32s.clear();
 			}
 		}
 };
+
+std::vector<Description> all_descriptions();
 
 struct Request {
 	Request(Name name, bool optional = false);

--- a/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		4B049CDD1DA3C82F00322067 /* BCDTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B049CDC1DA3C82F00322067 /* BCDTest.swift */; };
 		4B051C912669C90B00CA44E8 /* ROMCatalogue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B051C5826670A9300CA44E8 /* ROMCatalogue.cpp */; };
 		4B051C922669C90B00CA44E8 /* ROMCatalogue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B051C5826670A9300CA44E8 /* ROMCatalogue.cpp */; };
+		4B051C93266D9D6900CA44E8 /* ROMImages in Resources */ = {isa = PBXBuildFile; fileRef = 4BC9DF441D044FCA00F44158 /* ROMImages */; };
 		4B05401E219D1618001BF69C /* ScanTarget.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B05401D219D1618001BF69C /* ScanTarget.cpp */; };
 		4B05401F219D1618001BF69C /* ScanTarget.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B05401D219D1618001BF69C /* ScanTarget.cpp */; };
 		4B055A7A1FAE78A00060FFFF /* SDL2.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4B055A771FAE78210060FFFF /* SDL2.framework */; };
@@ -568,7 +569,6 @@
 		4B9F11CA2272433900701480 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 4B69FB451C4D950F00B5F0AA /* libz.tbd */; };
 		4B9F11CC22729B3600701480 /* OPCLOGR2.BIN in Resources */ = {isa = PBXBuildFile; fileRef = 4B9F11CB22729B3500701480 /* OPCLOGR2.BIN */; };
 		4BA0F68E1EEA0E8400E9489E /* ZX8081.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4BA0F68C1EEA0E8400E9489E /* ZX8081.cpp */; };
-		4BA3189422E7A4CA00D18CFA /* ROMImages in Resources */ = {isa = PBXBuildFile; fileRef = 4BC9DF441D044FCA00F44158 /* ROMImages */; };
 		4BA61EB01D91515900B3C876 /* NSData+StdVector.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4BA61EAF1D91515900B3C876 /* NSData+StdVector.mm */; };
 		4BA91E1D216D85BA00F79557 /* MasterSystemVDPTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4BA91E1C216D85BA00F79557 /* MasterSystemVDPTests.mm */; };
 		4BAD13441FF709C700FD114A /* MSX.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0E61051FF34737002A9DBD /* MSX.cpp */; };
@@ -4768,7 +4768,7 @@
 				4BB73EAC1B587A5100552FC2 /* MainMenu.xib in Resources */,
 				4B8FE21D1DA19D5F0090D3CE /* QuickLoadCompositeOptions.xib in Resources */,
 				4B49F0A923346F7A0045E6A6 /* MacintoshOptions.xib in Resources */,
-				4BA3189422E7A4CA00D18CFA /* ROMImages in Resources */,
+				4B051C93266D9D6900CA44E8 /* ROMImages in Resources */,
 				4B79E4461E3AF38600141F11 /* floppy525.png in Resources */,
 				4BEEE6BD20DC72EB003723BF /* CompositeOptions.xib in Resources */,
 				4B1497981EE4B97F00CE2596 /* ZX8081Options.xib in Resources */,

--- a/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
@@ -1019,6 +1019,8 @@
 		4B047075201ABC180047AB0D /* Cartridge.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Cartridge.hpp; sourceTree = "<group>"; };
 		4B049CDC1DA3C82F00322067 /* BCDTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BCDTest.swift; sourceTree = "<group>"; };
 		4B04B65622A58CB40006AB58 /* Target.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Target.hpp; sourceTree = "<group>"; };
+		4B051C5826670A9300CA44E8 /* ROMCatalogue.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ROMCatalogue.cpp; sourceTree = "<group>"; };
+		4B051C5926670A9300CA44E8 /* ROMCatalogue.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = ROMCatalogue.hpp; sourceTree = "<group>"; };
 		4B05401D219D1618001BF69C /* ScanTarget.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ScanTarget.cpp; sourceTree = "<group>"; };
 		4B055A6A1FAE763F0060FFFF /* Clock Signal Kiosk */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "Clock Signal Kiosk"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4B055A771FAE78210060FFFF /* SDL2.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SDL2.framework; path = ../../../../Library/Frameworks/SDL2.framework; sourceTree = SOURCE_ROOT; };
@@ -2415,11 +2417,13 @@
 				4B055ABE1FAE98000060FFFF /* MachineForTarget.cpp */,
 				4B2B3A481F9B8FA70062DABF /* MemoryFuzzer.cpp */,
 				4BCE005B227D30CC000CA200 /* MemoryPacker.cpp */,
+				4B051C5826670A9300CA44E8 /* ROMCatalogue.cpp */,
 				4B17B58920A8A9D9007CCA8F /* StringSerialiser.cpp */,
 				4B2B3A471F9B8FA70062DABF /* Typer.cpp */,
 				4B055ABF1FAE98000060FFFF /* MachineForTarget.hpp */,
 				4B2B3A491F9B8FA70062DABF /* MemoryFuzzer.hpp */,
 				4BCE005C227D30CC000CA200 /* MemoryPacker.hpp */,
+				4B051C5926670A9300CA44E8 /* ROMCatalogue.hpp */,
 				4B17B58A20A8A9D9007CCA8F /* StringSerialiser.hpp */,
 				4B79A4FE1FC9082300EEDAD5 /* TypedDynamicMachine.hpp */,
 				4B2B3A4A1F9B8FA70062DABF /* Typer.hpp */,

--- a/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		4B0333AF2094081A0050B93D /* AppleDSK.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0333AD2094081A0050B93D /* AppleDSK.cpp */; };
 		4B0333B02094081A0050B93D /* AppleDSK.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0333AD2094081A0050B93D /* AppleDSK.cpp */; };
 		4B049CDD1DA3C82F00322067 /* BCDTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B049CDC1DA3C82F00322067 /* BCDTest.swift */; };
+		4B051C912669C90B00CA44E8 /* ROMCatalogue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B051C5826670A9300CA44E8 /* ROMCatalogue.cpp */; };
+		4B051C922669C90B00CA44E8 /* ROMCatalogue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B051C5826670A9300CA44E8 /* ROMCatalogue.cpp */; };
 		4B05401E219D1618001BF69C /* ScanTarget.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B05401D219D1618001BF69C /* ScanTarget.cpp */; };
 		4B05401F219D1618001BF69C /* ScanTarget.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B05401D219D1618001BF69C /* ScanTarget.cpp */; };
 		4B055A7A1FAE78A00060FFFF /* SDL2.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4B055A771FAE78210060FFFF /* SDL2.framework */; };
@@ -5325,6 +5327,7 @@
 				4BB0A65C2044FD3000FB3688 /* SN76489.cpp in Sources */,
 				4B595FAE2086DFBA0083CAA8 /* AudioToggle.cpp in Sources */,
 				4B0F1C242605996900B85C66 /* ZXSpectrumTAP.cpp in Sources */,
+				4B051C912669C90B00CA44E8 /* ROMCatalogue.cpp in Sources */,
 				4B055AB91FAE86170060FFFF /* Acorn.cpp in Sources */,
 				4B302185208A550100773308 /* DiskII.cpp in Sources */,
 				4B0F1BB32602645900B85C66 /* StaticAnalyser.cpp in Sources */,
@@ -5541,6 +5544,7 @@
 				4B15A9FC208249BB005E6C8D /* StaticAnalyser.cpp in Sources */,
 				4B5FADC01DE3BF2B00AEC565 /* Microdisc.cpp in Sources */,
 				4B0F1BDA2602FF9800B85C66 /* Video.cpp in Sources */,
+				4B051C922669C90B00CA44E8 /* ROMCatalogue.cpp in Sources */,
 				4B54C0C81F8D91E50050900F /* Keyboard.cpp in Sources */,
 				4B79A5011FC913C900EEDAD5 /* MSX.cpp in Sources */,
 				4BEE0A701D72496600532C7B /* PRG.cpp in Sources */,

--- a/OSBindings/Mac/Clock Signal.xcodeproj/xcshareddata/xcschemes/Clock Signal Kiosk.xcscheme
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/xcshareddata/xcschemes/Clock Signal Kiosk.xcscheme
@@ -58,7 +58,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--rompath=~/ROMs"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--has-disk-drive"

--- a/OSBindings/Mac/Clock Signal.xcodeproj/xcshareddata/xcschemes/Clock Signal Kiosk.xcscheme
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/xcshareddata/xcschemes/Clock Signal Kiosk.xcscheme
@@ -125,7 +125,7 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "--new=msx"
+            argument = "--new=electron"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/OSBindings/Mac/Clock Signal.xcodeproj/xcshareddata/xcschemes/Clock Signal Kiosk.xcscheme
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/xcshareddata/xcschemes/Clock Signal Kiosk.xcscheme
@@ -57,6 +57,14 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
+            argument = "--rompath=~/ROMs"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--has-disk-drive"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "&quot;/Users/thomasharte/Library/Mobile Documents/com~apple~CloudDocs/Desktop/Soft/Macintosh/MusicWorks 0.42.image&quot;"
             isEnabled = "NO">
          </CommandLineArgument>
@@ -106,7 +114,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--rompath=/Users/thomasharte/Projects/CLK/ROMImages"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--help"
@@ -117,7 +125,7 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "--new=oric"
+            argument = "--new=msx"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/OSBindings/Mac/Clock Signal.xcodeproj/xcshareddata/xcschemes/Clock Signal Kiosk.xcscheme
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/xcshareddata/xcschemes/Clock Signal Kiosk.xcscheme
@@ -125,7 +125,7 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "--new=msx"
+            argument = "--new=vic20"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/OSBindings/Mac/Clock Signal.xcodeproj/xcshareddata/xcschemes/Clock Signal Kiosk.xcscheme
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/xcshareddata/xcschemes/Clock Signal Kiosk.xcscheme
@@ -125,7 +125,7 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "--new=electron"
+            argument = "--new=msx"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/OSBindings/Mac/Clock Signal.xcodeproj/xcshareddata/xcschemes/Clock Signal Kiosk.xcscheme
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/xcshareddata/xcschemes/Clock Signal Kiosk.xcscheme
@@ -106,7 +106,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--rompath=/Users/thomasharte/Projects/CLK/ROMImages"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--help"

--- a/OSBindings/Mac/Clock Signal.xcodeproj/xcshareddata/xcschemes/Clock Signal Kiosk.xcscheme
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/xcshareddata/xcschemes/Clock Signal Kiosk.xcscheme
@@ -74,7 +74,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--new=amstradcpc"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "&quot;/Users/thomasharte/Library/Mobile Documents/com~apple~CloudDocs/Desktop/Soft/ColecoVision/Galaxian (1983)(Atari).col&quot;"
@@ -115,6 +115,10 @@
          <CommandLineArgument
             argument = "--model=cpc6128"
             isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--new=oric"
+            isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>
    </LaunchAction>

--- a/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
+++ b/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
@@ -137,22 +137,18 @@ class MachineDocument:
 		volumeSlider.floatValue = userDefaultsVolume()
 	}
 
-	private var missingROMs: [CSMissingROM] = []
+	private var missingROMs: String = ""
 	func configureAs(_ analysis: CSStaticAnalyser) {
 		self.machineDescription = analysis
 
 		actionLock.lock()
 		drawLock.lock()
 
-		let missingROMs = NSMutableArray()
 		if let machine = CSMachine(analyser: analysis, missingROMs: missingROMs) {
 			self.machine = machine
 			machine.setVolume(userDefaultsVolume())
 			setupMachineOutput()
 		} else {
-			// Store the selected machine and list of missing ROMs, and
-			// show the missing ROMs dialogue.
-			self.missingROMs = missingROMs.map({$0 as! CSMissingROM})
 			requestRoms()
 		}
 
@@ -437,30 +433,7 @@ class MachineDocument:
 	}
 
 	func populateMissingRomList() {
-		// Fill in the missing details; first build a list of all the individual
-		// line items.
-		var requestLines: [String] = []
-		for missingROM in self.missingROMs {
-			if let descriptiveName = missingROM.descriptiveName {
-				requestLines.append("• " + descriptiveName)
-			} else {
-				requestLines.append("• " + missingROM.fileName)
-			}
-		}
-
-		// Suffix everything up to the penultimate line with a semicolon;
-		// the penultimate line with a semicolon and a conjunctive; the final
-		// line with a full stop.
-		for x in 0 ..< requestLines.count {
-			if x < requestLines.count - 2 {
-				requestLines[x].append(";")
-			} else if x < requestLines.count - 1 {
-				requestLines[x].append("; and")
-			} else {
-				requestLines[x].append(".")
-			}
-		}
-		romRequesterText!.stringValue = self.romRequestBaseText + requestLines.joined(separator: "\n")
+		romRequesterText!.stringValue = self.romRequestBaseText + self.missingROMs
 	}
 
 	func romReceiverView(_ view: CSROMReceiverView, didReceiveFileAt URL: URL) {
@@ -474,7 +447,7 @@ class MachineDocument:
 			// Try to match by size first, CRC second. Accept that some ROMs may have
 			// some additional appended data. Arbitrarily allow them to be up to 10kb
 			// too large.
-			var index = 0
+/*			var index = 0
 			for missingROM in self.missingROMs {
 				if fileData.count >= missingROM.size && fileData.count < missingROM.size + 10*1024 {
 					// Trim to size.
@@ -506,7 +479,7 @@ class MachineDocument:
 				}
 
 				index = index + 1
-			}
+			}*/
 
 			if didInstallRom {
 				if self.missingROMs.count == 0 {

--- a/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
+++ b/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
@@ -415,6 +415,10 @@ class MachineDocument:
 	private var romRequestBaseText = ""
 
 	private func setRomRequesterIsVisible(_ visible : Bool) {
+		if !visible && self.romRequesterPanel == nil {
+			return;
+		}
+
 		if self.romRequesterPanel!.isVisible == visible {
 			return
 		}

--- a/OSBindings/Mac/Clock Signal/Machine/CSMachine.h
+++ b/OSBindings/Mac/Clock Signal/Machine/CSMachine.h
@@ -33,19 +33,13 @@ typedef NS_ENUM(NSInteger, CSMachineKeyboardInputMode) {
 	CSMachineKeyboardInputModeJoystick,
 };
 
-@interface CSMissingROM: NSObject
-@property (nonatomic, readonly, nonnull) NSString *machineName;
-@property (nonatomic, readonly, nonnull) NSString *fileName;
-@property (nonatomic, readonly, nullable) NSString *descriptiveName;
-@property (nonatomic, readonly) NSUInteger size;
-@property (nonatomic, readonly, nonnull) NSArray<NSNumber *> *crc32s;
-@end
-
 // Deliberately low; to ensure CSMachine has been declared as an @class already.
 #import "CSAtari2600.h"
 #import "CSZX8081.h"
 
 @interface CSMachine : NSObject
+
++ (BOOL)attemptInstallROM:(NSURL *)url;
 
 - (nonnull instancetype)init NS_UNAVAILABLE;
 
@@ -56,7 +50,7 @@ typedef NS_ENUM(NSInteger, CSMachineKeyboardInputMode) {
 	@param missingROMs An array that is filled with a list of ROMs that the machine requested but which
 		were not found; populated only if this `init` has failed.
 */
-- (nullable instancetype)initWithAnalyser:(nonnull CSStaticAnalyser *)result missingROMs:(nullable inout NSMutableArray<CSMissingROM *> *)missingROMs NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithAnalyser:(nonnull CSStaticAnalyser *)result missingROMs:(nullable inout NSString *)missingROMs NS_DESIGNATED_INITIALIZER;
 
 - (float)idealSamplingRateFromRange:(NSRange)range;
 @property (readonly, getter=isStereo) BOOL stereo;

--- a/OSBindings/Mac/Clock Signal/Machine/CSMachine.h
+++ b/OSBindings/Mac/Clock Signal/Machine/CSMachine.h
@@ -39,7 +39,7 @@ typedef NS_ENUM(NSInteger, CSMachineKeyboardInputMode) {
 
 @interface CSMachine : NSObject
 
-+ (BOOL)attemptInstallROM:(NSURL *)url;
++ (BOOL)attemptInstallROM:(nonnull NSURL *)url;
 
 - (nonnull instancetype)init NS_UNAVAILABLE;
 
@@ -50,7 +50,7 @@ typedef NS_ENUM(NSInteger, CSMachineKeyboardInputMode) {
 	@param missingROMs An array that is filled with a list of ROMs that the machine requested but which
 		were not found; populated only if this `init` has failed.
 */
-- (nullable instancetype)initWithAnalyser:(nonnull CSStaticAnalyser *)result missingROMs:(nullable inout NSString *)missingROMs NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithAnalyser:(nonnull CSStaticAnalyser *)result missingROMs:(nullable inout NSMutableString *)missingROMs NS_DESIGNATED_INITIALIZER;
 
 - (float)idealSamplingRateFromRange:(NSRange)range;
 @property (readonly, getter=isStereo) BOOL stereo;

--- a/OSBindings/Mac/Clock Signal/Machine/CSMachine.mm
+++ b/OSBindings/Mac/Clock Signal/Machine/CSMachine.mm
@@ -31,6 +31,8 @@
 
 #include <atomic>
 #include <bitset>
+#include <codecvt>
+#include <locale>
 
 @interface CSMachine() <CSScanTargetViewDisplayLinkDelegate>
 - (void)speaker:(Outputs::Speaker::Speaker *)speaker didCompleteSamples:(const int16_t *)samples length:(int)length;
@@ -113,28 +115,9 @@ struct ActivityObserver: public Activity::Observer {
 		ROM::Request missing_roms;
 		_machine.reset(Machine::MachineForTargets(_analyser.targets, CSROMFetcher(&missing_roms), error));
 		if(!_machine) {
-			// TODO.
-			[missingROMs appendFormat:@"Who told you?"];
-/*			for(const auto &missing_rom : missing_roms) {
-				CSMissingROM *rom = [[CSMissingROM alloc] init];
-
-				// Copy/convert the primitive fields.
-				rom.machineName = @(missing_rom.machine_name.c_str());
-				rom.fileName = @(missing_rom.file_name.c_str());
-				rom.descriptiveName = missing_rom.descriptive_name.empty() ? nil : @(missing_rom.descriptive_name.c_str());
-				rom.size = missing_rom.size;
-
-				// Convert the CRC list.
-				NSMutableArray<NSNumber *> *crc32s = [[NSMutableArray alloc] initWithCapacity:missing_rom.crc32s.size()];
-				for(const auto &crc : missing_rom.crc32s) {
-					[crc32s addObject:@(crc)];
-				}
-				rom.crc32s = crc32s;
-
-				// Add to the missing list.
-				[missingROMs addObject:rom];
-			}*/
-
+			std::wstring_convert<std::codecvt_utf8<wchar_t>> wstring_converter;
+			const std::wstring description = missing_roms.description(0, L'•');
+			[missingROMs appendString:[NSString stringWithUTF8String:wstring_converter.to_bytes(description).c_str()]];
 			return nil;
 		}
 

--- a/OSBindings/Mac/Clock Signal/Machine/CSMachine.mm
+++ b/OSBindings/Mac/Clock Signal/Machine/CSMachine.mm
@@ -113,6 +113,7 @@ struct ActivityObserver: public Activity::Observer {
 		ROM::Request missing_roms;
 		_machine.reset(Machine::MachineForTargets(_analyser.targets, CSROMFetcher(&missing_roms), error));
 		if(!_machine) {
+			// TODO.
 			[missingROMs appendFormat:@"Who told you?"];
 /*			for(const auto &missing_rom : missing_roms) {
 				CSMissingROM *rom = [[CSMissingROM alloc] init];

--- a/OSBindings/Mac/Clock Signal/Machine/CSMachine.mm
+++ b/OSBindings/Mac/Clock Signal/Machine/CSMachine.mm
@@ -132,10 +132,10 @@ struct ActivityObserver: public Activity::Observer {
 		_analyser = result;
 
 		Machine::Error error;
-		std::vector<ROMMachine::ROM> missing_roms;
+		ROM::Request missing_roms;
 		_machine.reset(Machine::MachineForTargets(_analyser.targets, CSROMFetcher(&missing_roms), error));
 		if(!_machine) {
-			for(const auto &missing_rom : missing_roms) {
+/*			for(const auto &missing_rom : missing_roms) {
 				CSMissingROM *rom = [[CSMissingROM alloc] init];
 
 				// Copy/convert the primitive fields.
@@ -153,7 +153,7 @@ struct ActivityObserver: public Activity::Observer {
 
 				// Add to the missing list.
 				[missingROMs addObject:rom];
-			}
+			}*/
 
 			return nil;
 		}

--- a/OSBindings/Mac/Clock Signal/Machine/CSMachine.mm
+++ b/OSBindings/Mac/Clock Signal/Machine/CSMachine.mm
@@ -74,28 +74,6 @@ struct ActivityObserver: public Activity::Observer {
 	__unsafe_unretained CSMachine *machine;
 };
 
-@interface CSMissingROM (/*Mutability*/)
-@property (nonatomic, nonnull, copy) NSString *machineName;
-@property (nonatomic, nonnull, copy) NSString *fileName;
-@property (nonatomic, nullable, copy) NSString *descriptiveName;
-@property (nonatomic, readwrite) NSUInteger size;
-@property (nonatomic, copy) NSArray<NSNumber *> *crc32s;
-@end
-
-@implementation CSMissingROM
-
-@synthesize machineName=_machineName;
-@synthesize fileName=_fileName;
-@synthesize descriptiveName=_descriptiveName;
-@synthesize size=_size;
-@synthesize crc32s=_crc32s;
-
-- (NSString *)description {
-	return [NSString stringWithFormat:@"%@/%@, %lu bytes, CRCs: %@", _fileName, _descriptiveName, (unsigned long)_size, _crc32s];
-}
-
-@end
-
 @implementation CSMachine {
 	SpeakerDelegate _speakerDelegate;
 	ActivityObserver _activityObserver;
@@ -126,7 +104,7 @@ struct ActivityObserver: public Activity::Observer {
 	NSMutableArray<dispatch_block_t> *_inputEvents;
 }
 
-- (instancetype)initWithAnalyser:(CSStaticAnalyser *)result missingROMs:(inout NSMutableArray<CSMissingROM *> *)missingROMs {
+- (instancetype)initWithAnalyser:(CSStaticAnalyser *)result missingROMs:(inout NSString *)missingROMs {
 	self = [super init];
 	if(self) {
 		_analyser = result;
@@ -781,6 +759,10 @@ struct ActivityObserver: public Activity::Observer {
 - (void)stop {
 	[_timer invalidate];
 	_timer = nil;
+}
+
++ (BOOL)attemptInstallROM:(NSURL *)url {
+	return CSInstallROM(url);
 }
 
 @end

--- a/OSBindings/Mac/Clock Signal/Machine/CSMachine.mm
+++ b/OSBindings/Mac/Clock Signal/Machine/CSMachine.mm
@@ -104,7 +104,7 @@ struct ActivityObserver: public Activity::Observer {
 	NSMutableArray<dispatch_block_t> *_inputEvents;
 }
 
-- (instancetype)initWithAnalyser:(CSStaticAnalyser *)result missingROMs:(inout NSString *)missingROMs {
+- (instancetype)initWithAnalyser:(CSStaticAnalyser *)result missingROMs:(inout NSMutableString *)missingROMs {
 	self = [super init];
 	if(self) {
 		_analyser = result;
@@ -113,6 +113,7 @@ struct ActivityObserver: public Activity::Observer {
 		ROM::Request missing_roms;
 		_machine.reset(Machine::MachineForTargets(_analyser.targets, CSROMFetcher(&missing_roms), error));
 		if(!_machine) {
+			[missingROMs appendFormat:@"Who told you?"];
 /*			for(const auto &missing_rom : missing_roms) {
 				CSMissingROM *rom = [[CSMissingROM alloc] init];
 

--- a/OSBindings/Mac/Clock Signal/Machine/CSROMFetcher.hpp
+++ b/OSBindings/Mac/Clock Signal/Machine/CSROMFetcher.hpp
@@ -9,3 +9,4 @@
 #include "ROMMachine.hpp"
 
 ROMMachine::ROMFetcher CSROMFetcher(ROM::Request *missing = nullptr);
+BOOL CSInstallROM(NSURL *);

--- a/OSBindings/Mac/Clock Signal/Machine/CSROMFetcher.hpp
+++ b/OSBindings/Mac/Clock Signal/Machine/CSROMFetcher.hpp
@@ -8,4 +8,4 @@
 
 #include "ROMMachine.hpp"
 
-ROMMachine::ROMFetcher CSROMFetcher(std::vector<ROMMachine::ROM> *missing_roms = nullptr);
+ROMMachine::ROMFetcher CSROMFetcher(ROM::Request *missing = nullptr);

--- a/OSBindings/Mac/Clock Signal/Machine/CSROMFetcher.mm
+++ b/OSBindings/Mac/Clock Signal/Machine/CSROMFetcher.mm
@@ -65,7 +65,8 @@ BOOL CSInstallROM(NSURL *url) {
 
 	// Copy the data to its destination and report success.
 	NSURL *const targetURL = [urlsFor(*target_description, target_description->file_names[0]) firstObject];
-	[data writeToURL:targetURL atomically:YES];
+	[[NSFileManager defaultManager] createDirectoryAtPath:targetURL.URLByDeletingLastPathComponent.path withIntermediateDirectories:YES attributes:nil error:nil];
+	[data writeToURL:targetURL atomically:NO];
 
 	return YES;
 }

--- a/OSBindings/Mac/Clock Signal/ROMRequester/ROMRequester.xib
+++ b/OSBindings/Mac/Clock Signal/ROMRequester/ROMRequester.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="18122" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="18122"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -20,18 +20,16 @@
             <windowStyleMask key="styleMask" titled="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="240" width="480" height="270"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="900"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1440"/>
             <view key="contentView" wantsLayer="YES" id="EiT-Mj-1SZ" customClass="CSROMReceiverView">
                 <rect key="frame" x="0.0" y="0.0" width="480" height="270"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5qG-I3-Qav">
-                        <rect key="frame" x="18" y="154" width="444" height="96"/>
+                        <rect key="frame" x="18" y="186" width="444" height="64"/>
                         <textFieldCell key="cell" enabled="NO" allowsUndo="NO" id="itJ-2T-0ia">
                             <font key="font" usesAppearanceFont="YES"/>
-                            <string key="title">Clock Signal requires you to provide images of the system ROMs for this machine. They will be stored permanently; you need do this only once.  Please drag and drop the following over this text:
-
-</string>
+                            <string key="title">Clock Signal requires you to provide images of the system ROMs for this machine. They will be stored permanently; you need do this only once.  Please drag and drop over this text</string>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>

--- a/OSBindings/Mac/Clock SignalTests/Bridges/C1540Bridge.mm
+++ b/OSBindings/Mac/Clock SignalTests/Bridges/C1540Bridge.mm
@@ -35,7 +35,8 @@ class VanillaSerialPort: public Commodore::Serial::Port {
 		_serialPort = std::make_shared<VanillaSerialPort>();
 
 		auto rom_fetcher = CSROMFetcher();
-		_c1540 = std::make_unique<Commodore::C1540::Machine>(Commodore::C1540::Personality::C1540, rom_fetcher);
+		auto roms = rom_fetcher(Commodore::C1540::Machine::rom_request(Commodore::C1540::Personality::C1540));
+		_c1540 = std::make_unique<Commodore::C1540::Machine>(Commodore::C1540::Personality::C1540, roms);
 		_c1540->set_serial_bus(_serialBus);
 		Commodore::Serial::AttachPortAndBus(_serialPort, _serialBus);
 	}

--- a/OSBindings/Mac/Clock SignalTests/EmuTOSTests.mm
+++ b/OSBindings/Mac/Clock SignalTests/EmuTOSTests.mm
@@ -103,21 +103,20 @@ class EmuTOS: public ComparativeBusHandler {
 	std::unique_ptr<EmuTOS> _machine;
 }
 
-- (void)testImage:(NSString *)image trace:(NSString *)trace length:(int)length {
-	const std::vector<ROMMachine::ROM> rom_names = {{"AtariST", "", image.UTF8String, 0, 0 }};
-	const auto roms = CSROMFetcher()(rom_names);
+- (void)testImage:(ROM::Name)name trace:(NSString *)trace length:(int)length {
+	const auto roms = CSROMFetcher()(ROM::Request(name));
 	NSString *const traceLocation = [[NSBundle bundleForClass:[self class]] pathForResource:trace ofType:@"trace.txt.gz"];
-	_machine = std::make_unique<EmuTOS>(*roms[0], traceLocation.fileSystemRepresentation);
+	_machine = std::make_unique<EmuTOS>(roms.find(name)->second, traceLocation.fileSystemRepresentation);
 	_machine->run_for(HalfCycles(length));
 }
 
 - (void)testEmuTOSStartup {
-	[self testImage:@"etos192uk.img" trace:@"etos192uk" length:313490];
+	[self testImage:ROM::Name::AtariSTEmuTOS192 trace:@"etos192uk" length:313490];
 	// TODO: assert that machine is now STOPped.
 }
 
 - (void)testTOSStartup {
-	[self testImage:@"tos100.img" trace:@"tos100" length:54011091];
+	[self testImage:ROM::Name::AtariSTTOS100 trace:@"tos100" length:54011091];
 }
 
 @end

--- a/OSBindings/Mac/Clock SignalTests/QLTests.mm
+++ b/OSBindings/Mac/Clock SignalTests/QLTests.mm
@@ -101,10 +101,11 @@ class QL: public ComparativeBusHandler {
 	Tests the progression of Clock Signal's 68000 through the Sinclair QL's ROM against a known-good trace.
 */
 - (void)testStartup {
-	const std::vector<ROMMachine::ROM> rom_names = {{"SinclairQL", "", "js.rom", 0, 0 }};
-	const auto roms = CSROMFetcher()(rom_names);
+	constexpr ROM::Name rom_name = ROM::Name::SinclairQLJS;
+	ROM::Request request(rom_name);
+	const auto roms = CSROMFetcher()(request);
 	NSString *const traceLocation = [[NSBundle bundleForClass:[self class]] pathForResource:@"qltrace" ofType:@".txt.gz"];
-	_machine = std::make_unique<QL>(*roms[0], traceLocation.UTF8String);
+	_machine = std::make_unique<QL>(roms.find(rom_name)->second, traceLocation.UTF8String);
 
 	// This is how many cycles it takes to exhaust the supplied trace file.
 	_machine->run_for(HalfCycles(23923180));

--- a/OSBindings/Mac/Clock SignalTests/SpectrumVideoContentionTests.mm
+++ b/OSBindings/Mac/Clock SignalTests/SpectrumVideoContentionTests.mm
@@ -24,8 +24,10 @@ struct ContentionAnalysis {
 	HalfCycles pattern[8];
 };
 
-template <Sinclair::ZXSpectrum::VideoTiming video_timing> ContentionAnalysis analyse() {
-	Sinclair::ZXSpectrum::Video<video_timing> video;
+using Timing = Sinclair::ZXSpectrum::Video::Timing;
+
+template <Timing video_timing> ContentionAnalysis analyse() {
+	Sinclair::ZXSpectrum::Video::Video<video_timing> video;
 	ContentionAnalysis analysis;
 
 	// Advance to the start of the first interrupt.
@@ -82,7 +84,7 @@ template <Sinclair::ZXSpectrum::VideoTiming video_timing> ContentionAnalysis ana
 }
 
 - (void)test48k {
-	const auto analysis = analyse<Sinclair::ZXSpectrum::VideoTiming::FortyEightK>();
+	const auto analysis = analyse<Timing::FortyEightK>();
 
 	// Check time from interrupt.
 	XCTAssertEqual(analysis.time_after_interrupt, 14335*2);
@@ -105,7 +107,7 @@ template <Sinclair::ZXSpectrum::VideoTiming video_timing> ContentionAnalysis ana
 }
 
 - (void)test128k {
-	const auto analysis = analyse<Sinclair::ZXSpectrum::VideoTiming::OneTwoEightK>();
+	const auto analysis = analyse<Timing::OneTwoEightK>();
 
 	// Check time from interrupt.
 	XCTAssertEqual(analysis.time_after_interrupt, 14361*2);
@@ -128,7 +130,7 @@ template <Sinclair::ZXSpectrum::VideoTiming video_timing> ContentionAnalysis ana
 }
 
 - (void)testPlus3 {
-	const auto analysis = analyse<Sinclair::ZXSpectrum::VideoTiming::Plus3>();
+	const auto analysis = analyse<Timing::Plus3>();
 
 	// Check time from interrupt.
 	XCTAssertEqual(analysis.time_after_interrupt, 14361*2);

--- a/OSBindings/Qt/mainwindow.cpp
+++ b/OSBindings/Qt/mainwindow.cpp
@@ -253,7 +253,7 @@ void MainWindow::launchMachine() {
 	const QStringList appDataLocations = QStandardPaths::standardLocations(QStandardPaths::AppDataLocation);
 
 	ROMMachine::ROMFetcher rom_fetcher = [&appDataLocations, this]
-		(const ROM::Request &roms) -> std::vector<std::unique_ptr<std::vector<uint8_t>>> {
+		(const ROM::Request &roms) -> ROM::Map {
 		ROM::Map results;
 
 		for(const auto &description: roms.all_descriptions()) {
@@ -270,7 +270,7 @@ void MainWindow::launchMachine() {
 				if(file) {
 					auto data = fileContentsAndClose(file);
 					if(data) {
-						results[description.name] = std::move(data);
+						results[description.name] = *data;
 						continue;
 					}
 				}

--- a/OSBindings/Qt/mainwindow.cpp
+++ b/OSBindings/Qt/mainwindow.cpp
@@ -721,16 +721,16 @@ void MainWindow::dropEvent(QDropEvent* event) {
 				CRC::CRC32 generator;
 				const uint32_t crc = generator.compute_crc(*contents);
 
-				std::optional<ROM::Description> target = ROM::Description::from_crc(crc);
-				if(target) {
+				std::optional<ROM::Description> target_rom = ROM::Description::from_crc(crc);
+				if(target_rom) {
 					// Ensure the destination folder exists.
-					const std::string path = appDataLocation + "/ROMImages/" + rom.machine_name;
+					const std::string path = appDataLocation + "/ROMImages/" + target_rom->machine_name;
 					const QDir dir(QString::fromStdString(path));
 					if (!dir.exists())
 						dir.mkpath(".");
 
 					// Write into place.
-					const std::string destination =  QDir::toNativeSeparators(QString::fromStdString(path+ "/" + rom.file_name)).toStdString();
+					const std::string destination =  QDir::toNativeSeparators(QString::fromStdString(path+ "/" + target_rom->file_names[0])).toStdString();
 					FILE *const target = fopen(destination.c_str(), "wb");
 					fwrite(contents->data(), 1, contents->size(), target);
 					fclose(target);

--- a/OSBindings/Qt/mainwindow.cpp
+++ b/OSBindings/Qt/mainwindow.cpp
@@ -251,33 +251,33 @@ void MainWindow::tile(const QMainWindow *previous) {
 
 void MainWindow::launchMachine() {
 	const QStringList appDataLocations = QStandardPaths::standardLocations(QStandardPaths::AppDataLocation);
-	missingRoms.clear();
 
 	ROMMachine::ROMFetcher rom_fetcher = [&appDataLocations, this]
-		(const std::vector<ROMMachine::ROM> &roms) -> std::vector<std::unique_ptr<std::vector<uint8_t>>> {
-		std::vector<std::unique_ptr<std::vector<uint8_t>>> results;
+		(const ROM::Request &roms) -> std::vector<std::unique_ptr<std::vector<uint8_t>>> {
+		ROM::Map results;
 
-		for(const auto &rom: roms) {
-			FILE *file = nullptr;
-			for(const auto &path: appDataLocations) {
-				const std::string source = path.toStdString() + "/ROMImages/" + rom.machine_name + "/" + rom.file_name;
-				const std::string nativeSource = QDir::toNativeSeparators(QString::fromStdString(source)).toStdString();
+		for(const auto &description: roms.all_descriptions()) {
+			for(const auto &file_name: description.file_names) {
+				FILE *file = nullptr;
+				for(const auto &path: appDataLocations) {
+					const std::string source = path.toStdString() + "/ROMImages/" + description.machine_name + "/" + file_name;
+					const std::string nativeSource = QDir::toNativeSeparators(QString::fromStdString(source)).toStdString();
 
-				file = fopen(nativeSource.c_str(), "rb");
-				if(file) break;
-			}
+					file = fopen(nativeSource.c_str(), "rb");
+					if(file) break;
+				}
 
-			if(file) {
-				auto data = fileContentsAndClose(file);
-				if(data) {
-					results.push_back(std::move(data));
-					continue;
+				if(file) {
+					auto data = fileContentsAndClose(file);
+					if(data) {
+						results[description.name] = std::move(data);
+						continue;
+					}
 				}
 			}
-
-			results.push_back(nullptr);
-			missingRoms.push_back(rom);
 		}
+
+		missingRoms = roms.subtract(results);
 		return results;
 	};
 	Machine::Error error;
@@ -291,22 +291,7 @@ void MainWindow::launchMachine() {
 
 				// Populate request text.
 				QString requestText = romRequestBaseText;
-				size_t index = 0;
-				for(const auto &rom: missingRoms) {
-					requestText += "• ";
-					requestText += rom.descriptive_name.c_str();
-
-					++index;
-					if(index == missingRoms.size()) {
-						requestText += ".\n";
-						continue;
-					}
-					if(index == missingRoms.size() - 1) {
-						requestText += "; and\n";
-						continue;
-					}
-					requestText += ";\n";
-				}
+				requestText += missingRoms.description(0, L'•');
 				ui->missingROMsBox->setPlainText(requestText);
 			} break;
 		}
@@ -736,28 +721,23 @@ void MainWindow::dropEvent(QDropEvent* event) {
 				CRC::CRC32 generator;
 				const uint32_t crc = generator.compute_crc(*contents);
 
-				bool wasUsed = false;
-				for(const auto &rom: missingRoms) {
-					if(std::find(rom.crc32s.begin(), rom.crc32s.end(), crc) != rom.crc32s.end()) {
-						foundROM = true;
+				std::optional<ROM::Description> target = ROM::Description::from_crc(crc);
+				if(target) {
+					// Ensure the destination folder exists.
+					const std::string path = appDataLocation + "/ROMImages/" + rom.machine_name;
+					const QDir dir(QString::fromStdString(path));
+					if (!dir.exists())
+						dir.mkpath(".");
 
-						// Ensure the destination folder exists.
-						const std::string path = appDataLocation + "/ROMImages/" + rom.machine_name;
-						const QDir dir(QString::fromStdString(path));
-						if (!dir.exists())
-							dir.mkpath(".");
+					// Write into place.
+					const std::string destination =  QDir::toNativeSeparators(QString::fromStdString(path+ "/" + rom.file_name)).toStdString();
+					FILE *const target = fopen(destination.c_str(), "wb");
+					fwrite(contents->data(), 1, contents->size(), target);
+					fclose(target);
 
-						// Write into place.
-						const std::string destination =  QDir::toNativeSeparators(QString::fromStdString(path+ "/" + rom.file_name)).toStdString();
-						FILE *const target = fopen(destination.c_str(), "wb");
-						fwrite(contents->data(), 1, contents->size(), target);
-						fclose(target);
-
-						wasUsed = true;
-					}
-				}
-
-				if(!wasUsed) {
+					// Note that at least one meaningful ROM was supplied.
+					foundROM = true;
+				} else {
 					if(!unusedRoms.isEmpty()) unusedRoms += ", ";
 					unusedRoms += url.fileName();
 				}

--- a/OSBindings/Qt/mainwindow.cpp
+++ b/OSBindings/Qt/mainwindow.cpp
@@ -291,7 +291,7 @@ void MainWindow::launchMachine() {
 
 				// Populate request text.
 				QString requestText = romRequestBaseText;
-				requestText += missingRoms.description(0, L'•');
+				requestText += QString::fromWCharArray(missingRoms.description(0, L'•').c_str());
 				ui->missingROMsBox->setPlainText(requestText);
 			} break;
 		}

--- a/OSBindings/Qt/mainwindow.h
+++ b/OSBindings/Qt/mainwindow.h
@@ -60,7 +60,7 @@ class MainWindow : public QMainWindow, public Outputs::Speaker::Speaker::Delegat
 		void launchMachine();
 
 		QString romRequestBaseText;
-		std::vector<ROMMachine::ROM> missingRoms;
+		ROM::Request missingRoms;
 
 		// File drag and drop is supported.
 		void dragEnterEvent(QDragEnterEvent* event) override;

--- a/OSBindings/Qt/mainwindow.ui
+++ b/OSBindings/Qt/mainwindow.ui
@@ -860,9 +860,7 @@
       <property name="plainText">
        <string>Clock Signal requires you to provide images of the system ROMs for this machine. They will be stored permanently; you need do this only once.
 
-Please drag and drop the following over this window:
-
-</string>
+Please drag and drop over this window</string>
       </property>
      </widget>
     </item>

--- a/OSBindings/SDL/main.cpp
+++ b/OSBindings/SDL/main.cpp
@@ -776,41 +776,41 @@ int main(int argc, char *argv[]) {
 				std::cerr << "Could not find system ROMs; please install to /usr/local/share/CLK/ or /usr/share/CLK/, or provide a --rompath, e.g. --rompath=~/ROMs." << std::endl;
 				std::cerr << "Needed — but didn't find — ";
 
-				int indentation_level = 0;
-				const auto indent = [&indentation_level] {
-					if(indentation_level) {
-						std::cerr << std::endl;
-						for(int c = 0; c < indentation_level; c++) std::cerr << '\t';
-						std::cerr << "* ";
-					}
-				};
-
-				missing_roms.visit([&indentation_level, indent] (ROM::Request::ListType type) {
-					indent();
-					switch(type) {
-						default:
-						case ROM::Request::ListType::All:	std::cerr << "all of:";		break;
-						case ROM::Request::ListType::Any:	std::cerr << "any of:";		break;
-					}
-					++indentation_level;
-				}, [&indentation_level] {
-					--indentation_level;
-				}, [&indentation_level, indent] (ROM::Request::ListType type, const ROM::Description &rom, bool is_optional, size_t remaining) {
-					indent();
-					if(is_optional) std::cerr << "optionally, ";
-
-					using DescriptionFlag = ROM::Description::DescriptionFlag;
-					std::cerr << rom.description(DescriptionFlag::Filename | DescriptionFlag::CRC);
-
-					if(remaining) {
-						std::cerr << ";";
-						if(remaining == 1) {
-							std::cerr << ((type == ROM::Request::ListType::All) ? " and" : " or");
+				missing_roms.visit(
+					[] (ROM::Request::LineItem item, ROM::Request::ListType type, int indentation_level, const ROM::Description *description, bool is_optional, size_t remaining) {
+						if(indentation_level) {
+							std::cerr << std::endl;
+							for(int c = 0; c < indentation_level; c++) std::cerr << '\t';
+							std::cerr << "* ";
 						}
-					} else {
-						std::cerr << ".";
+
+						switch(item) {
+							case ROM::Request::LineItem::NewList:
+								switch(type) {
+									default:
+									case ROM::Request::ListType::All:	std::cerr << "all of:";		break;
+									case ROM::Request::ListType::Any:	std::cerr << "any of:";		break;
+								}
+							break;
+
+							case ROM::Request::LineItem::Description:
+								if(is_optional) std::cerr << "optionally, ";
+
+								using DescriptionFlag = ROM::Description::DescriptionFlag;
+								std::cerr << description->description(DescriptionFlag::Filename | DescriptionFlag::CRC);
+
+								if(remaining) {
+									std::cerr << ";";
+									if(remaining == 1) {
+										std::cerr << ((type == ROM::Request::ListType::All) ? " and" : " or");
+									}
+								} else {
+									std::cerr << ".";
+								}
+							break;
+						}
 					}
-				});
+				);
 
 				std::cerr << std::endl << std::endl << "Searched unsuccessfully: ";
 				bool is_first = true;

--- a/OSBindings/SDL/main.cpp
+++ b/OSBindings/SDL/main.cpp
@@ -774,7 +774,7 @@ int main(int argc, char *argv[]) {
 			default: break;
 			case ::Machine::Error::MissingROM: {
 				std::cerr << "Could not find system ROMs; please install to /usr/local/share/CLK/ or /usr/share/CLK/, or provide a --rompath, e.g. --rompath=~/ROMs." << std::endl;
-				std::cerr << "Needed — but didn't find — ";
+				std::cerr << "Needed — but didn't find —";
 
 				using DescriptionFlag = ROM::Description::DescriptionFlag;
 				std::wcerr << missing_roms.description(DescriptionFlag::Filename | DescriptionFlag::CRC, L'*');

--- a/OSBindings/SDL/main.cpp
+++ b/OSBindings/SDL/main.cpp
@@ -776,41 +776,8 @@ int main(int argc, char *argv[]) {
 				std::cerr << "Could not find system ROMs; please install to /usr/local/share/CLK/ or /usr/share/CLK/, or provide a --rompath, e.g. --rompath=~/ROMs." << std::endl;
 				std::cerr << "Needed — but didn't find — ";
 
-				missing_roms.visit(
-					[] (ROM::Request::LineItem item, ROM::Request::ListType type, int indentation_level, const ROM::Description *description, bool is_optional, size_t remaining) {
-						if(indentation_level) {
-							std::cerr << std::endl;
-							for(int c = 0; c < indentation_level; c++) std::cerr << '\t';
-							std::cerr << "* ";
-						}
-
-						switch(item) {
-							case ROM::Request::LineItem::NewList:
-								switch(type) {
-									default:
-									case ROM::Request::ListType::All:	std::cerr << "all of:";		break;
-									case ROM::Request::ListType::Any:	std::cerr << "any of:";		break;
-								}
-							break;
-
-							case ROM::Request::LineItem::Description:
-								if(is_optional) std::cerr << "optionally, ";
-
-								using DescriptionFlag = ROM::Description::DescriptionFlag;
-								std::cerr << description->description(DescriptionFlag::Filename | DescriptionFlag::CRC);
-
-								if(remaining) {
-									std::cerr << ";";
-									if(remaining == 1) {
-										std::cerr << ((type == ROM::Request::ListType::All) ? " and" : " or");
-									}
-								} else {
-									std::cerr << ".";
-								}
-							break;
-						}
-					}
-				);
+				using DescriptionFlag = ROM::Description::DescriptionFlag;
+				std::wcerr << missing_roms.description(DescriptionFlag::Filename | DescriptionFlag::CRC, L'*');
 
 				std::cerr << std::endl << std::endl << "Searched unsuccessfully: ";
 				bool is_first = true;

--- a/OSBindings/SDL/main.cpp
+++ b/OSBindings/SDL/main.cpp
@@ -694,12 +694,10 @@ int main(int argc, char *argv[]) {
 	//	/usr/local/share/CLK/[system];
 	//	/usr/share/CLK/[system]; or
 	//	[user-supplied path]/[system]
-	ROM::Request requested_roms;
+	ROM::Request missing_roms;
 	std::vector<std::string> checked_paths;
-	ROMMachine::ROMFetcher rom_fetcher = [&requested_roms, &arguments, &checked_paths]
+	ROMMachine::ROMFetcher rom_fetcher = [&missing_roms, &arguments, &checked_paths]
 		(const ROM::Request &roms) -> ROM::Map {
-			requested_roms = roms;
-
 			std::vector<std::string> paths = {
 				"/usr/local/share/CLK/",
 				"/usr/share/CLK/"
@@ -756,6 +754,7 @@ int main(int argc, char *argv[]) {
 				}
 			}
 
+			missing_roms = roms.subtract(results);
 			return results;
 		};
 
@@ -775,7 +774,7 @@ int main(int argc, char *argv[]) {
 			default: break;
 			case ::Machine::Error::MissingROM: {
 				std::cerr << "Could not find system ROMs; please install to /usr/local/share/CLK/ or /usr/share/CLK/, or provide a --rompath, e.g. --rompath=~/ROMs." << std::endl;
-				std::cerr << "Needed ";
+				std::cerr << "Needed — but didn't find — ";
 
 				int indentation_level = 0;
 				const auto indent = [&indentation_level] {
@@ -786,7 +785,7 @@ int main(int argc, char *argv[]) {
 					}
 				};
 
-				requested_roms.visit([&indentation_level, indent] (ROM::Request::ListType type) {
+				missing_roms.visit([&indentation_level, indent] (ROM::Request::ListType type) {
 					indent();
 					switch(type) {
 						default:

--- a/OSBindings/SDL/main.cpp
+++ b/OSBindings/SDL/main.cpp
@@ -799,18 +799,25 @@ int main(int argc, char *argv[]) {
 				}, [&indentation_level, indent] (ROM::Request::ListType type, const ROM::Description &rom, bool is_optional, size_t remaining) {
 					indent();
 					if(is_optional) std::cerr << "optionally, ";
-					std::cerr << rom.machine_name << '/' << rom.file_names[0] << " (";
-					if(!rom.descriptive_name.empty()) {
-						std::cerr << rom.descriptive_name << "; ";
+					std::cerr << rom.machine_name << '/' << rom.file_names[0];
+
+					if(!rom.descriptive_name.empty() || !rom.crc32s.empty()) {
+						std::cerr << " (";
+						if(!rom.descriptive_name.empty()) {
+							std::cerr << rom.descriptive_name;
+							if(!rom.crc32s.empty()) std::cerr << "; ";
+						}
+						if(!rom.crc32s.empty()) {
+							std::cerr << ((rom.crc32s.size() > 1) ? "usual crc32s: " : "usual crc32: ");
+							bool is_first = true;
+							for(const auto crc32: rom.crc32s) {
+								if(!is_first) std::cerr << ", ";
+								is_first = false;
+								std::cerr << std::hex << std::setfill('0') << std::setw(8) << crc32;
+							}
+						}
+						std::cerr << ")";
 					}
-					std::cerr << ((rom.crc32s.size() > 1) ? "usual crc32s: " : "usual crc32: ");
-					bool is_first = true;
-					for(const auto crc32: rom.crc32s) {
-						if(!is_first) std::cerr << ", ";
-						is_first = false;
-						std::cerr << std::hex << std::setfill('0') << std::setw(8) << crc32;
-					}
-					std::cerr << ")";
 
 					if(remaining) {
 						std::cerr << ";";

--- a/OSBindings/SDL/main.cpp
+++ b/OSBindings/SDL/main.cpp
@@ -798,25 +798,9 @@ int main(int argc, char *argv[]) {
 				}, [&indentation_level, indent] (ROM::Request::ListType type, const ROM::Description &rom, bool is_optional, size_t remaining) {
 					indent();
 					if(is_optional) std::cerr << "optionally, ";
-					std::cerr << rom.machine_name << '/' << rom.file_names[0];
 
-					if(!rom.descriptive_name.empty() || !rom.crc32s.empty()) {
-						std::cerr << " (";
-						if(!rom.descriptive_name.empty()) {
-							std::cerr << rom.descriptive_name;
-							if(!rom.crc32s.empty()) std::cerr << "; ";
-						}
-						if(!rom.crc32s.empty()) {
-							std::cerr << ((rom.crc32s.size() > 1) ? "usual crc32s: " : "usual crc32: ");
-							bool is_first = true;
-							for(const auto crc32: rom.crc32s) {
-								if(!is_first) std::cerr << ", ";
-								is_first = false;
-								std::cerr << std::hex << std::setfill('0') << std::setw(8) << crc32;
-							}
-						}
-						std::cerr << ")";
-					}
+					using DescriptionFlag = ROM::Description::DescriptionFlag;
+					std::cerr << rom.description(DescriptionFlag::Filename | DescriptionFlag::CRC);
 
 					if(remaining) {
 						std::cerr << ";";


### PR DESCRIPTION
ROMs can be optional, and chained together in AND or OR combinations. A central catalogue knows the definitions of all ROMs.

So:

Error reports of missing ROMs can be more accurate. For the MSX it can be clear that the generic BIOS is an alternative option to the region-specific one. For the Oric the colour ROM can be purely optional.

The user can provide as much as they wish during drag-and-drop ROM installations. E.g. when starting a Macintosh 128k for the first time the user can just drag and drop all the Macintosh ROMs they have and the emulator will keep all that match any currently-supported model.

i.e. resolves #942 while also cleaning up some of my mental backlog.