### PR TITLE
Tidy up 68000, primarily switching from macros to templates.

### DIFF
--- a/InstructionSets/M68k/Implementation/PerformImplementation.hpp
+++ b/InstructionSets/M68k/Implementation/PerformImplementation.hpp
@@ -859,14 +859,14 @@ template <
 		break;
 
 		case Operation::ROLm:
-			src.w = (src.w << 1) | (src.w >> 15);
+			src.w = uint16_t((src.w << 1) | (src.w >> 15));
 			status.carry_flag = src.w & 0x0001;
 			status.overflow_flag = 0;
 			Primitive::set_neg_zero(src.w, status);
 		break;
 
 		case Operation::RORm:
-			src.w = (src.w >> 1) | (src.w << 15);
+			src.w = uint16_t((src.w >> 1) | (src.w << 15));
 			status.carry_flag = src.w & Primitive::top_bit<uint16_t>();
 			status.overflow_flag = 0;
 			Primitive::set_neg_zero(src.w, status);
@@ -874,7 +874,7 @@ template <
 
 		case Operation::ROXLm:
 			status.carry_flag = src.w & Primitive::top_bit<uint16_t>();
-			src.w = (src.w << 1) | (status.extend_flag ? 0x0001 : 0x0000);
+			src.w = uint16_t((src.w << 1) | (status.extend_flag ? 0x0001 : 0x0000));
 			status.extend_flag = status.carry_flag;
 			status.overflow_flag = 0;
 			Primitive::set_neg_zero(src.w, status);
@@ -882,7 +882,7 @@ template <
 
 		case Operation::ROXRm:
 			status.carry_flag = src.w & 0x0001;
-			src.w = (src.w >> 1) | (status.extend_flag ? 0x8000 : 0x0000);
+			src.w = uint16_t((src.w >> 1) | (status.extend_flag ? 0x8000 : 0x0000));
 			status.extend_flag = status.carry_flag;
 			status.overflow_flag = 0;
 			Primitive::set_neg_zero(src.w, status);

--- a/InstructionSets/M68k/Implementation/PerformImplementation.hpp
+++ b/InstructionSets/M68k/Implementation/PerformImplementation.hpp
@@ -435,20 +435,22 @@ template <Operation operation, typename IntT, typename FlowController> void rox(
 	} else {
  		switch(operation) {
 			case Operation::ROXLb:	case Operation::ROXLw:	case Operation::ROXLl:
-				status.carry_flag = status.extend_flag = Status::FlagT((destination >> (size - shift)) & 1);
+				status.carry_flag = Status::FlagT((destination >> (size - shift)) & 1);
 				destination = IntT(
 					(destination << shift) |
 					(IntT(status.extend_flag ? 1 : 0) << (shift - 1)) |
 					(destination >> (size + 1 - shift))
 				);
+				status.extend_flag = status.carry_flag;
 			break;
 			case Operation::ROXRb:	case Operation::ROXRw:	case Operation::ROXRl:
-				status.carry_flag = status.extend_flag = Status::FlagT(destination & (1 << (shift - 1)));
+				status.carry_flag = Status::FlagT(destination & (1 << (shift - 1)));
 				destination = IntT(
 					(destination >> shift) |
 					((status.extend_flag ? top_bit<IntT>() : 0) >> (shift - 1)) |
 					(destination << (size + 1 - shift))
 				);
+				status.extend_flag = status.carry_flag;
 			break;
 		}
 	}

--- a/InstructionSets/M68k/Implementation/PerformImplementation.hpp
+++ b/InstructionSets/M68k/Implementation/PerformImplementation.hpp
@@ -888,29 +888,29 @@ template <
 			Primitive::set_neg_zero(src.w, status);
 		break;
 
