### PR TITLE
macOS: perform audio buffer allocations ahead of time.

### DIFF
--- a/OSBindings/Mac/Clock Signal/Audio/CSAudioQueue.h
+++ b/OSBindings/Mac/Clock Signal/Audio/CSAudioQueue.h
@@ -36,9 +36,8 @@
 	Enqueues a buffer for playback.
 
 	@param buffer A pointer to the data that comprises the buffer.
-	@param lengthInSamples The length of the buffer, in samples.
 */
-- (void)enqueueAudioBuffer:(nonnull const int16_t *)buffer numberOfSamples:(size_t)lengthInSamples;
+- (void)enqueueAudioBuffer:(nonnull const int16_t *)buffer;
 
 /// @returns The sampling rate at which this queue is playing audio.
 @property (nonatomic, readonly) Float64 samplingRate;
@@ -57,6 +56,11 @@
 	decide in what size to enqueue audio, this is a helpful suggestion.
 */
 @property (nonatomic, readonly) NSUInteger preferredBufferSize;
+
+/*!
+	Sets the size of buffers to be posted, in samplrs.
+*/
+@property (nonatomic) NSUInteger bufferSize;
 
 /*!
 	@returns @C YES if this queue is running low or is completely exhausted of new audio buffers.

--- a/OSBindings/Mac/Clock Signal/Audio/CSAudioQueue.m
+++ b/OSBindings/Mac/Clock Signal/Audio/CSAudioQueue.m
@@ -119,8 +119,8 @@
 
 #pragma mark - Audio enqueuer
 
-- (void)enqueueAudioBuffer:(const int16_t *)buffer numberOfSamples:(size_t)lengthInSamples {
-	size_t bufferBytes = lengthInSamples * sizeof(int16_t);
+- (void)enqueueAudioBuffer:(const int16_t *)buffer {
+	const size_t bufferBytes = self.bufferSize * sizeof(int16_t);
 
 	// Don't enqueue more than 4 buffers ahead of now, to ensure not too much latency accrues.
 	if(atomic_load_explicit(&_enqueuedBuffers, memory_order_relaxed) == 4) {

--- a/OSBindings/Mac/Clock Signal/Machine/CSMachine.mm
+++ b/OSBindings/Mac/Clock Signal/Machine/CSMachine.mm
@@ -30,6 +30,7 @@
 #import "NSBundle+DataResource.h"
 #import "NSData+StdVector.h"
 
+#include <cassert>
 #include <atomic>
 #include <bitset>
 #include <codecvt>
@@ -175,7 +176,8 @@ struct ActivityObserver: public Activity::Observer {
 }
 
 - (void)speaker:(Outputs::Speaker::Speaker *)speaker didCompleteSamples:(const int16_t *)samples length:(int)length {
-	[self.audioQueue enqueueAudioBuffer:samples numberOfSamples:(unsigned int)length];
+	assert(NSUInteger(length) == self.audioQueue.bufferSize);
+	[self.audioQueue enqueueAudioBuffer:samples];
 }
 
 - (void)speakerDidChangeInputClock:(Outputs::Speaker::Speaker *)speaker {
@@ -231,6 +233,7 @@ struct ActivityObserver: public Activity::Observer {
 
 - (void)setAudioSamplingRate:(float)samplingRate bufferSize:(NSUInteger)bufferSize stereo:(BOOL)stereo {
 	@synchronized(self) {
+		self.audioQueue.bufferSize = bufferSize;
 		[self setSpeakerDelegate:&_speakerDelegate sampleRate:samplingRate bufferSize:bufferSize stereo:stereo];
 	}
 }


### PR DESCRIPTION
The more interesting part of this is that it reduces potential runtime failure points; although it reduces the scope of the critical section, it had no empirical effect on performance.