### PR TITLE
Align Scan to be a multiple of four bytes

### DIFF
--- a/Outputs/OpenGL/ScanTargetGLSLFragments.cpp
+++ b/Outputs/OpenGL/ScanTargetGLSLFragments.cpp
@@ -84,6 +84,11 @@ void ScanTarget::enable_vertex_attributes(ShaderType type, Shader &target) {
 	Scan test_scan;
 	Line test_line;
 
+	// Some GPUs require alignment and will need to copy vertex data to a
+	// shadow buffer otherwise
+	static_assert(sizeof(Scan) % 4 == 0);
+	static_assert(sizeof(Line) % 4 == 0);
+
 	switch(type) {
 		case ShaderType::Composition:
 			for(int c = 0; c < 2; ++c) {

--- a/Outputs/ScanTarget.hpp
+++ b/Outputs/ScanTarget.hpp
@@ -304,7 +304,11 @@ struct ScanTarget {
 
 			/// For composite video, dictates the amplitude of the colour subcarrier as a proportion of
 			/// the whole, as determined from the colour burst. Will be 0 if there was no colour burst.
-			uint8_t composite_amplitude;
+			union {
+				uint8_t composite_amplitude;
+
+				uint32_t padding;
+			};
 		};
 
 		/// Requests a new scan to populate.


### PR DESCRIPTION
Some GPUs (e.g. r600) require the stride of vertex attributes to be a multiple of four bytes, add two bytes of padding to the Scan struct to meet this alignment requirement and reduce driver CPU overhead.