-		case Operation::ASLb: Primitive::shift<Operation::ASLb>(src.l, dest.b, status, flow_controller);	break;
-		case Operation::ASLw: Primitive::shift<Operation::ASLw>(src.l, dest.w, status, flow_controller);	break;
-		case Operation::ASLl: Primitive::shift<Operation::ASLl>(src.l, dest.l, status, flow_controller);	break;
+		case Operation::ASLb:	Primitive::shift<Operation::ASLb>(src.l, dest.b, status, flow_controller);	break;
+		case Operation::ASLw:	Primitive::shift<Operation::ASLw>(src.l, dest.w, status, flow_controller);	break;
+		case Operation::ASLl:	Primitive::shift<Operation::ASLl>(src.l, dest.l, status, flow_controller);	break;
 
-		case Operation::ASRb: Primitive::shift<Operation::ASRb>(src.l, dest.b, status, flow_controller);	break;
-		case Operation::ASRw: Primitive::shift<Operation::ASRw>(src.l, dest.w, status, flow_controller);	break;
-		case Operation::ASRl: Primitive::shift<Operation::ASRl>(src.l, dest.l, status, flow_controller);	break;
+		case Operation::ASRb:	Primitive::shift<Operation::ASRb>(src.l, dest.b, status, flow_controller);	break;
+		case Operation::ASRw:	Primitive::shift<Operation::ASRw>(src.l, dest.w, status, flow_controller);	break;
+		case Operation::ASRl:	Primitive::shift<Operation::ASRl>(src.l, dest.l, status, flow_controller);	break;
 
-		case Operation::LSLb: Primitive::shift<Operation::LSLb>(src.l, dest.b, status, flow_controller);	break;
-		case Operation::LSLw: Primitive::shift<Operation::LSLw>(src.l, dest.w, status, flow_controller);	break;
-		case Operation::LSLl: Primitive::shift<Operation::LSLl>(src.l, dest.l, status, flow_controller);	break;
+		case Operation::LSLb:	Primitive::shift<Operation::LSLb>(src.l, dest.b, status, flow_controller);	break;
+		case Operation::LSLw:	Primitive::shift<Operation::LSLw>(src.l, dest.w, status, flow_controller);	break;
+		case Operation::LSLl:	Primitive::shift<Operation::LSLl>(src.l, dest.l, status, flow_controller);	break;
 
-		case Operation::LSRb: Primitive::shift<Operation::LSRb>(src.l, dest.b, status, flow_controller);	break;
-		case Operation::LSRw: Primitive::shift<Operation::LSRw>(src.l, dest.w, status, flow_controller);	break;
-		case Operation::LSRl: Primitive::shift<Operation::LSRl>(src.l, dest.l, status, flow_controller);	break;
+		case Operation::LSRb:	Primitive::shift<Operation::LSRb>(src.l, dest.b, status, flow_controller);	break;
+		case Operation::LSRw:	Primitive::shift<Operation::LSRw>(src.l, dest.w, status, flow_controller);	break;
+		case Operation::LSRl:	Primitive::shift<Operation::LSRl>(src.l, dest.l, status, flow_controller);	break;
 
-		case Operation::ROLb: Primitive::rotate<Operation::ROLb>(src.l, dest.b, status, flow_controller);	break;
-		case Operation::ROLw: Primitive::rotate<Operation::ROLw>(src.l, dest.w, status, flow_controller); 	break;
-		case Operation::ROLl: Primitive::rotate<Operation::ROLl>(src.l, dest.l, status, flow_controller); 	break;
+		case Operation::ROLb:	Primitive::rotate<Operation::ROLb>(src.l, dest.b, status, flow_controller);	break;
+		case Operation::ROLw:	Primitive::rotate<Operation::ROLw>(src.l, dest.w, status, flow_controller); break;
+		case Operation::ROLl:	Primitive::rotate<Operation::ROLl>(src.l, dest.l, status, flow_controller); break;
 
