### PR TITLE
Eliminate usages of unistd.h.

### DIFF
--- a/OSBindings/SDL/main.cpp
+++ b/OSBindings/SDL/main.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <cstddef>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -17,7 +18,6 @@
 #include <map>
 #include <memory>
 #include <sys/stat.h>
-#include <unistd.h>
 
 #include <SDL2/SDL.h>
 

--- a/Storage/MassStorage/Encodings/MacintoshVolume.hpp
+++ b/Storage/MassStorage/Encodings/MacintoshVolume.hpp
@@ -9,10 +9,10 @@
 #ifndef MacintoshVolume_hpp
 #define MacintoshVolume_hpp
 
-#include <vector>
+#include <cstddef>
 #include <cstdint>
 #include <sys/types.h>
-#include <unistd.h>
+#include <vector>
 
 namespace Storage {
 namespace MassStorage {


### PR DESCRIPTION
This is a portability concern; I think I've been just a touch too lazy here.