### PR TITLE
Introduce randomised old vs new 68000 tests.

### DIFF
--- a/InstructionSets/M68k/Instruction.hpp
+++ b/InstructionSets/M68k/Instruction.hpp
@@ -250,6 +250,8 @@ enum class AddressingMode: uint8_t {
 	/// .q; value is embedded in the opcode.
 	Quick												= 0b01'110,
 };
+/// Guaranteed to be 1+[largest value used by AddressingMode].
+static constexpr int AddressingModeCount = 0b10'110;
 
 /*!
 	A preinstruction is as much of an instruction as can be decoded with

--- a/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
@@ -641,6 +641,7 @@
 		4B9F11CC22729B3600701480 /* OPCLOGR2.BIN in Resources */ = {isa = PBXBuildFile; fileRef = 4B9F11CB22729B3500701480 /* OPCLOGR2.BIN */; };
 		4BA0F68E1EEA0E8400E9489E /* ZX8081.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4BA0F68C1EEA0E8400E9489E /* ZX8081.cpp */; };
 		4BA61EB01D91515900B3C876 /* NSData+StdVector.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4BA61EAF1D91515900B3C876 /* NSData+StdVector.mm */; };
+		4BA6B6AE284EDAC100A3B7A8 /* 68000OldVsNew.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4BA6B6AD284EDAC000A3B7A8 /* 68000OldVsNew.mm */; };
 		4BA91E1D216D85BA00F79557 /* MasterSystemVDPTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4BA91E1C216D85BA00F79557 /* MasterSystemVDPTests.mm */; };
 		4BAD13441FF709C700FD114A /* MSX.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0E61051FF34737002A9DBD /* MSX.cpp */; };
 		4BAE49582032881E004BE78E /* CSZX8081.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4B14978E1EE4B4D200CE2596 /* CSZX8081.mm */; };
@@ -1683,6 +1684,7 @@
 		4BA3AE44283317CB00328FED /* RegisterSet.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = RegisterSet.hpp; sourceTree = "<group>"; };
 		4BA61EAE1D91515900B3C876 /* NSData+StdVector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSData+StdVector.h"; sourceTree = "<group>"; };
 		4BA61EAF1D91515900B3C876 /* NSData+StdVector.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "NSData+StdVector.mm"; sourceTree = "<group>"; };
+		4BA6B6AD284EDAC000A3B7A8 /* 68000OldVsNew.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = 68000OldVsNew.mm; sourceTree = "<group>"; };
 		4BA91E1C216D85BA00F79557 /* MasterSystemVDPTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MasterSystemVDPTests.mm; sourceTree = "<group>"; };
 		4BA9C3CF1D8164A9002DDB61 /* MediaTarget.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = MediaTarget.hpp; sourceTree = "<group>"; };
 		4BAA167B21582B1D008A3276 /* Target.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Target.hpp; sourceTree = "<group>"; };
@@ -4235,6 +4237,7 @@
 				4B75F978280D7C5100121055 /* 68000DecoderTests.mm */,
 				4B7C79FF282C3BCA002D6C0B /* 68000flamewingTests.mm */,
 				4BC5C3DF22C994CC00795658 /* 68000MoveTests.mm */,
+				4BA6B6AD284EDAC000A3B7A8 /* 68000OldVsNew.mm */,
 				4B9D0C4E22C7E0CF00DE1AD3 /* 68000RollShiftTests.mm */,
 				4BD388872239E198002D14B5 /* 68000Tests.mm */,
 				4BF7019F26FFD32300996424 /* AmigaBlitterTests.mm */,
@@ -5975,6 +5978,7 @@
 				4B3F76B925A1635300178AEC /* PowerPCDecoderTests.mm in Sources */,
 				4B778F0A23A5EC150000D260 /* TapePRG.cpp in Sources */,
 				4B778F0823A5EC150000D260 /* CSW.cpp in Sources */,
+				4BA6B6AE284EDAC100A3B7A8 /* 68000OldVsNew.mm in Sources */,
 				4B778F5323A5F23F0000D260 /* SerialBus.cpp in Sources */,
 				4B1E85811D176468001EF87D /* 6532Tests.swift in Sources */,
 				4B7752BA28217F160073E2C5 /* Bitplanes.cpp in Sources */,

--- a/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
@@ -278,6 +278,7 @@
 		4B595FAE2086DFBA0083CAA8 /* AudioToggle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B595FAC2086DFBA0083CAA8 /* AudioToggle.cpp */; };
 		4B5B37312777C7FC0047F238 /* IPF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B5B372F2777C7FC0047F238 /* IPF.cpp */; };
 		4B5B37322777C7FC0047F238 /* IPF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B5B372F2777C7FC0047F238 /* IPF.cpp */; };
+		4B5D497C28513F870076E2F9 /* IPF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B5B372F2777C7FC0047F238 /* IPF.cpp */; };
 		4B5D5C9725F56FC7001B4623 /* Spectrum.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B5D5C9525F56FC7001B4623 /* Spectrum.cpp */; };
 		4B5D5C9825F56FC7001B4623 /* Spectrum.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B5D5C9525F56FC7001B4623 /* Spectrum.cpp */; };
 		4B5FADBA1DE3151600AEC565 /* FileHolder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B5FADB81DE3151600AEC565 /* FileHolder.cpp */; };
@@ -6122,6 +6123,7 @@
 				4B7752C328217F720073E2C5 /* Z80.cpp in Sources */,
 				4B778F1A23A5ED320000D260 /* Video.cpp in Sources */,
 				4B778F3B23A5F1650000D260 /* KeyboardMachine.cpp in Sources */,
+				4B5D497C28513F870076E2F9 /* IPF.cpp in Sources */,
 				4B778F2E23A5F09E0000D260 /* IRQDelegatePortHandler.cpp in Sources */,
 				4B778EF323A5DB230000D260 /* PCMSegment.cpp in Sources */,
 				4B778F0D23A5EC150000D260 /* ZX80O81P.cpp in Sources */,

--- a/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
+++ b/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
@@ -25,7 +25,25 @@ struct Transaction {
 	bool data_strobe = false;
 
 	bool operator !=(const Transaction &rhs) const {
+		if(timestamp != rhs.timestamp) return true;
+		if(function_code != rhs.function_code) return true;
+		if(address != rhs.address) return true;
+		if(value != rhs.value) return true;
+		if(address_strobe != rhs.address_strobe) return true;
+		if(data_strobe != rhs.data_strobe) return true;
 		return false;
+	}
+
+	void print() const {
+		printf("%d: %d%d%d %c %c @ %06x with %04x\n",
+			timestamp.as<int>(),
+			(function_code >> 2) & 1,
+			(function_code >> 1) & 1,
+			(function_code >> 0) & 1,
+			address_strobe ? 'a' : '-',
+			data_strobe ? 'd' : '-',
+			address,
+			value);
 	}
 };
 