-		case Operation::RORb: Primitive::rotate<Operation::RORb>(src.l, dest.b, status, flow_controller);	break;
-		case Operation::RORw: Primitive::rotate<Operation::RORw>(src.l, dest.w, status, flow_controller); 	break;
-		case Operation::RORl: Primitive::rotate<Operation::RORl>(src.l, dest.l, status, flow_controller); 	break;
+		case Operation::RORb:	Primitive::rotate<Operation::RORb>(src.l, dest.b, status, flow_controller);	break;
+		case Operation::RORw:	Primitive::rotate<Operation::RORw>(src.l, dest.w, status, flow_controller); break;
+		case Operation::RORl:	Primitive::rotate<Operation::RORl>(src.l, dest.l, status, flow_controller); break;
 
 		case Operation::ROXLb:	Primitive::rox<Operation::ROXLb>(src.l, dest.b, status, flow_controller);	break;
 		case Operation::ROXLw:	Primitive::rox<Operation::ROXLw>(src.l, dest.w, status, flow_controller);	break;

--- a/InstructionSets/M68k/Implementation/PerformImplementation.hpp
+++ b/InstructionSets/M68k/Implementation/PerformImplementation.hpp
@@ -830,6 +830,34 @@ template <
 		/*
 			Shifts and rotates.
 		*/
+		case Operation::ASLm:
+			status.extend_flag = status.carry_flag = src.w & Primitive::top_bit<uint16_t>();
+			status.overflow_flag = (src.w ^ (src.w << 1)) & Primitive::top_bit<uint16_t>();
+			src.w <<= 1;
+			Primitive::set_neg_zero(src.w, status);
+		break;
+
+		case Operation::LSLm:
+			status.extend_flag = status.carry_flag = src.w & Primitive::top_bit<uint16_t>();
+			status.overflow_flag = 0;
+			src.w <<= 1;
+			Primitive::set_neg_zero(src.w, status);
+		break;
+
+		case Operation::ASRm:
+			status.extend_flag = status.carry_flag = src.w & 1;
+			status.overflow_flag = 0;
+			src.w = (src.w & Primitive::top_bit<uint16_t>()) | (src.w >> 1);
+			Primitive::set_neg_zero(src.w, status);
+		break;
+
+		case Operation::LSRm:
+			status.extend_flag = status.carry_flag = src.w & 1;
+			status.overflow_flag = 0;
+			src.w >>= 1;
+			Primitive::set_neg_zero(src.w, status);
+		break;
+
 #define set_neg_zero(v, m)														\
 	status.zero_result = Status::FlagT(v);						\
 	status.negative_flag = status.zero_result & Status::FlagT(m);
@@ -847,42 +875,18 @@ template <
 
 #define set_flags_w(t) set_flags(src.w, 0x8000, t)
 
-		case Operation::ASLm: {
-			const auto value = src.w;
-			src.w = uint16_t(value << 1);
-			status.extend_flag = status.carry_flag = value & 0x8000;
-			set_neg_zero_overflow(src.w, 0x8000);
-		} break;
 		case Operation::ASLb: Primitive::shift<Operation::ASLb>(src.l, dest.b, status, flow_controller);	break;
 		case Operation::ASLw: Primitive::shift<Operation::ASLw>(src.l, dest.w, status, flow_controller);	break;
 		case Operation::ASLl: Primitive::shift<Operation::ASLl>(src.l, dest.l, status, flow_controller);	break;
 
-		case Operation::ASRm: {
-			const auto value = src.w;
-			src.w = (value&0x8000) | (value >> 1);
-			status.extend_flag = status.carry_flag = value & 1;
-			set_neg_zero_overflow(src.w, 0x8000);
-		} break;
 		case Operation::ASRb: Primitive::shift<Operation::ASRb>(src.l, dest.b, status, flow_controller);	break;
 		case Operation::ASRw: Primitive::shift<Operation::ASRw>(src.l, dest.w, status, flow_controller);	break;
 		case Operation::ASRl: Primitive::shift<Operation::ASRl>(src.l, dest.l, status, flow_controller);	break;
 
-		case Operation::LSLm: {
-			const auto value = src.w;
-			src.w = uint16_t(value << 1);
-			status.extend_flag = status.carry_flag = value & 0x8000;
-			set_neg_zero_overflow(src.w, 0x8000);
-		} break;
 		case Operation::LSLb: Primitive::shift<Operation::LSLb>(src.l, dest.b, status, flow_controller);	break;
 		case Operation::LSLw: Primitive::shift<Operation::LSLw>(src.l, dest.w, status, flow_controller);	break;
 		case Operation::LSLl: Primitive::shift<Operation::LSLl>(src.l, dest.l, status, flow_controller);	break;
 
