### PR TITLE
Classify some LEDs as 'persistent'

### DIFF
--- a/Activity/Observer.hpp
+++ b/Activity/Observer.hpp
@@ -23,8 +23,12 @@ namespace Activity {
 */
 class Observer {
 	public:
+		enum LEDPresentation: uint8_t {
+			Persistent = (1 << 0),
+		};
+
 		/// Announces to the receiver that there is an LED of name @c name.
-		virtual void register_led([[maybe_unused]] const std::string &name) {}
+		virtual void register_led([[maybe_unused]] const std::string &name, [[maybe_unused]] uint8_t presentation = 0) {}
 
 		/// Announces to the receiver that there is a drive of name @c name.
 		///

--- a/Activity/Observer.hpp
+++ b/Activity/Observer.hpp
@@ -23,7 +23,10 @@ namespace Activity {
 */
 class Observer {
 	public:
+		/// Provides hints as to the sort of information presented on an LED.
 		enum LEDPresentation: uint8_t {
+			/// This LED informs the user of some sort of persistent state, e.g. scroll lock.
+			/// If this flag is absent then the LED describes an ephemeral state, such as media access.
 			Persistent = (1 << 0),
 		};
 

--- a/Analyser/Static/Enterprise/StaticAnalyser.cpp
+++ b/Analyser/Static/Enterprise/StaticAnalyser.cpp
@@ -48,9 +48,10 @@ Analyser::Static::TargetList Analyser::Static::Enterprise::GetTargets(const Medi
 		auto volume = Storage::Disk::FAT::GetVolume(media.disks.front());
 		if(volume) {
 			// If there's an EXDOS.INI then this disk should be able to boot itself.
-			// If not but if there's only one .COM or .BAS, automatically load that.
-			// Failing that, issue a :DIR and give the user a clue as to how to load.
-			const Storage::Disk::FAT::File *selected_file = nullptr;
+			// If not but if there's only one visible .COM or .BAS, automatically load
+			// that. Otherwise, issue a :DIR.
+			using File = Storage::Disk::FAT::File;
+			const File *selected_file = nullptr;
 			bool has_exdos_ini = false;
 			bool did_pick_file = false;
 			for(const auto &file: (*volume).root_directory) {
@@ -59,7 +60,9 @@ Analyser::Static::TargetList Analyser::Static::Enterprise::GetTargets(const Medi
 					break;
 				}
 
-				if(insensitive_equal(file.extension, "com") || insensitive_equal(file.extension, "bas")) {
+				if(!(file.attributes & File::Attribute::Hidden) &&
+					(insensitive_equal(file.extension, "com") || insensitive_equal(file.extension, "bas"))
+				) {
 					did_pick_file = !selected_file;
 					selected_file = &file;
 				}

--- a/Machines/AmstradCPC/AmstradCPC.cpp
+++ b/Machines/AmstradCPC/AmstradCPC.cpp
@@ -1119,7 +1119,7 @@ template <bool has_fdc> class ConcreteMachine:
 		}
 
 		HalfCycles get_typer_frequency() const final {
-			return Cycles(80'000);	// Perform one key transition per frame.
+			return Cycles(160'000);	// Perform one key transition per frame and a half.
 		}
 
 		// See header; sets a key as either pressed or released.

--- a/Machines/AmstradCPC/Keyboard.hpp
+++ b/Machines/AmstradCPC/Keyboard.hpp
@@ -40,7 +40,7 @@ struct KeyboardMapper: public MachineTypes::MappedKeyboardMachine::KeyboardMappe
 struct CharacterMapper: public ::Utility::CharacterMapper {
 	const uint16_t *sequence_for_character(char character) const override;
 
-	bool needs_pause_after_reset_all_keys() const override	{ return false; }
+	bool needs_pause_after_reset_all_keys() const override	{ return true; }
 	bool needs_pause_after_key(uint16_t key) const override;
 };
 

--- a/Machines/Electron/Electron.cpp
+++ b/Machines/Electron/Electron.cpp
@@ -607,7 +607,7 @@ template <bool has_scsi_bus> class ConcreteMachine:
 		void set_activity_observer(Activity::Observer *observer) final {
 			activity_observer_ = observer;
 			if(activity_observer_) {
-				activity_observer_->register_led(caps_led);
+				activity_observer_->register_led(caps_led, Activity::Observer::LEDPresentation::Persistent);
 				activity_observer_->set_led_status(caps_led, caps_led_state_);
 			}
 

--- a/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
+++ b/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
@@ -674,8 +674,8 @@ class MachineDocument:
 
 			// Apply labels and create leds entries.
 			for c in 0 ..< leds.count {
-				textFields[c].stringValue = leds[c]
-				self.leds[leds[c]] = LED(levelIndicator: activityIndicators[c])
+				textFields[c].stringValue = leds[c].name
+				self.leds[leds[c].name] = LED(levelIndicator: activityIndicators[c])
 			}
 
 			// Create a fader.

--- a/OSBindings/Mac/Clock Signal/Machine/CSMachine.h
+++ b/OSBindings/Mac/Clock Signal/Machine/CSMachine.h
@@ -33,6 +33,11 @@ typedef NS_ENUM(NSInteger, CSMachineKeyboardInputMode) {
 	CSMachineKeyboardInputModeJoystick,
 };
 
+@interface CSMachineLED: NSObject
+@property(nonatomic, nonnull, readonly) NSString *name;
+@property(nonatomic, readonly) BOOL isPersisent;
+@end
+
 // Deliberately low; to ensure CSMachine has been declared as an @class already.
 #import "CSAtari2600.h"
 #import "CSZX8081.h"
@@ -99,7 +104,7 @@ typedef NS_ENUM(NSInteger, CSMachineKeyboardInputMode) {
 @property (nonatomic, nullable) CSJoystickManager *joystickManager;
 
 // LED list.
-@property (nonatomic, readonly, nonnull) NSArray<NSString *> *leds;
+@property (nonatomic, readonly, nonnull) NSArray<CSMachineLED *> *leds;
 
 // Special-case accessors; undefined behaviour if accessed for a machine not of the corresponding type.
 @property (nonatomic, readonly, nullable) CSAtari2600 *atari2600;

--- a/OSBindings/Mac/Clock Signal/Machine/CSMachine.mm
+++ b/OSBindings/Mac/Clock Signal/Machine/CSMachine.mm
@@ -61,7 +61,7 @@ struct SpeakerDelegate: public Outputs::Speaker::Speaker::Delegate, public LockP
 };
 
 struct ActivityObserver: public Activity::Observer {
-	void register_led(const std::string &name) final {
+	void register_led(const std::string &name, uint8_t) final {
 		[machine addLED:[NSString stringWithUTF8String:name.c_str()]];
 	}
 

--- a/OSBindings/Mac/Clock Signal/Machine/CSMachine.mm
+++ b/OSBindings/Mac/Clock Signal/Machine/CSMachine.mm
@@ -37,7 +37,7 @@
 @interface CSMachine() <CSScanTargetViewDisplayLinkDelegate>
 - (void)speaker:(Outputs::Speaker::Speaker *)speaker didCompleteSamples:(const int16_t *)samples length:(int)length;
 - (void)speakerDidChangeInputClock:(Outputs::Speaker::Speaker *)speaker;
-- (void)addLED:(NSString *)led;
+- (void)addLED:(NSString *)led isPersistent:(BOOL)isPersistent;
 @end
 
 struct LockProtectedDelegate {
@@ -61,8 +61,8 @@ struct SpeakerDelegate: public Outputs::Speaker::Speaker::Delegate, public LockP
 };
 
 struct ActivityObserver: public Activity::Observer {
-	void register_led(const std::string &name, uint8_t) final {
-		[machine addLED:[NSString stringWithUTF8String:name.c_str()]];
+	void register_led(const std::string &name, uint8_t flags) final {
+		[machine addLED:[NSString stringWithUTF8String:name.c_str()] isPersistent:flags & Activity::Observer::LEDPresentation::Persistent];
 	}
 
 	void set_led_status(const std::string &name, bool lit) final {
@@ -76,6 +76,19 @@ struct ActivityObserver: public Activity::Observer {
 	__unsafe_unretained CSMachine *machine;
 };
 
+@implementation CSMachineLED
+
+- (instancetype)initWithName:(NSString *)name isPersistent:(BOOL)isPersistent {
+	self = [super init];
+	if(self) {
+		_name = name;
+		_isPersisent = isPersistent;
+	}
+	return self;
+}
+
+@end
+
 @implementation CSMachine {
 	SpeakerDelegate _speakerDelegate;
 	ActivityObserver _activityObserver;
@@ -86,7 +99,7 @@ struct ActivityObserver: public Activity::Observer {
 	MachineTypes::JoystickMachine *_joystickMachine;
 
 	CSJoystickManager *_joystickManager;
-	NSMutableArray<NSString *> *_leds;
+	NSMutableArray<CSMachineLED *> *_leds;
 
 	CSHighPrecisionTimer *_timer;
 	std::atomic_flag _isUpdating;
@@ -623,11 +636,11 @@ struct ActivityObserver: public Activity::Observer {
 
 #pragma mark - Activity observation
 
-- (void)addLED:(NSString *)led {
-	[_leds addObject:led];
+- (void)addLED:(NSString *)led isPersistent:(BOOL)isPersistent {
+	[_leds addObject:[[CSMachineLED alloc] initWithName:led isPersistent:isPersistent]];
 }
 
-- (NSArray<NSString *> *)leds {
+- (NSArray<CSMachineLED *> *)leds {
 	return _leds;
 }
 

--- a/OSBindings/Qt/mainwindow.cpp
+++ b/OSBindings/Qt/mainwindow.cpp
@@ -1323,7 +1323,7 @@ void MainWindow::addActivityObserver() {
 	activitySource->set_activity_observer(this);
 }
 
-void MainWindow::register_led(const std::string &name) {
+void MainWindow::register_led(const std::string &name, uint8_t) {
 	std::lock_guard guard(ledStatusesLock);
 	ledStatuses[name] = false;
 	QMetaObject::invokeMethod(this, "updateStatusBarText");

--- a/OSBindings/Qt/mainwindow.h
+++ b/OSBindings/Qt/mainwindow.h
@@ -152,7 +152,7 @@ class MainWindow : public QMainWindow, public Outputs::Speaker::Speaker::Delegat
 
 		KeyboardMapper keyMapper;
 
-		void register_led(const std::string &) override;
+		void register_led(const std::string &, uint8_t) override;
 		void set_led_status(const std::string &, bool) override;
 
 		std::recursive_mutex ledStatusesLock;

--- a/OSBindings/SDL/main.cpp
+++ b/OSBindings/SDL/main.cpp
@@ -271,7 +271,7 @@ class ActivityObserver: public Activity::Observer {
 
 	private:
 		std::vector<std::string> leds_;
-		void register_led(const std::string &name) final {
+		void register_led(const std::string &name, uint8_t) final {
 			std::lock_guard lock_guard(mutex);
 			leds_.push_back(name);
 		}


### PR DESCRIPTION
i.e. they indicate a persistent state rather than transient activity.

This is used by the macOS UI as a display hint.