### PR TITLE
Switches all Copper WAITs to 12 cycles

### DIFF
--- a/Machines/Amiga/Copper.cpp
+++ b/Machines/Amiga/Copper.cpp
@@ -124,13 +124,11 @@ bool Copper::advance_dma(uint16_t position, uint16_t blitter_status) {
 
 			// Got to here => this is a WAIT or a SKIP.
 
-			const bool raster_is_satisfied = satisfies_raster(position, blitter_status, instruction_);
-
 			if(!(instruction_[1] & 1)) {
-				// A WAIT. Empirically, I don't think this waits at all if the test is
-				// already satisfied.
-				state_ = raster_is_satisfied ? State::FetchFirstWord : State::Waiting;
-				if(raster_is_satisfied) LOG("Will wait from " << PADHEX(4) << position);
+				// A WAIT. The wait-for-start-of-next PAL wait of
+				// $FFDF,$FFFE seems to suggest evaluation will happen
+				// in the next cycle rather than this one.
+				state_ = State::Waiting;
 				break;
 			}
 

--- a/Machines/Amiga/Disk.cpp
+++ b/Machines/Amiga/Disk.cpp
@@ -8,6 +8,10 @@
 
 #include "Chipset.hpp"
 
+#ifndef NDEBUG
+#define NDEBUG
+#endif
+
 #define LOG_PREFIX "[Disk] "
 #include "../../Outputs/Log.hpp"
 


### PR DESCRIPTION
Previously I had been led empirically to believe that WAITs which don't wait terminate in just 8 cycles, but I no longer believe that to be true.

Primary improvement: PAL titles which use the standard $FFDF, $FFFE and then immediately another WAIT no longer trigger upon the end of line 255. Which has resolved an issue with the bottom of the display being cropped in a decent amount of software.