-		case Operation::LSRm: {
-			const auto value = src.w;
-			src.w = value >> 1;
-			status.extend_flag = status.carry_flag = value & 1;
-			set_neg_zero_overflow(src.w, 0x8000);
-		} break;
 		case Operation::LSRb: Primitive::shift<Operation::LSRb>(src.l, dest.b, status, flow_controller);	break;
 		case Operation::LSRw: Primitive::shift<Operation::LSRw>(src.l, dest.w, status, flow_controller);	break;
 		case Operation::LSRl: Primitive::shift<Operation::LSRl>(src.l, dest.l, status, flow_controller);	break;

--- a/InstructionSets/M68k/Implementation/PerformImplementation.hpp
+++ b/InstructionSets/M68k/Implementation/PerformImplementation.hpp
@@ -22,18 +22,6 @@ namespace M68k {
 
 namespace Primitive {
 
-/// Provides a type alias, @c type, which is an unsigned int bigger than @c IntT.
-template <typename IntT> struct BiggerInt {};
-template <> struct BiggerInt<uint8_t> {
-	using type = uint16_t;
-};
-template <> struct BiggerInt<uint16_t> {
-	using type = uint32_t;
-};
-template <> struct BiggerInt<uint32_t> {
-	using type = uint64_t;
-};
-
 /// @returns An int of type @c IntT with only the most-significant bit set.
 template <typename IntT> constexpr IntT top_bit() {
 	static_assert(!std::numeric_limits<IntT>::is_signed);

--- a/InstructionSets/M68k/Implementation/PerformImplementation.hpp
+++ b/InstructionSets/M68k/Implementation/PerformImplementation.hpp
@@ -234,6 +234,12 @@ template <bool is_extend, typename IntT> void negative(IntT &source, Status &sta
 	source = result;
 }
 
+template <typename IntT> void test(IntT source, Status &status) {
+	status.carry_flag = status.overflow_flag = 0;
+	status.zero_result = Status::FlagT(source);
+	status.negative_flag = status.zero_result & top_bit<IntT>();
+}
+
 }
 
 template <
@@ -970,23 +976,9 @@ template <
 			TSTs: compare to zero.
 		*/
 
-		case Operation::TSTb:
-			status.carry_flag = status.overflow_flag = 0;
-			status.zero_result = src.b;
-			status.negative_flag = status.zero_result & 0x80;
-		break;
-
-		case Operation::TSTw:
-			status.carry_flag = status.overflow_flag = 0;
-			status.zero_result = src.w;
-			status.negative_flag = status.zero_result & 0x8000;
-		break;
-
-		case Operation::TSTl:
-			status.carry_flag = status.overflow_flag = 0;
-			status.zero_result = src.l;
-			status.negative_flag = status.zero_result & 0x80000000;
-		break;
+		case Operation::TSTb:	Primitive::test(src.b, status);	break;
+		case Operation::TSTw:	Primitive::test(src.w, status);	break;
+		case Operation::TSTl:	Primitive::test(src.l, status);	break;
 
 		case Operation::STOP:
 			status.set_status(src.w);

--- a/InstructionSets/M68k/Implementation/PerformImplementation.hpp
+++ b/InstructionSets/M68k/Implementation/PerformImplementation.hpp
@@ -357,11 +357,13 @@ template <Operation operation, typename IntT, typename FlowController> void shif
 						// result of 0, so overflow is set if any bit was originally set.
 						status.overflow_flag = destination;
 					} else {
-						// For a shift of n places, overflow will be set if the top n bits were not
+						// For a shift of n places, overflow will be set if the top n+1 bits were not
 						// all the same value.
 						const auto affected_bits = IntT(
 							~((top_bit<IntT>() >> shift) - 1)
-						);
+						);	// e.g. shift = 1 => ~((0x80 >> 1) - 1) = ~(0x40 - 1) = ~0x3f = 0xc0, i.e. if shift is
+							// 1 then the top two bits are relevant to whether there was overflow. If they have the
+							// same value, i.e. are both 0 or are both 1, then there wasn't. Otherwise there was.
 						status.overflow_flag = (destination & affected_bits) && (destination & affected_bits) != affected_bits;
 					}
 				}

