### PR TITLE
TMS9918 &c: Eliminate hard-coded assumption of 16kb.

### DIFF
--- a/Components/9918/Implementation/9918Base.hpp
+++ b/Components/9918/Implementation/9918Base.hpp
@@ -360,10 +360,10 @@ template <Personality personality> struct Base {
 						break;
 					}
 				}
-				ram_[ram_pointer_ & 16383] = read_ahead_buffer_;
+				ram_[ram_pointer_ & memory_mask(personality)] = read_ahead_buffer_;
 			break;
 			case MemoryAccess::Read:
-				read_ahead_buffer_ = ram_[ram_pointer_ & 16383];
+				read_ahead_buffer_ = ram_[ram_pointer_ & memory_mask(personality)];
 			break;
 		}
 		++ram_pointer_;

--- a/Components/9918/Implementation/PersonalityTraits.hpp
+++ b/Components/9918/Implementation/PersonalityTraits.hpp
@@ -42,6 +42,10 @@ constexpr size_t memory_size(Personality p) {
 	}
 }
 
+constexpr uint16_t memory_mask(Personality p) {
+	return (memory_size(p) >= 65536) ? 0xffff : uint16_t(memory_size(p) - 1);
+}
+
 }
 }
 


### PR DESCRIPTION
Clearly I'll have to do something else to support 128k+, probably move the ram pointer?