@@ -178,18 +196,23 @@ template <typename M68000> struct Tester {
 			// Compare bus activity.
 			const auto &oldTransactions = oldTester->bus_handler.transactions;
 			const auto &newTransactions = newTester->bus_handler.transactions;
-//			if(
-//				oldTransactions.size() != newTransactions.size()
-//			) {
-//				printf("Size mismatch: %zu vs %zu\n", newTransactions.size(), oldTransactions.size());
-//				continue;
-//			}
 
 			auto newIt = newTransactions.begin();
 			auto oldIt = oldTransactions.begin();
 			while(newIt != newTransactions.end() && oldIt != oldTransactions.end()) {
 				if(*newIt != *oldIt) {
-					printf("Peekaboo!");
+					printf("Mismatch in %s, test %d:", instruction.to_string().c_str(), test);
+
+					auto repeatIt = newTransactions.begin();
+					while(repeatIt != newIt) {
+						repeatIt->print();
+						++repeatIt;
+					}
+					printf("---\n");
+					printf("< "); oldIt->print();
+					printf("> "); newIt->print();
+
+					break;
 				}
 
 				++newIt;

--- a/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
+++ b/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
@@ -313,7 +313,7 @@ template <typename M68000> struct Tester {
 		}
 
 		// Test each 1000 times.
-		for(int test = 0; test < 10; test++) {
+		for(int test = 0; test < 1000; test++) {
 			++testsRun;
 
 			// Establish with certainty the initial memory state.

--- a/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
+++ b/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
@@ -16,14 +16,23 @@
 namespace {
 
 struct BusHandler {
+	template <typename Microcycle> HalfCycles perform_bus_operation(const Microcycle &cycle, bool is_supervisor) {
+		return HalfCycles(0);
+	}
 
+	void flush() {}
 };
 
 using OldProcessor = CPU::MC68000::Processor<BusHandler, true>;
 using NewProcessor = CPU::MC68000Mk2::Processor<BusHandler, true, true>;
 
 template <typename M68000> struct Tester {
-	Tester() : processor_(bus_handler_) {}
+	Tester() : processor_(bus_handler_) {
+	}
+
+	void advance(int cycles) {
+		processor_.run_for(HalfCycles(cycles << 1));
+	}
 
 	BusHandler bus_handler_;
 	M68000 processor_;
@@ -40,6 +49,11 @@ template <typename M68000> struct Tester {
 - (void)testOldVsNew {
 	Tester<OldProcessor> oldTester;
 	Tester<NewProcessor> newTester;
+
+	for(int c = 0; c < 2000; c++) {
+		oldTester.advance(1);
+		newTester.advance(1);
+	}
 }
 
 @end

--- a/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
+++ b/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
@@ -262,7 +262,7 @@ template <typename M68000> struct Tester {
 	// Use a fixed seed to guarantee continuity across repeated runs.
 	srand(68000);
 
-	std::set<InstructionSet::M68k::Operation> test_set;/* = {
+	std::set<InstructionSet::M68k::Operation> test_set = {
 		InstructionSet::M68k::Operation::ABCD,
 		InstructionSet::M68k::Operation::SBCD,
 		InstructionSet::M68k::Operation::MOVEb,
@@ -273,10 +273,11 @@ template <typename M68000> struct Tester {
 		InstructionSet::M68k::Operation::MOVEtoCCR,
 		InstructionSet::M68k::Operation::JSR,
 		InstructionSet::M68k::Operation::DIVU,
+		InstructionSet::M68k::Operation::DIVS,
 		InstructionSet::M68k::Operation::RTE,
 		InstructionSet::M68k::Operation::RTR,
 		InstructionSet::M68k::Operation::TAS,
-	};*/
+	};
 
 	std::set<InstructionSet::M68k::Operation> failing_operations;
 	for(int c = 0; c < 65536; c++) {

--- a/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
+++ b/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
@@ -1,0 +1,45 @@
+//
+//  68000ArithmeticTests.m
+//  Clock SignalTests
+//
+//  Created by Thomas Harte on 28/06/2019.
+//
+//  Largely ported from the tests of the Portable 68k Emulator.
+//
+
+#import <XCTest/XCTest.h>
+
+#include "TestRunner68000.hpp"
+#include "68000.hpp"
+#include "68000Mk2.hpp"
+
+namespace {
+
+struct BusHandler {
+
+};
+
+using OldProcessor = CPU::MC68000::Processor<BusHandler, true>;
+using NewProcessor = CPU::MC68000Mk2::Processor<BusHandler, true, true>;
+
+template <typename M68000> struct Tester {
+	Tester() : processor_(bus_handler_) {}
+
+	BusHandler bus_handler_;
+	M68000 processor_;
+};
+
+}
+
+@interface M68000OldVsNewTests : XCTestCase
+@end
+
+@implementation M68000OldVsNewTests {
+}
+
+- (void)testOldVsNew {
+	Tester<OldProcessor> oldTester;
+	Tester<NewProcessor> newTester;
+}
+
+@end

--- a/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
+++ b/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
@@ -76,8 +76,8 @@ struct Transaction {
 			(function_code >> 1) & 1,
 			(function_code >> 0) & 1,
 			address_strobe ? 'a' : '-',
-			(address_strobe & 1) ? 'b' : '-',
-			(address_strobe & 2) ? 'w' : '-',
+			(data_strobes & 1) ? 'b' : '-',
+			(data_strobes & 2) ? 'w' : '-',
 			address,
 			read ? "->" : "<-",
 			value);

--- a/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
+++ b/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
@@ -9,33 +9,122 @@
 
 #import <XCTest/XCTest.h>
 
-#include "TestRunner68000.hpp"
 #include "68000.hpp"
 #include "68000Mk2.hpp"
 
+#include <array>
+
 namespace {
+
+struct Transaction {
+	uint8_t function_code = 0;
+	uint32_t address = 0;
+	uint16_t value = 0;
+	bool address_strobe = false;
+	bool data_strobe = false;
+
+	bool operator !=(const Transaction &rhs) {
+		return false;
+	}
+};
 
 struct BusHandler {
 	template <typename Microcycle> HalfCycles perform_bus_operation(const Microcycle &cycle, bool is_supervisor) {
+		Transaction transaction;
+
+		// Fill all of the transaction record except the data field; will do that after
+		// any potential read.
+		if(cycle.operation & Microcycle::InterruptAcknowledge) {
+			transaction.function_code = 0b111;
+		} else {
+			transaction.function_code = is_supervisor ? 0x4 : 0x0;
+			transaction.function_code |= (cycle.operation & Microcycle::IsData) ? 0x1 : 0x2;
+		}
+		transaction.address_strobe = cycle.operation & (Microcycle::NewAddress | Microcycle::SameAddress);
+		transaction.data_strobe = cycle.operation & (Microcycle::SelectByte | Microcycle::SelectWord);
+		if(cycle.address) transaction.address = *cycle.address & 0xffff'ff;
+
+		// TODO: generate a random value if this is a read from an address not yet written to;
+		// use a shared store in order to ensure that both devices get the same random values.
+
+		// Do the operation...
+		const uint32_t address = cycle.address ? (*cycle.address & 0xffff'ff) : 0;
+		switch(cycle.operation & (Microcycle::SelectWord | Microcycle::SelectByte | Microcycle::Read)) {
+			default: break;
+
+			case Microcycle::SelectWord | Microcycle::Read:
+				cycle.set_value16((ram[address] << 8) | ram[address + 1]);
+			break;
+			case Microcycle::SelectByte | Microcycle::Read:
+				if(address & 1) {
+					cycle.set_value8_low(ram[address]);
+				} else {
+					cycle.set_value8_high(ram[address]);
+				}
+			break;
+			case Microcycle::SelectWord:
+				ram[address] = cycle.value8_high();
+				ram[address+1] = cycle.value8_low();
+			break;
+			case Microcycle::SelectByte:
+				ram[address] = (address & 1) ? cycle.value8_low() : cycle.value8_high();
+			break;
+		}
+
+
+		// Add the data value if relevant.
+		if(transaction.data_strobe) {
+			transaction.value = cycle.value16();
+		}
+
+		// Push back only if interesting.
+		if(transaction.address_strobe || transaction.data_strobe || transaction.function_code == 7) {
+			transactions.push_back(transaction);
+		}
+
 		return HalfCycles(0);
 	}
 
 	void flush() {}
+
+	std::vector<Transaction> transactions;
+	std::array<uint8_t, 16*1024*1024> ram;
+
+	void set_default_vectors() {
+		// Establish that all exception vectors point to 1024-byte blocks of memory.
+		for(int c = 0; c < 256; c++) {
+			const uint32_t target = (c + 1) << 10;
+			ram[(c << 2) + 0] = uint8_t(target >> 24);
+			ram[(c << 2) + 1] = uint8_t(target >> 16);
+			ram[(c << 2) + 2] = uint8_t(target >> 8);
+			ram[(c << 2) + 3] = uint8_t(target >> 0);
+		}
+	}
 };
 
 using OldProcessor = CPU::MC68000::Processor<BusHandler, true>;
 using NewProcessor = CPU::MC68000Mk2::Processor<BusHandler, true, true>;
 
 template <typename M68000> struct Tester {
-	Tester() : processor_(bus_handler_) {
+	Tester() : processor(bus_handler) {
 	}
 
 	void advance(int cycles) {
-		processor_.run_for(HalfCycles(cycles << 1));
+		processor.run_for(HalfCycles(cycles << 1));
 	}
 
-	BusHandler bus_handler_;
-	M68000 processor_;
+	void reset_with_opcode(uint16_t opcode) {
+		bus_handler.transactions.clear();
+		bus_handler.set_default_vectors();
+
+		bus_handler.ram[(2 << 10) + 0] = uint8_t(opcode >> 8);
+		bus_handler.ram[(2 << 10) + 1] = uint8_t(opcode >> 0);
+
+		processor.reset();
+	}
+
+	BusHandler bus_handler;
+	M68000 processor;
 };
 
 }
@@ -47,12 +136,47 @@ template <typename M68000> struct Tester {
 }
 
 - (void)testOldVsNew {
-	Tester<OldProcessor> oldTester;
-	Tester<NewProcessor> newTester;
+	auto oldTester = std::make_unique<Tester<OldProcessor>>();
+	auto newTester = std::make_unique<Tester<NewProcessor>>();
+	InstructionSet::M68k::Predecoder<InstructionSet::M68k::Model::M68000> decoder;
 
-	for(int c = 0; c < 2000; c++) {
-		oldTester.advance(1);
-		newTester.advance(1);
+	for(int c = 0; c < 65536; c++) {
+		// Test only defined opcodes.
+		const auto instruction = decoder.decode(uint16_t(c));
+		if(instruction.operation == InstructionSet::M68k::Operation::Undefined) {
+			continue;
+		}
+
+		// Test each 1000 times.
+		for(int test = 0; test < 1000; test++) {
+			oldTester->reset_with_opcode(c);
+			newTester->reset_with_opcode(c);
+
+			// For arbitrary resons, only run for 200 cycles.
+			newTester->advance(200);
+			oldTester->advance(200);
+
+			// Compare bus activity.
+			const auto &oldTransactions = oldTester->bus_handler.transactions;
+			const auto &newTransactions = newTester->bus_handler.transactions;
+			if(
+				oldTransactions.size() != newTransactions.size()
+			) {
+				printf("Size mismatch: %zu vs %zu\n", newTransactions.size(), oldTransactions.size());
+				continue;
+			}
+
+			auto newIt = newTransactions.begin();
+			auto oldIt = oldTransactions.begin();
+			while(newIt != newTransactions.end()) {
+//				if(*newIt != *oldIt) {
+//					printf("Peekaboo!");
+//				}
+
+				++newIt;
+				++oldIt;
+			}
+		}
 	}
 }
 

--- a/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
+++ b/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
@@ -229,10 +229,7 @@ template <typename M68000> struct Tester {
 		bus_handler.store.flag(address, bus_handler.participant);
 		bus_handler.store.flag(address+1, bus_handler.participant);
 
-		bus_handler.transaction_delay = 8;	// i.e. ignore the first eight transactions,
-											// which will just be the vector fetch part of
-											// the reset procedure. Instead assume logging
-											// at the initial prefetch fill.
+		bus_handler.transaction_delay = 12;	// i.e. ignore everything from the RESET sequence.
 		bus_handler.time = HalfCycles(0);
 
 		processor.reset();
@@ -264,13 +261,13 @@ template <typename M68000> struct Tester {
 //		InstructionSet::M68k::Operation::MOVEb,
 //		InstructionSet::M68k::Operation::MOVEw,
 //		InstructionSet::M68k::Operation::MOVEl,
-//		InstructionSet::M68k::Operation::PEA,
+		InstructionSet::M68k::Operation::PEA,
 //		InstructionSet::M68k::Operation::MOVEtoSR,		// Old implementation doesn't repeat a PC fetch.
 //		InstructionSet::M68k::Operation::MOVEtoCCR,		// Old implementation doesn't repeat a PC fetch.
 //		InstructionSet::M68k::Operation::JSR,			// Old implementation ends up skipping stack space if the destination throws an address error.
 //		InstructionSet::M68k::Operation::DIVU,
 //		InstructionSet::M68k::Operation::DIVS,
-//		InstructionSet::M68k::Operation::TAS,
+//		InstructionSet::M68k::Operation::TAS,			// Old implementation just doesn't match published cycle counts.
 	};
 
 	std::set<InstructionSet::M68k::Operation> failing_operations;

--- a/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
+++ b/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
@@ -262,7 +262,6 @@ template <typename M68000> struct Tester {
 //		InstructionSet::M68k::Operation::MOVEb,
 //		InstructionSet::M68k::Operation::MOVEw,
 //		InstructionSet::M68k::Operation::MOVEl,
-//		InstructionSet::M68k::Operation::PEA,
 //		InstructionSet::M68k::Operation::MOVEtoSR,		// Old implementation doesn't repeat a PC fetch.
 //		InstructionSet::M68k::Operation::MOVEtoCCR,		// Old implementation doesn't repeat a PC fetch.
 //		InstructionSet::M68k::Operation::CMPAl,			// Old implementation omits an idle cycle before -(An)
@@ -285,6 +284,7 @@ template <typename M68000> struct Tester {
 //		InstructionSet::M68k::Operation::TAS,			// Old implementation just doesn't match published cycle counts.
 	};
 
+	int testsRun = 0;
 	std::set<InstructionSet::M68k::Operation> failing_operations;
 	for(int c = 0; c < 65536; c++) {
 //		printf("%04x\n", c);
@@ -305,6 +305,8 @@ template <typename M68000> struct Tester {
 
 		// Test each 1000 times.
 		for(int test = 0; test < 100; test++) {
+			++testsRun;
+
 			// Establish with certainty the initial memory state.
 			random_store.clear();
 			newTester->reset_with_opcode(c);
@@ -408,9 +410,14 @@ template <typename M68000> struct Tester {
 		}
 	}
 
-	printf("\nAll failing operations:\n");
-	for(const auto operation: failing_operations) {
-		printf("%d,\n", int(operation));
+	printf("%d tests run\n", testsRun);
+	if(failing_operations.empty()) {
+		printf("No failures\n");
+	} else {
+		printf("\nAll failing operations:\n");
+		for(const auto operation: failing_operations) {
+			printf("%d,\n", int(operation));
+		}
 	}
 }
 

--- a/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
+++ b/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
@@ -257,7 +257,7 @@ template <typename M68000> struct Tester {
 	// Use a fixed seed to guarantee continuity across repeated runs.
 	srand(68000);
 
-	for(int c = 0; c < 65536; c++) {
+	for(int c = 0x4e72; c < 65536; c++) {
 		printf("%04x\n", c);
 
 		// Test only defined opcodes.
@@ -326,8 +326,15 @@ template <typename M68000> struct Tester {
 							++repeatIt;
 						}
 						printf("---\n");
-						printf("o: "); oldIt->print();
-						printf("n: "); newIt->print();
+						while(newIt != newTransactions.end()) {
+							printf("n: "); newIt->print();
+							++newIt;
+						}
+						printf("\n");
+						while(oldIt != oldTransactions.end()) {
+							printf("o: "); oldIt->print();
+							++oldIt;
+						}
 						printf("\n");
 
 						break;

--- a/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
+++ b/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
@@ -255,7 +255,7 @@ template <typename M68000> struct Tester {
 	// Use a fixed seed to guarantee continuity across repeated runs.
 	srand(68000);
 
-	std::set<InstructionSet::M68k::Operation> test_set;/* = {
+	std::set<InstructionSet::M68k::Operation> test_set = {
 //		InstructionSet::M68k::Operation::ABCD,			// Old implementation doesn't match flamewing tests, sometimes produces incorrect results.
 //		InstructionSet::M68k::Operation::SBCD,			// Old implementation doesn't match flamewing tests, sometimes produces incorrect results.
 //		InstructionSet::M68k::Operation::MOVEb,
@@ -264,11 +264,30 @@ template <typename M68000> struct Tester {
 		InstructionSet::M68k::Operation::PEA,
 //		InstructionSet::M68k::Operation::MOVEtoSR,		// Old implementation doesn't repeat a PC fetch.
 //		InstructionSet::M68k::Operation::MOVEtoCCR,		// Old implementation doesn't repeat a PC fetch.
+//		InstructionSet::M68k::Operation::CMPAl,
 //		InstructionSet::M68k::Operation::JSR,			// Old implementation ends up skipping stack space if the destination throws an address error.
+//		InstructionSet::M68k::Operation::CLRb,
+//		InstructionSet::M68k::Operation::CLRw,
+//		InstructionSet::M68k::Operation::NEGXb,
+//		InstructionSet::M68k::Operation::NEGXw,
+//		InstructionSet::M68k::Operation::NEGb,
+//		InstructionSet::M68k::Operation::NEGw,
+//		InstructionSet::M68k::Operation::MOVEMtoRl,
+//		InstructionSet::M68k::Operation::MOVEMtoRw,
+//		InstructionSet::M68k::Operation::MOVEMtoMl,
+//		InstructionSet::M68k::Operation::MOVEMtoMw,
+//		InstructionSet::M68k::Operation::NOTb,
+//		InstructionSet::M68k::Operation::NOTw,
+//		InstructionSet::M68k::Operation::MULU,
+//		InstructionSet::M68k::Operation::MULS,
 //		InstructionSet::M68k::Operation::DIVU,
 //		InstructionSet::M68k::Operation::DIVS,
+//		InstructionSet::M68k::Operation::RTE,
+//		InstructionSet::M68k::Operation::TRAP,
+//		InstructionSet::M68k::Operation::TRAPV,
+//		InstructionSet::M68k::Operation::CHK,
 //		InstructionSet::M68k::Operation::TAS,			// Old implementation just doesn't match published cycle counts.
-	};*/
+	};
 
 	std::set<InstructionSet::M68k::Operation> failing_operations;
 	for(int c = 0; c < 65536; c++) {

--- a/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
+++ b/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
@@ -278,7 +278,6 @@ template <typename M68000> struct Tester {
 //		InstructionSet::M68k::Operation::MULS,
 //		InstructionSet::M68k::Operation::DIVU,
 //		InstructionSet::M68k::Operation::DIVS,
-//		InstructionSet::M68k::Operation::RTE,			// When an address error is thrown, the old implementation will enter it at the interrupt level reinstalled from the RTE.
 //		InstructionSet::M68k::Operation::TRAP,			// Old implementation relocates the idle state near the end to the beginning.
 //		InstructionSet::M68k::Operation::TRAPV,			// Old implementation relocates the idle state near the end to the beginning.
 //		InstructionSet::M68k::Operation::CHK,			// Old implementation pauses four cycles too long.

--- a/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
+++ b/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
@@ -272,10 +272,6 @@ template <typename M68000> struct Tester {
 //		InstructionSet::M68k::Operation::NEGXw,			// Old implementation omits an idle cycle before -(An)
 //		InstructionSet::M68k::Operation::NEGb,			// Old implementation omits an idle cycle before -(An)
 //		InstructionSet::M68k::Operation::NEGw,			// Old implementation omits an idle cycle before -(An)
-		InstructionSet::M68k::Operation::MOVEMtoRl,
-		InstructionSet::M68k::Operation::MOVEMtoRw,
-		InstructionSet::M68k::Operation::MOVEMtoMl,
-		InstructionSet::M68k::Operation::MOVEMtoMw,
 //		InstructionSet::M68k::Operation::NOTb,			// Old implementation omits an idle cycle before -(An)
 //		InstructionSet::M68k::Operation::NOTw,			// Old implementation omits an idle cycle before -(An)
 //		InstructionSet::M68k::Operation::MULU,

--- a/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
+++ b/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
@@ -264,7 +264,7 @@ template <typename M68000> struct Tester {
 //		InstructionSet::M68k::Operation::PEA,
 //		InstructionSet::M68k::Operation::MOVEtoSR,		// Old implementation doesn't repeat a PC fetch.
 //		InstructionSet::M68k::Operation::MOVEtoCCR,		// Old implementation doesn't repeat a PC fetch.
-//		InstructionSet::M68k::Operation::CMPAl,
+//		InstructionSet::M68k::Operation::CMPAl,			// Old implementation omits an idle cycle before -(An)
 //		InstructionSet::M68k::Operation::JSR,			// Old implementation ends up skipping stack space if the destination throws an address error.
 //		InstructionSet::M68k::Operation::CLRb,			// Old implementation omits an idle cycle before -(An)
 //		InstructionSet::M68k::Operation::CLRw,			// Old implementation omits an idle cycle before -(An)
@@ -278,10 +278,10 @@ template <typename M68000> struct Tester {
 //		InstructionSet::M68k::Operation::MULS,
 //		InstructionSet::M68k::Operation::DIVU,
 //		InstructionSet::M68k::Operation::DIVS,
-//		InstructionSet::M68k::Operation::RTE,
-//		InstructionSet::M68k::Operation::TRAP,
-//		InstructionSet::M68k::Operation::TRAPV,
-//		InstructionSet::M68k::Operation::CHK,
+//		InstructionSet::M68k::Operation::RTE,			// When an address error is thrown, the old implementation will enter it at the interrupt level reinstalled from the RTE.
+//		InstructionSet::M68k::Operation::TRAP,			// Old implementation relocates the idle state near the end to the beginning.
+//		InstructionSet::M68k::Operation::TRAPV,			// Old implementation relocates the idle state near the end to the beginning.
+//		InstructionSet::M68k::Operation::CHK,			// Old implementation pauses four cycles too long.
 //		InstructionSet::M68k::Operation::TAS,			// Old implementation just doesn't match published cycle counts.
 	};
 

--- a/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
+++ b/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
@@ -103,6 +103,11 @@ struct BusHandler {
 		if(transaction.address_strobe || transaction.data_strobe || transaction.function_code == 7) {
 			if(transaction_delay) {
 				--transaction_delay;
+
+				// Start counting time only from the first recorded transaction.
+				if(!transaction_delay) {
+					time = HalfCycles(0);
+				}
 			} else {
 				if(transaction.timestamp < time_cutoff) {
 					transactions.push_back(transaction);
@@ -153,7 +158,7 @@ template <typename M68000> struct Tester {
 		bus_handler.ram[(2 << 10) + 0] = uint8_t(opcode >> 8);
 		bus_handler.ram[(2 << 10) + 1] = uint8_t(opcode >> 0);
 
-		bus_handler.transaction_delay = 8;	// i.e. ignore the first eight transactions,
+		bus_handler.transaction_delay = 12;	// i.e. ignore the first eight transactions,
 											// which will just be the reset procedure.
 		bus_handler.time = HalfCycles(0);
 
@@ -201,7 +206,7 @@ template <typename M68000> struct Tester {
 			auto oldIt = oldTransactions.begin();
 			while(newIt != newTransactions.end() && oldIt != oldTransactions.end()) {
 				if(*newIt != *oldIt) {
-					printf("Mismatch in %s, test %d:", instruction.to_string().c_str(), test);
+					printf("Mismatch in %s, test %d:\n", instruction.to_string().c_str(), test);
 
 					auto repeatIt = newTransactions.begin();
 					while(repeatIt != newIt) {

--- a/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
+++ b/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
@@ -248,6 +248,10 @@ template <typename M68000> struct Tester {
 
 @implementation M68000OldVsNewTests
 
+// List of known deviations of the new from the old, to check out:
+//
+//	1) address error following an RTE now raises the interrupt level to 7; before it left it untouched.
+
 - (void)testOldVsNew {
 	RandomStore random_store;
 	auto oldTester = std::make_unique<Tester<OldProcessor>>(random_store, 0x01);
@@ -262,6 +266,11 @@ template <typename M68000> struct Tester {
 
 		// Test only defined opcodes.
 		const auto instruction = decoder.decode(uint16_t(c));
+//		if(
+//			instruction.operation != InstructionSet::M68k::Operation::RTE
+//		) {
+//			continue;
+//		}
 		if(
 			instruction.operation == InstructionSet::M68k::Operation::Undefined ||
 			instruction.operation == InstructionSet::M68k::Operation::STOP

--- a/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
+++ b/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
@@ -262,7 +262,7 @@ template <typename M68000> struct Tester {
 	// Use a fixed seed to guarantee continuity across repeated runs.
 	srand(68000);
 
-	std::set<InstructionSet::M68k::Operation> test_set = {
+	std::set<InstructionSet::M68k::Operation> test_set;/* = {
 		InstructionSet::M68k::Operation::ABCD,
 		InstructionSet::M68k::Operation::SBCD,
 		InstructionSet::M68k::Operation::MOVEb,
@@ -276,7 +276,7 @@ template <typename M68000> struct Tester {
 		InstructionSet::M68k::Operation::RTE,
 		InstructionSet::M68k::Operation::RTR,
 		InstructionSet::M68k::Operation::TAS,
-	};
+	};*/
 
 	std::set<InstructionSet::M68k::Operation> failing_operations;
 	for(int c = 0; c < 65536; c++) {
@@ -332,12 +332,12 @@ template <typename M68000> struct Tester {
 			newState = newTester->processor.get_state();
 
 			// Compare bus activity only if it doesn't look like an address
-			// error occurred. Don't check those as I don't have good information
-			// on the proper stack write order, so transactions are permitted to differ.
+			// error occurred. Don't check those as the old 68000 appears to be wrong
+			// most of the time about function codes, and that bleeds into the stacked data.
 			//
 			// Net effect will be 50% fewer transaction comparisons for instructions that
 			// can trigger an address error.
-//			if(oldState.program_counter != 0x1404 || newState.registers.program_counter != 0x1404) {
+			if(oldState.program_counter != 0x1404 || newState.registers.program_counter != 0x1404) {
 				const auto &oldTransactions = oldTester->bus_handler.transactions;
 				const auto &newTransactions = newTester->bus_handler.transactions;
 
@@ -371,7 +371,7 @@ template <typename M68000> struct Tester {
 					++newIt;
 					++oldIt;
 				}
-//			}
+			}
 
 			// Compare registers.
 			bool mismatch = false;

--- a/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
+++ b/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
@@ -191,10 +191,10 @@ template <typename M68000> struct Tester {
 
 		// Test each 1000 times.
 		for(int test = 0; test < 1000; test++) {
-			oldTester->reset_with_opcode(c);
 			newTester->reset_with_opcode(c);
+			oldTester->reset_with_opcode(c);
 
-			// For arbitrary resons, only run for 200 bus cycles, capturing up to 200 cycles of activity.
+			// For arbitrary resons, only run for 200 bus cycles, capturing up to 200 clock cycles of activity.
 			newTester->advance(200, HalfCycles(400));
 			oldTester->advance(200, HalfCycles(400));
 

--- a/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
+++ b/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
@@ -262,7 +262,10 @@ template <typename M68000> struct Tester {
 
 		// Test only defined opcodes.
 		const auto instruction = decoder.decode(uint16_t(c));
-		if(instruction.operation == InstructionSet::M68k::Operation::Undefined) {
+		if(
+			instruction.operation == InstructionSet::M68k::Operation::Undefined ||
+			instruction.operation == InstructionSet::M68k::Operation::STOP
+		) {
 			continue;
 		}
 

--- a/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
+++ b/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
@@ -261,23 +261,23 @@ template <typename M68000> struct Tester {
 //		InstructionSet::M68k::Operation::MOVEb,
 //		InstructionSet::M68k::Operation::MOVEw,
 //		InstructionSet::M68k::Operation::MOVEl,
-		InstructionSet::M68k::Operation::PEA,
+//		InstructionSet::M68k::Operation::PEA,
 //		InstructionSet::M68k::Operation::MOVEtoSR,		// Old implementation doesn't repeat a PC fetch.
 //		InstructionSet::M68k::Operation::MOVEtoCCR,		// Old implementation doesn't repeat a PC fetch.
 //		InstructionSet::M68k::Operation::CMPAl,
 //		InstructionSet::M68k::Operation::JSR,			// Old implementation ends up skipping stack space if the destination throws an address error.
-//		InstructionSet::M68k::Operation::CLRb,
-//		InstructionSet::M68k::Operation::CLRw,
-//		InstructionSet::M68k::Operation::NEGXb,
-//		InstructionSet::M68k::Operation::NEGXw,
-//		InstructionSet::M68k::Operation::NEGb,
-//		InstructionSet::M68k::Operation::NEGw,
-//		InstructionSet::M68k::Operation::MOVEMtoRl,
-//		InstructionSet::M68k::Operation::MOVEMtoRw,
-//		InstructionSet::M68k::Operation::MOVEMtoMl,
-//		InstructionSet::M68k::Operation::MOVEMtoMw,
-//		InstructionSet::M68k::Operation::NOTb,
-//		InstructionSet::M68k::Operation::NOTw,
+//		InstructionSet::M68k::Operation::CLRb,			// Old implementation omits an idle cycle before -(An)
+//		InstructionSet::M68k::Operation::CLRw,			// Old implementation omits an idle cycle before -(An)
+//		InstructionSet::M68k::Operation::NEGXb,			// Old implementation omits an idle cycle before -(An)
+//		InstructionSet::M68k::Operation::NEGXw,			// Old implementation omits an idle cycle before -(An)
+//		InstructionSet::M68k::Operation::NEGb,			// Old implementation omits an idle cycle before -(An)
+//		InstructionSet::M68k::Operation::NEGw,			// Old implementation omits an idle cycle before -(An)
+		InstructionSet::M68k::Operation::MOVEMtoRl,
+		InstructionSet::M68k::Operation::MOVEMtoRw,
+		InstructionSet::M68k::Operation::MOVEMtoMl,
+		InstructionSet::M68k::Operation::MOVEMtoMw,
+//		InstructionSet::M68k::Operation::NOTb,			// Old implementation omits an idle cycle before -(An)
+//		InstructionSet::M68k::Operation::NOTw,			// Old implementation omits an idle cycle before -(An)
 //		InstructionSet::M68k::Operation::MULU,
 //		InstructionSet::M68k::Operation::MULS,
 //		InstructionSet::M68k::Operation::DIVU,
@@ -291,7 +291,7 @@ template <typename M68000> struct Tester {
 
 	std::set<InstructionSet::M68k::Operation> failing_operations;
 	for(int c = 0; c < 65536; c++) {
-		printf("%04x\n", c);
+//		printf("%04x\n", c);
 
 		// Test only defined opcodes that aren't STOP (which will never teminate).
 		const auto instruction = decoder.decode(uint16_t(c));

--- a/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
+++ b/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
@@ -60,7 +60,7 @@ struct Transaction {
 	bool read = false;
 
 	bool operator !=(const Transaction &rhs) const {
-//		if(timestamp != rhs.timestamp) return true;
+		if(timestamp != rhs.timestamp) return true;
 //		if(function_code != rhs.function_code) return true;
 		if(address != rhs.address) return true;
 		if(value != rhs.value) return true;
@@ -255,7 +255,7 @@ template <typename M68000> struct Tester {
 	// Use a fixed seed to guarantee continuity across repeated runs.
 	srand(68000);
 
-	std::set<InstructionSet::M68k::Operation> test_set = {
+	std::set<InstructionSet::M68k::Operation> test_set;/* = {
 //		InstructionSet::M68k::Operation::ABCD,			// Old implementation doesn't match flamewing tests, sometimes produces incorrect results.
 //		InstructionSet::M68k::Operation::SBCD,			// Old implementation doesn't match flamewing tests, sometimes produces incorrect results.
 //		InstructionSet::M68k::Operation::MOVEb,
@@ -268,7 +268,7 @@ template <typename M68000> struct Tester {
 //		InstructionSet::M68k::Operation::DIVU,
 //		InstructionSet::M68k::Operation::DIVS,
 //		InstructionSet::M68k::Operation::TAS,			// Old implementation just doesn't match published cycle counts.
-	};
+	};*/
 
 	std::set<InstructionSet::M68k::Operation> failing_operations;
 	for(int c = 0; c < 65536; c++) {

--- a/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
+++ b/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
@@ -262,21 +262,37 @@ template <typename M68000> struct Tester {
 	// Use a fixed seed to guarantee continuity across repeated runs.
 	srand(68000);
 
+	std::set<InstructionSet::M68k::Operation> test_set = {
+		InstructionSet::M68k::Operation::ABCD,
+		InstructionSet::M68k::Operation::SBCD,
+		InstructionSet::M68k::Operation::MOVEb,
+		InstructionSet::M68k::Operation::MOVEw,
+		InstructionSet::M68k::Operation::MOVEl,
+		InstructionSet::M68k::Operation::PEA,
+		InstructionSet::M68k::Operation::MOVEtoSR,
+		InstructionSet::M68k::Operation::MOVEtoCCR,
+		InstructionSet::M68k::Operation::JSR,
+		InstructionSet::M68k::Operation::DIVU,
+		InstructionSet::M68k::Operation::RTE,
+		InstructionSet::M68k::Operation::RTR,
+		InstructionSet::M68k::Operation::TAS,
+	};
+
 	std::set<InstructionSet::M68k::Operation> failing_operations;
 	for(int c = 0; c < 65536; c++) {
 		printf("%04x\n", c);
 
-		// Test only defined opcodes.
+		// Test only defined opcodes that aren't STOP (which will never teminate).
 		const auto instruction = decoder.decode(uint16_t(c));
-//		if(
-//			instruction.operation != InstructionSet::M68k::Operation::RTE
-//		) {
-//			continue;
-//		}
 		if(
 			instruction.operation == InstructionSet::M68k::Operation::Undefined ||
 			instruction.operation == InstructionSet::M68k::Operation::STOP
 		) {
+			continue;
+		}
+
+		// If a whitelist is in place, adhere to it.
+		if(!test_set.empty() && test_set.find(instruction.operation) == test_set.end()) {
 			continue;
 		}
 
@@ -321,7 +337,7 @@ template <typename M68000> struct Tester {
 			//
 			// Net effect will be 50% fewer transaction comparisons for instructions that
 			// can trigger an address error.
-			if(oldState.program_counter != 0x1404 || newState.registers.program_counter != 0x1404) {
+//			if(oldState.program_counter != 0x1404 || newState.registers.program_counter != 0x1404) {
 				const auto &oldTransactions = oldTester->bus_handler.transactions;
 				const auto &newTransactions = newTester->bus_handler.transactions;
 
@@ -355,7 +371,7 @@ template <typename M68000> struct Tester {
 					++newIt;
 					++oldIt;
 				}
-			}
+//			}
 
 			// Compare registers.
 			bool mismatch = false;

--- a/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
+++ b/OSBindings/Mac/Clock SignalTests/68000OldVsNew.mm
@@ -14,6 +14,7 @@
 
 #include <array>
 #include <unordered_map>
+#include <set>
 
 namespace {
 
@@ -261,7 +262,8 @@ template <typename M68000> struct Tester {
 	// Use a fixed seed to guarantee continuity across repeated runs.
 	srand(68000);
 
-	for(int c = 0x4e72; c < 65536; c++) {
+	std::set<InstructionSet::M68k::Operation> failing_operations;
+	for(int c = 0; c < 65536; c++) {
 		printf("%04x\n", c);
 
 		// Test only defined opcodes.
@@ -346,6 +348,7 @@ template <typename M68000> struct Tester {
 						}
 						printf("\n");
 
+						failing_operations.insert(instruction.operation);
 						break;
 					}
 
@@ -366,10 +369,16 @@ template <typename M68000> struct Tester {
 			mismatch |= oldState.supervisor_stack_pointer != newState.registers.supervisor_stack_pointer;
 
 			if(mismatch) {
+				failing_operations.insert(instruction.operation);
 				printf("Registers don't match after %s, test %d\n", instruction.to_string().c_str(), test);
 				// TODO: more detail here!
 			}
 		}
+	}
+
+	printf("\nAll failing operations:\n");
+	for(const auto operation: failing_operations) {
+		printf("%d,\n", int(operation));
 	}
 }
 

--- a/OSBindings/Mac/Clock SignalTests/68000Tests.mm
+++ b/OSBindings/Mac/Clock SignalTests/68000Tests.mm
@@ -189,6 +189,9 @@
 	// PC.
 	XCTAssertEqual(stack_frame[5], 0x0000);
 	XCTAssertEqual(stack_frame[6], 0x1004);
+
+	// Check that A7 ended up in the proper location.
+	XCTAssertEqual(_machine->get_processor_state().registers.stack_pointer(), 0x1f8);
 }
 
 - (void)testShiftDuration {

--- a/Processors/68000/68000.hpp
+++ b/Processors/68000/68000.hpp
@@ -462,6 +462,8 @@ template <class T, bool dtack_is_implicit, bool signal_will_perform = false> cla
 			return e_clock_phase_;
 		}
 
+		void reset();
+
 	private:
 		T &bus_handler_;
 };

--- a/Processors/68000/Implementation/68000Implementation.hpp
+++ b/Processors/68000/Implementation/68000Implementation.hpp
@@ -2243,6 +2243,7 @@ template <class T, bool dtack_is_implicit, bool signal_will_perform> void Proces
 	effective_address_[0] = 0;
 	is_supervisor_ = 1;
 	interrupt_level_ = 7;
+	half_cycles_left_to_run_ = HalfCycles(0);
 }
 
 #undef status

--- a/Processors/68000/Implementation/68000Implementation.hpp
+++ b/Processors/68000/Implementation/68000Implementation.hpp
@@ -2237,6 +2237,13 @@ void ProcessorStorage::set_status(uint16_t status) {
 	apply_status(status);
 }
 
+template <class T, bool dtack_is_implicit, bool signal_will_perform> void Processor<T, dtack_is_implicit, signal_will_perform>::reset() {
+	execution_state_ = ExecutionState::Executing;
+	active_step_ = reset_bus_steps_;
+	is_supervisor_ = 1;
+	interrupt_level_ = 7;
+}
+
 #undef status
 #undef apply_status
 #undef apply_ccr

--- a/Processors/68000/Implementation/68000Implementation.hpp
+++ b/Processors/68000/Implementation/68000Implementation.hpp
@@ -2240,6 +2240,7 @@ void ProcessorStorage::set_status(uint16_t status) {
 template <class T, bool dtack_is_implicit, bool signal_will_perform> void Processor<T, dtack_is_implicit, signal_will_perform>::reset() {
 	execution_state_ = ExecutionState::Executing;
 	active_step_ = reset_bus_steps_;
+	effective_address_[0] = 0;
 	is_supervisor_ = 1;
 	interrupt_level_ = 7;
 }

--- a/Processors/68000Mk2/68000Mk2.hpp
+++ b/Processors/68000Mk2/68000Mk2.hpp
@@ -441,6 +441,8 @@ class Processor: private ProcessorBase {
 			return e_clock_phase_;
 		}
 
+		void reset();
+
 	private:
 		BusHandler &bus_handler_;
 };

--- a/Processors/68000Mk2/Implementation/68000Mk2Implementation.hpp
+++ b/Processors/68000Mk2/Implementation/68000Mk2Implementation.hpp
@@ -475,7 +475,7 @@ void Processor<BusHandler, dtack_is_implicit, permit_overrun, signal_will_perfor
 			IdleBus(2);
 
 			// Switch to supervisor mode, disable interrupts.
-			captured_status_.w = status_.begin_exception(7);
+			captured_status_.w = status_.begin_exception();
 			should_trace_ = 0;
 			did_update_status();
 

--- a/Processors/68000Mk2/Implementation/68000Mk2Implementation.hpp
+++ b/Processors/68000Mk2/Implementation/68000Mk2Implementation.hpp
@@ -2396,18 +2396,25 @@ void Processor<BusHandler, dtack_is_implicit, permit_overrun, signal_will_perfor
 			Prefetch();
 		MoveToStateSpecific(Decode);
 
+		// Yacht cites the bus activity for RTE and RTR as nS ns ns, so
+		// the program counter high word must be the first thing
+		// retrieved; the order of the other two is a guess,
+		// being the converse of the write order.
+
 		BeginState(RTE):
 			SetupDataAccess(Microcycle::Read, Microcycle::SelectWord);
 			SetDataAddress(registers_[15].l);
 
 			registers_[15].l += 2;
 			Access(program_counter_.high);
-			registers_[15].l += 2;
-			Access(program_counter_.low);
 
-			registers_[15].l -= 4;
+			registers_[15].l -= 2;
 			Access(temporary_value_.low);
-			registers_[15].l += 6;
+
+			registers_[15].l += 4;
+			Access(program_counter_.low);
+			registers_[15].l += 2;
+
 			status_.set_status(temporary_value_.w);
 			did_update_status();
 
@@ -2421,12 +2428,14 @@ void Processor<BusHandler, dtack_is_implicit, permit_overrun, signal_will_perfor
 
 			registers_[15].l += 2;
 			Access(program_counter_.high);
-			registers_[15].l += 2;
-			Access(program_counter_.low);
 
-			registers_[15].l -= 4;
+			registers_[15].l -= 2;
 			Access(temporary_value_.low);
-			registers_[15].l += 6;
+
+			registers_[15].l += 4;
+			Access(program_counter_.low);
+			registers_[15].l += 2;
+
 			status_.set_ccr(temporary_value_.w);
 
 			Prefetch();

--- a/Processors/68000Mk2/Implementation/68000Mk2Implementation.hpp
+++ b/Processors/68000Mk2/Implementation/68000Mk2Implementation.hpp
@@ -2793,6 +2793,7 @@ void Processor<BusHandler, dtack_is_implicit, permit_overrun, signal_will_perfor
 template <class BusHandler, bool dtack_is_implicit, bool permit_overrun, bool signal_will_perform>
 void Processor<BusHandler, dtack_is_implicit, permit_overrun, signal_will_perform>::reset() {
 	state_ = Reset;
+	time_remaining_ = HalfCycles(0);
 }
 
 }

--- a/Processors/68000Mk2/Implementation/68000Mk2Implementation.hpp
+++ b/Processors/68000Mk2/Implementation/68000Mk2Implementation.hpp
@@ -2785,7 +2785,6 @@ void Processor<BusHandler, dtack_is_implicit, permit_overrun, signal_will_perfor
 template <class BusHandler, bool dtack_is_implicit, bool permit_overrun, bool signal_will_perform>
 void Processor<BusHandler, dtack_is_implicit, permit_overrun, signal_will_perform>::reset() {
 	state_ = Reset;
-	status_.begin_exception(7);
 }
 
 }

--- a/Processors/68000Mk2/Implementation/68000Mk2Implementation.hpp
+++ b/Processors/68000Mk2/Implementation/68000Mk2Implementation.hpp
@@ -1118,7 +1118,7 @@ void Processor<BusHandler, dtack_is_implicit, permit_overrun, signal_will_perfor
 		BeginStateMode(MOVE_l, AddressRegisterDirect):
 		BeginStateMode(MOVE_l, DataRegisterDirect):
 		BeginStateMode(MOVE_bw, AddressRegisterDirect):
-			registers_[instruction_.reg(1)] = operand_[1];
+			registers_[instruction_.lreg(1)] = operand_[1];
 			Prefetch();
 		MoveToStateSpecific(Decode);
 
@@ -1937,11 +1937,11 @@ void Processor<BusHandler, dtack_is_implicit, permit_overrun, signal_will_perfor
 		MoveToAddressingMode(MOVE_bw, instruction_.mode(1));
 
 		BeginState(MOVE_w):
-			PerformSpecific(MOVEw);
+			PerformDynamic();	// Could be MOVE.w or MOVEA.w.
 		MoveToAddressingMode(MOVE_bw, instruction_.mode(1));
 
 		BeginState(MOVE_l):
-			PerformSpecific(MOVEl);
+			PerformDynamic();	// Could be MOVE.l or MOVEA.l.
 		MoveToAddressingMode(MOVE_l, instruction_.mode(1));
 
 		//

--- a/Processors/68000Mk2/Implementation/68000Mk2Implementation.hpp
+++ b/Processors/68000Mk2/Implementation/68000Mk2Implementation.hpp
@@ -191,6 +191,8 @@ enum ExecutionState: int {
 	AddressingDispatch(PEA),
 	PEA_np_nS_ns,		// Used to complete (An), (d16, [An/PC]) and (d8, [An/PC], Xn).
 	PEA_np_nS_ns_np,	// Used to complete (xxx).w and (xxx).l
+
+	AddressingDispatch(MOVE_b),	MOVE_b_AbsoluteLong_prefetch_first,
 };
 
 #undef AddressingDispatch
@@ -744,7 +746,7 @@ void Processor<BusHandler, dtack_is_implicit, permit_overrun, signal_will_perfor
 				StdCASE(EXTbtow, 	perform_state_ = Perform_np);
 				StdCASE(EXTwtol, 	perform_state_ = Perform_np);
 
-				StdCASE(MOVEb,		perform_state_ = MOVE);
+				StdCASE(MOVEb,		perform_state_ = MOVE_b);
 				Duplicate(MOVEAw, MOVEw)
 				StdCASE(MOVEw,		perform_state_ = MOVE);
 				Duplicate(MOVEAl, MOVEl)
@@ -1113,6 +1115,11 @@ void Processor<BusHandler, dtack_is_implicit, permit_overrun, signal_will_perfor
 			operand_[next_operand_] = registers_[instruction_.lreg(next_operand_)];
 		MoveToNextOperand(FetchOperand_l);
 
+		BeginStateMode(MOVE_b, DataRegisterDirect):
+			registers_[instruction_.lreg(1)].b = operand_[1].b;
+			Prefetch();
+		MoveToStateSpecific(Decode);
+
 		//
 		// Quick
 		//
@@ -1133,6 +1140,15 @@ void Processor<BusHandler, dtack_is_implicit, permit_overrun, signal_will_perfor
 
 			Access(operand_[next_operand_].low);	// nr
 		MoveToNextOperand(FetchOperand_bw);
+
+		BeginStateMode(MOVE_b, AddressRegisterIndirect):
+			effective_address_[1].l = registers_[8 + instruction_.reg(1)].l;
+			SetDataAddress(effective_address_[1].l);
+			SetupDataAccess(0, Microcycle::SelectByte);
+
+			Access(operand_[next_operand_].low);	// nw
+			Prefetch();								// np
+		MoveToStateSpecific(Decode);
 
 		BeginStateMode(FetchOperand_l, AddressRegisterIndirect):
 			effective_address_[next_operand_].l = registers_[8 + instruction_.reg(next_operand_)].l;
@@ -1170,6 +1186,16 @@ void Processor<BusHandler, dtack_is_implicit, permit_overrun, signal_will_perfor
 			Access(operand_[next_operand_].low);	// nr
 		MoveToNextOperand(FetchOperand_bw);
 
+		BeginStateMode(MOVE_b, AddressRegisterIndirectWithPostincrement):
+			effective_address_[1].l = registers_[8 + instruction_.reg(1)].l;
+			registers_[8 + instruction_.reg(1)].l += address_increments[0][instruction_.reg(1)];
+			SetDataAddress(effective_address_[1].l);
+			SetupDataAccess(0, Microcycle::SelectByte);
+
+			Access(operand_[next_operand_].low);	// nw
+			Prefetch();								// np
+		MoveToStateSpecific(Decode);
+
 		BeginStateMode(FetchOperand_l, AddressRegisterIndirectWithPostincrement):
 			effective_address_[next_operand_].l = registers_[8 + instruction_.reg(next_operand_)].l;
 			registers_[8 + instruction_.reg(next_operand_)].l += 4;
@@ -1199,6 +1225,16 @@ void Processor<BusHandler, dtack_is_implicit, permit_overrun, signal_will_perfor
 			IdleBus(1);								// n
 			Access(operand_[next_operand_].low);	// nr
 		MoveToNextOperand(FetchOperand_bw);
+
+		BeginStateMode(MOVE_b, AddressRegisterIndirectWithPredecrement):
+			registers_[8 + instruction_.reg(1)].l -= address_increments[0][instruction_.reg(1)];
+			effective_address_[1].l = registers_[8 + instruction_.reg(1)].l;
+			SetDataAddress(effective_address_[1].l);
+			SetupDataAccess(0, Microcycle::SelectByte);
+
+			Prefetch();								// np
+			Access(operand_[next_operand_].low);	// nw
+		MoveToStateSpecific(Decode);
 
 		BeginStateMode(FetchOperand_l, AddressRegisterIndirectWithPredecrement):
 			registers_[8 + instruction_.reg(next_operand_)].l -= 4;
@@ -1233,6 +1269,19 @@ void Processor<BusHandler, dtack_is_implicit, permit_overrun, signal_will_perfor
 			Prefetch();								// np
 			Access(operand_[next_operand_].low);	// nr
 		MoveToNextOperand(FetchOperand_bw);
+
+		BeginStateMode(MOVE_b, AddressRegisterIndirectWithDisplacement):
+			effective_address_[1].l =
+				registers_[8 + instruction_.reg(1)].l +
+				uint32_t(int16_t(prefetch_.w));
+
+			SetDataAddress(effective_address_[1].l);
+			SetupDataAccess(0, Microcycle::SelectByte);
+
+			Prefetch();								// np
+			Access(operand_[next_operand_].low);	// nw
+			Prefetch();								// np
+		MoveToStateSpecific(Decode);
 
 		BeginStateMode(FetchOperand_l, AddressRegisterIndirectWithDisplacement):
 			effective_address_[next_operand_].l =
@@ -1281,6 +1330,19 @@ void Processor<BusHandler, dtack_is_implicit, permit_overrun, signal_will_perfor
 			Prefetch();								// np
 			Access(operand_[next_operand_].low);	// nr
 		MoveToNextOperand(FetchOperand_bw);
+
+		BeginStateMode(MOVE_b, ProgramCounterIndirectWithDisplacement):
+			effective_address_[1].l =
+				program_counter_.l - 2 +
+				uint32_t(int16_t(prefetch_.w));
+
+			SetDataAddress(effective_address_[1].l);
+			SetupDataAccess(0, Microcycle::SelectByte);
+
+			Prefetch();								// np
+			Access(operand_[next_operand_].low);	// nw
+			Prefetch();								// np
+		MoveToStateSpecific(Decode);
 
 		BeginStateMode(FetchOperand_l, ProgramCounterIndirectWithDisplacement):
 			effective_address_[next_operand_].l =
@@ -1336,6 +1398,18 @@ void Processor<BusHandler, dtack_is_implicit, permit_overrun, signal_will_perfor
 			Access(operand_[next_operand_].low);	// nr
 		MoveToNextOperand(FetchOperand_bw);
 
+		BeginStateMode(MOVE_b, AddressRegisterIndirectWithIndex8bitDisplacement):
+			effective_address_[1].l = d8Xn(registers_[8 + instruction_.reg(1)].l);
+
+			SetDataAddress(effective_address_[1].l);
+			SetupDataAccess(0, Microcycle::SelectByte);
+
+			IdleBus(1);								// n
+			Prefetch();								// np
+			Access(operand_[next_operand_].low);	// nw
+			Prefetch();								// np
+		MoveToStateSpecific(Decode);
+
 		BeginStateMode(FetchOperand_l, AddressRegisterIndirectWithIndex8bitDisplacement):
 			effective_address_[next_operand_].l = d8Xn(registers_[8 + instruction_.reg(next_operand_)].l);
 			SetDataAddress(effective_address_[next_operand_].l);
@@ -1387,6 +1461,18 @@ void Processor<BusHandler, dtack_is_implicit, permit_overrun, signal_will_perfor
 			Prefetch();								// np
 			Access(operand_[next_operand_].low);	// nr
 		MoveToNextOperand(FetchOperand_bw);
+
+		BeginStateMode(MOVE_b, ProgramCounterIndirectWithIndex8bitDisplacement):
+			effective_address_[1].l = d8Xn(program_counter_.l - 2);
+
+			SetDataAddress(effective_address_[1].l);
+			SetupDataAccess(0, Microcycle::SelectByte);
+
+			IdleBus(1);								// n
+			Prefetch();								// np
+			Access(operand_[next_operand_].low);	// nw
+			Prefetch();								// np
+		MoveToStateSpecific(Decode);
 
 		BeginStateMode(FetchOperand_l, ProgramCounterIndirectWithIndex8bitDisplacement):
 			effective_address_[next_operand_].l = d8Xn(program_counter_.l - 2);
@@ -1441,6 +1527,17 @@ void Processor<BusHandler, dtack_is_implicit, permit_overrun, signal_will_perfor
 			Access(operand_[next_operand_].low);	// nr
 		MoveToNextOperand(FetchOperand_bw);
 
+		BeginStateMode(MOVE_b, AbsoluteShort):
+			effective_address_[1].l = uint32_t(int16_t(prefetch_.w));
+
+			SetDataAddress(effective_address_[1].l);
+			SetupDataAccess(0, Microcycle::SelectByte);
+
+			Prefetch();								// np
+			Access(operand_[next_operand_].low);	// nw
+			Prefetch();								// np
+		MoveToStateSpecific(Decode);
+
 		BeginStateMode(FetchOperand_l, AbsoluteShort):
 			effective_address_[next_operand_].l = uint32_t(int16_t(prefetch_.w));
 			SetDataAddress(effective_address_[next_operand_].l);
@@ -1479,6 +1576,34 @@ void Processor<BusHandler, dtack_is_implicit, permit_overrun, signal_will_perfor
 			Prefetch();								// np
 			Access(operand_[next_operand_].low);	// nr
 		MoveToNextOperand(FetchOperand_bw);
+
+		BeginStateMode(MOVE_b, AbsoluteLong):
+			Prefetch();								// np
+
+			effective_address_[1].l = prefetch_.l;
+
+			SetDataAddress(effective_address_[1].l);
+			SetupDataAccess(0, Microcycle::SelectByte);
+
+			switch(instruction_.mode(0)) {
+				case Mode::AddressRegisterDirect:
+				case Mode::DataRegisterDirect:
+				case Mode::ImmediateData:
+					MoveToStateSpecific(MOVE_b_AbsoluteLong_prefetch_first);
+
+				default: break;
+			}
+
+			Access(operand_[next_operand_].low);	// nw
+			Prefetch();								// np
+			Prefetch();								// np
+		MoveToStateSpecific(Decode);
+
+		BeginState(MOVE_b_AbsoluteLong_prefetch_first):
+			Prefetch();								// np
+			Access(operand_[next_operand_].low);	// nw
+			Prefetch();								// np
+		MoveToStateSpecific(Decode);
 
 		BeginStateMode(FetchOperand_l, AbsoluteLong):
 			Prefetch();								// np
@@ -1748,6 +1873,10 @@ void Processor<BusHandler, dtack_is_implicit, permit_overrun, signal_will_perfor
 			Access(operand_[1].low);
 			Prefetch();
 		MoveToStateSpecific(Decode);
+
+		BeginState(MOVE_b):
+			PerformSpecific(MOVEb);
+		MoveToAddressingMode(MOVE_b, instruction_.mode(1));
 
 		//
 		// [ABCD/SBCD/SUBX/ADDX] (An)-, (An)-

--- a/Processors/68000Mk2/Implementation/68000Mk2Implementation.hpp
+++ b/Processors/68000Mk2/Implementation/68000Mk2Implementation.hpp
@@ -409,15 +409,14 @@ void Processor<BusHandler, dtack_is_implicit, permit_overrun, signal_will_perfor
 
 			// Push status and current program counter.
 			// Write order is wacky here, but I think it's correct.
-			registers_[15].l -= 6;
-			Access(captured_status_);			// ns
-
-			registers_[15].l += 4;
+			registers_[15].l -= 2;
 			Access(instruction_address_.low);	// ns
 
-			registers_[15].l -= 2;
-			Access(instruction_address_.high);	// nS
+			registers_[15].l -= 4;
+			Access(captured_status_);			// ns
 
+			registers_[15].l += 2;
+			Access(instruction_address_.high);	// nS
 			registers_[15].l -= 2;
 
 			// Grab new program counter.

--- a/Processors/68000Mk2/Implementation/68000Mk2Implementation.hpp
+++ b/Processors/68000Mk2/Implementation/68000Mk2Implementation.hpp
@@ -63,16 +63,32 @@ enum ExecutionState: int {
 	// up on its feet and profiling becomes an option.
 
 	/// Perform the proper sequence to fetch a byte or word operand.
+	/// i.e.
+	///
+	/// Dn/An/Q		-				(An)			nr
+	///	(An)+			nr				-(An)			n nr
+	///	(d16, An)		np nr				(d8, An, Xn)	n np nr
+	///	(d16, PC)		np nr				(d8, PC, Xn)	n np nr
+	///	(xxx).w		np nr				(xxx).l		np np nr
+	///	#			np
 	AddressingDispatch(FetchOperand_bw),
 
 	/// Perform the proper sequence to fetch a long-word operand.
+	/// i.e.
+	///
+	/// Dn/An/Q		-				(An)			nR nr
+	///	(An)+			nR nr				-(An)			n nR nr
+	///	(d16, An)		np nR nr			(d8, An, Xn)	n np nR nr
+	///	(d16, PC)		np nR nr			(d8, PC, Xn)	n np nR nr
+	///	(xxx).w		np nR nr			(xxx).l		np np nR nr
+	///	#			np np
 	AddressingDispatch(FetchOperand_l),
 
 	/// Perform the sequence to calculate an effective address, but don't fetch from it.
 	/// There's a lack of uniformity in the bus programs used by the 68000 for relevant
 	/// instructions; this entry point uses:
 	///
-	/// Dn			-				An			-
+	/// Dn/An		-				(An)			-
 	///	(An)+			-				-(An)			-
 	///	(d16, An)		np				(d8, An, Xn)	np n
 	///	(d16, PC)		np				(d8, PC, Xn)	np n

--- a/Processors/68000Mk2/Implementation/68000Mk2Implementation.hpp
+++ b/Processors/68000Mk2/Implementation/68000Mk2Implementation.hpp
@@ -2782,6 +2782,12 @@ void Processor<BusHandler, dtack_is_implicit, permit_overrun, signal_will_perfor
 	program_counter_.l += 2;
 }
 
+template <class BusHandler, bool dtack_is_implicit, bool permit_overrun, bool signal_will_perform>
+void Processor<BusHandler, dtack_is_implicit, permit_overrun, signal_will_perform>::reset() {
+	state_ = Reset;
+	status_.begin_exception(7);
+}
+
 }
 }
 


### PR DESCRIPTION
Expected steps:

1. use this to uncover all meaningful differences between my old and new implementations;
2. find out which implementation is correct, where known, and fix the new implementation if necessary;
3. solidify all intermediate results into JSON so that they can outlive the old implementation.

Corrections to the new 68000 are already included and will likely continue to turn up.