--- a/InstructionSets/M68k/Implementation/PerformImplementation.hpp
+++ b/InstructionSets/M68k/Implementation/PerformImplementation.hpp
@@ -359,7 +359,9 @@ template <Operation operation, typename IntT, typename FlowController> void shif
 					} else {
 						// For a shift of n places, overflow will be set if the top n bits were not
 						// all the same value.
-						const auto affected_bits = IntT(~0 << shift);
+						const auto affected_bits = IntT(
+							~((top_bit<IntT>() >> shift) - 1)
+						);
 						status.overflow_flag = (destination & affected_bits) && (destination & affected_bits) != affected_bits;
 					}
 				}

--- a/InstructionSets/M68k/Implementation/PerformImplementation.hpp
+++ b/InstructionSets/M68k/Implementation/PerformImplementation.hpp
@@ -29,11 +29,6 @@ template <typename IntT> constexpr IntT top_bit() {
 	return max - (max >> 1);
 }
 
-/// @returns The number of bits in @c IntT.
-template <typename IntT> constexpr int bit_count() {
-	return sizeof(IntT) * 8;
-}
-
 /// @returns An int with the top bit indicating whether overflow occurred when @c source and @c destination
 /// were either added (if @c is_add is true) or subtracted (if @c is_add is false) and the result was @c result.
 /// All other bits will be clear.

--- a/InstructionSets/M68k/Implementation/PerformImplementation.hpp
+++ b/InstructionSets/M68k/Implementation/PerformImplementation.hpp
@@ -435,6 +435,13 @@ template <Operation operation, typename IntT, typename FlowController> void rox(
 		// When shift is zero, extend is unaffected but is copied to carry.
 		status.carry_flag = status.extend_flag;
 	} else {
+		// TODO: if the value of the right operand is negative or is greater or equal to
+		// the number of bits in the promoted left operand, the behavior is undefined.
+		//
+		// i.e. for a long if shift >= 32,
+		// or size + 1 - shift >= 32, i.e. 1 - shift >= 0, 1 >= shift; i.e. shift <= 1
+		// ... the code below is undefined behaviour.
+
  		switch(operation) {
 			case Operation::ROXLb:	case Operation::ROXLw:	case Operation::ROXLl:
 				status.carry_flag = Status::FlagT((destination >> (size - shift)) & 1);

--- a/InstructionSets/M68k/Implementation/PerformImplementation.hpp
+++ b/InstructionSets/M68k/Implementation/PerformImplementation.hpp
@@ -392,11 +392,13 @@ template <Operation operation, typename IntT, typename FlowController> void rota
 	);
 
 	const auto size = bit_size<IntT>();
-	const auto shift = shift_count<IntT>(uint8_t(source), flow_controller) & (size - 1);
+	auto shift = shift_count<IntT>(uint8_t(source), flow_controller);
 
 	if(!shift) {
 		status.carry_flag = 0;
 	} else {
+		shift &= size - 1;
+
 		switch(operation) {
 			case Operation::ROLb:	case Operation::ROLw:	case Operation::ROLl:
 				destination = IntT(

--- a/InstructionSets/M68k/Status.hpp
+++ b/InstructionSets/M68k/Status.hpp
@@ -54,6 +54,18 @@ struct Status {
 	FlagT overflow_flag = 0;	// The overflow flag is set if and only if this value is non-zero.
 	FlagT negative_flag = 0;	// The negative flag is set if and only this value is non-zero.
 
+	/// Sets the negative flag per @c value
+	template <typename IntT> void set_negative(IntT value) {
+		constexpr auto top_bit = IntT(1 << ((sizeof(IntT) * 8) - 1));
+		negative_flag = value & top_bit;
+	}
+
+	/// Sets both the negative and zero flags according to @c value.
+	template <typename IntT> void set_neg_zero(IntT value) {
+		zero_result = value;
+		set_negative(value);
+	}
+
 	/// Gets the current condition codes.
 	constexpr uint16_t ccr() const {
 		return

--- a/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
@@ -316,6 +316,7 @@
 		4B7136911F789C93008B8ED9 /* SegmentParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B71368F1F789C93008B8ED9 /* SegmentParser.cpp */; };
 		4B74CF812312FA9C00500CE8 /* HFV.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B74CF802312FA9C00500CE8 /* HFV.cpp */; };
 		4B74CF822312FA9C00500CE8 /* HFV.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B74CF802312FA9C00500CE8 /* HFV.cpp */; };
+		4B75EBFE28FF9CA20088AB22 /* MacintoshVolume.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B4C81C928B56CF800F84AE9 /* MacintoshVolume.cpp */; };
 		4B75F979280D7C5100121055 /* 68000DecoderTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4B75F978280D7C5100121055 /* 68000DecoderTests.mm */; };
 		4B75F97B280D7C7700121055 /* 68000 Decoding in Resources */ = {isa = PBXBuildFile; fileRef = 4B75F97A280D7C7700121055 /* 68000 Decoding */; };
 		4B7752A628217DF80073E2C5 /* Dave.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4BFEA2ED2682A7B900EBF94C /* Dave.cpp */; };
@@ -6183,6 +6184,7 @@
 				4BEE4BD425A26E2B00011BD2 /* x86DecoderTests.mm in Sources */,
 				4B778F3623A5F1040000D260 /* Target.cpp in Sources */,
 				4B1D08061E0F7A1100763741 /* TimeTests.mm in Sources */,
+				4B75EBFE28FF9CA20088AB22 /* MacintoshVolume.cpp in Sources */,
 				4B778F3D23A5F1750000D260 /* ncr5380.cpp in Sources */,
 				4BF701A026FFD32300996424 /* AmigaBlitterTests.mm in Sources */,
 				4B7752B428217ECB0073E2C5 /* ZXSpectrumTAP.cpp in Sources */,

--- a/OSBindings/Mac/Clock SignalTests/68000ComparativeTests.mm
+++ b/OSBindings/Mac/Clock SignalTests/68000ComparativeTests.mm
@@ -307,7 +307,8 @@ struct TestProcessor: public CPU::MC68000Mk2::BusHandler {
 
 			if(!address || !value) break;
 			XCTAssertEqual(test68000->ram[address.integerValue ^ 1], value.integerValue, @"%@: Memory at location %@ inconsistent", name, address);
-			if(test68000->ram[address.integerValue ^ 1] != value.integerValue) [_failures addObject:name];
+			if(test68000->ram[address.integerValue ^ 1] != value.integerValue)
+				[_failures addObject:name];
 		}
 
 		// Consider collating extra detail.
@@ -359,7 +360,8 @@ struct TestProcessor: public CPU::MC68000Mk2::BusHandler {
 		NSNumber *const value = [enumerator nextObject];
 
 		if(!address || !value) break;
-		if(_testExecutor->ram[address.integerValue] != value.integerValue) [_failures addObject:name];
+		if(_testExecutor->ram[address.integerValue] != value.integerValue)
+			[_failures addObject:name];
 	}
 
 	// If this test is now in the failures set, add the corresponding opcode for
@@ -425,12 +427,17 @@ struct TestProcessor: public CPU::MC68000Mk2::BusHandler {
 		const NSString *dX = [@"d" stringByAppendingFormat:@"%d", c];
 		const NSString *aX = [@"a" stringByAppendingFormat:@"%d", c];
 
-		if(registers.data[c] != [finalState[dX] integerValue]) [_failures addObject:name];
-		if(c < 7 && registers.address[c] != [finalState[aX] integerValue]) [_failures addObject:name];
+		if(registers.data[c] != [finalState[dX] integerValue])
+			[_failures addObject:name];
+		if(c < 7 && registers.address[c] != [finalState[aX] integerValue])
+			[_failures addObject:name];
 	}
-	if(registers.supervisor_stack_pointer != [finalState[@"a7"] integerValue]) [_failures addObject:name];
-	if(registers.user_stack_pointer != [finalState[@"usp"] integerValue]) [_failures addObject:name];
-	if(registers.program_counter + pcOffset != [finalState[@"pc"] integerValue]) [_failures addObject:name];
+	if(registers.supervisor_stack_pointer != [finalState[@"a7"] integerValue])
+		[_failures addObject:name];
+	if(registers.user_stack_pointer != [finalState[@"usp"] integerValue])
+		[_failures addObject:name];
+	if(registers.program_counter + pcOffset != [finalState[@"pc"] integerValue])
+		[_failures addObject:name];
 
 	const uint16_t correctSR = [finalState[@"sr"] integerValue];
 	if(registers.status != correctSR) {

--- a/OSBindings/Mac/Clock SignalTests/68000ComparativeTests.mm
+++ b/OSBindings/Mac/Clock SignalTests/68000ComparativeTests.mm
@@ -307,8 +307,7 @@ struct TestProcessor: public CPU::MC68000Mk2::BusHandler {
 
 			if(!address || !value) break;
 			XCTAssertEqual(test68000->ram[address.integerValue ^ 1], value.integerValue, @"%@: Memory at location %@ inconsistent", name, address);
-			if(test68000->ram[address.integerValue ^ 1] != value.integerValue)
-				[_failures addObject:name];
+			if(test68000->ram[address.integerValue ^ 1] != value.integerValue) [_failures addObject:name];
 		}
 
 		// Consider collating extra detail.
@@ -360,8 +359,7 @@ struct TestProcessor: public CPU::MC68000Mk2::BusHandler {
 		NSNumber *const value = [enumerator nextObject];
 
 		if(!address || !value) break;
-		if(_testExecutor->ram[address.integerValue] != value.integerValue)
-			[_failures addObject:name];
+		if(_testExecutor->ram[address.integerValue] != value.integerValue) [_failures addObject:name];
 	}
 
 	// If this test is now in the failures set, add the corresponding opcode for
@@ -427,17 +425,12 @@ struct TestProcessor: public CPU::MC68000Mk2::BusHandler {
 		const NSString *dX = [@"d" stringByAppendingFormat:@"%d", c];
 		const NSString *aX = [@"a" stringByAppendingFormat:@"%d", c];
 
-		if(registers.data[c] != [finalState[dX] integerValue])
-			[_failures addObject:name];
-		if(c < 7 && registers.address[c] != [finalState[aX] integerValue])
-			[_failures addObject:name];
+		if(registers.data[c] != [finalState[dX] integerValue]) [_failures addObject:name];
+		if(c < 7 && registers.address[c] != [finalState[aX] integerValue]) [_failures addObject:name];
 	}
-	if(registers.supervisor_stack_pointer != [finalState[@"a7"] integerValue])
-		[_failures addObject:name];
-	if(registers.user_stack_pointer != [finalState[@"usp"] integerValue])
-		[_failures addObject:name];
-	if(registers.program_counter + pcOffset != [finalState[@"pc"] integerValue])
-		[_failures addObject:name];
+	if(registers.supervisor_stack_pointer != [finalState[@"a7"] integerValue]) [_failures addObject:name];
+	if(registers.user_stack_pointer != [finalState[@"usp"] integerValue]) [_failures addObject:name];
+	if(registers.program_counter + pcOffset != [finalState[@"pc"] integerValue]) [_failures addObject:name];
 
 	const uint16_t correctSR = [finalState[@"sr"] integerValue];
 	if(registers.status != correctSR) {


### PR DESCRIPTION
Also adjusts shifts and rolls:
* adding safeguards against undefined behaviour (which was in practice affecting carry and extend, amongst others); and
* correcting logic for the overflow flag.