### PR TITLE
Definitively switch 9918 to counting cycle 0 as start-of-sync.

### DIFF
--- a/Components/9918/Implementation/9918.cpp
+++ b/Components/9918/Implementation/9918.cpp
@@ -419,6 +419,11 @@ void TMS9918<personality>::run_for(const HalfCycles cycles) {
 					break;
 				}
 
+				if constexpr (is_yamaha_vdp(personality)) {
+					this->fetch_line_buffer_->first_pixel_output_column += Storage<personality>::adjustment_[0];
+					this->fetch_line_buffer_->next_border_column += Storage<personality>::adjustment_[0];
+				}
+
 				this->fetch_line_buffer_->vertical_state =
 					this->screen_mode_ == ScreenMode::Blank ?
 						VerticalState::Blank :
@@ -874,9 +879,8 @@ void Base<personality>::commit_register(int reg, uint8_t value) {
 			break;
 
 			case 18:
-				if(value) {
-					LOG("TODO: Yamaha position adjustment; " << PADHEX(2) << +value);
-				}
+				Storage<personality>::adjustment_[0] = (8 - ((value & 15) ^ 8)) * 4;
+				Storage<personality>::adjustment_[1] = 8 - ((value >> 4) ^ 8);
 				// b0-b3: horizontal adjustment
 				// b4-b7: vertical adjustment
 			break;

--- a/Components/9918/Implementation/9918.cpp
+++ b/Components/9918/Implementation/9918.cpp
@@ -514,7 +514,7 @@ void TMS9918<personality>::run_for(const HalfCycles cycles) {
 				};
 
 				const auto right_blank = [&]() {
-					if(this->output_pointer_.column == Timing<personality>::CyclesPerLine) {
+					if(end_column == Timing<personality>::CyclesPerLine) {
 						output_blank(Timing<personality>::CyclesPerLine - LineLayout<personality>::EndOfRightBorder);
 					}
 				};

--- a/Components/9918/Implementation/9918.cpp
+++ b/Components/9918/Implementation/9918.cpp
@@ -513,6 +513,12 @@ void TMS9918<personality>::run_for(const HalfCycles cycles) {
 					}
 				};
 
+				const auto right_blank = [&]() {
+					if(this->output_pointer_.column == Timing<personality>::CyclesPerLine) {
+						output_blank(Timing<personality>::CyclesPerLine - LineLayout<personality>::EndOfRightBorder);
+					}
+				};
+
 				if(this->draw_line_buffer_->vertical_state != VerticalState::Pixels) {
 					if(
 						this->output_pointer_.row >= this->mode_timing_.first_vsync_line &&
@@ -525,14 +531,8 @@ void TMS9918<personality>::run_for(const HalfCycles cycles) {
 						}
 					} else {
 						left_blank();
-
-						// Border colour until beginning of right erase.
 						border(LineLayout<personality>::EndOfLeftErase, LineLayout<personality>::EndOfRightBorder);
-
-						// Right erase.
-						if(this->output_pointer_.column == Timing<personality>::CyclesPerLine) {
-							output_blank(Timing<personality>::CyclesPerLine - LineLayout<personality>::EndOfRightBorder);
-						}
+						right_blank();
 					}
 				} else {
 					left_blank();
@@ -585,10 +585,7 @@ void TMS9918<personality>::run_for(const HalfCycles cycles) {
 					// Right border.
 					border(this->draw_line_buffer_->next_border_column, LineLayout<personality>::EndOfRightBorder);
 
-					// Right erase.
-					if(this->output_pointer_.column == Timing<personality>::CyclesPerLine) {
-						output_blank(Timing<personality>::CyclesPerLine - LineLayout<personality>::EndOfRightBorder);
-					}
+					right_blank();
 				}
 
 #undef border

--- a/Components/9918/Implementation/9918.cpp
+++ b/Components/9918/Implementation/9918.cpp
@@ -369,8 +369,8 @@ void TMS9918<personality>::run_for(const HalfCycles cycles) {
 				}
 
 				// Based on the output mode, pick a line mode.
-				this->fetch_line_buffer_->first_pixel_output_column = Timing<personality>::FirstPixelCycle;
-				this->fetch_line_buffer_->next_border_column = Timing<personality>::CyclesPerLine;
+				this->fetch_line_buffer_->first_pixel_output_column = LineLayout<personality>::EndOfLeftBorder;
+				this->fetch_line_buffer_->next_border_column = LineLayout<personality>::EndOfPixels;
 				this->fetch_line_buffer_->pixel_count = 256;
 				this->fetch_line_buffer_->screen_mode = this->screen_mode_;
 				this->mode_timing_.maximum_visible_sprites = 4;
@@ -381,14 +381,14 @@ void TMS9918<personality>::run_for(const HalfCycles cycles) {
 						} else {
 							this->fetch_line_buffer_->fetch_mode = FetchMode::Text;
 						}
-						this->fetch_line_buffer_->first_pixel_output_column = Timing<personality>::FirstTextCycle;
-						this->fetch_line_buffer_->next_border_column = Timing<personality>::LastTextCycle;
+						this->fetch_line_buffer_->first_pixel_output_column = LineLayout<personality>::TextModeEndOfLeftBorder;
+						this->fetch_line_buffer_->next_border_column = LineLayout<personality>::TextModeEndOfPixels;
 						this->fetch_line_buffer_->pixel_count = 240;
 					break;
 					case ScreenMode::YamahaText80:
 						this->fetch_line_buffer_->fetch_mode = FetchMode::Yamaha;
-						this->fetch_line_buffer_->first_pixel_output_column = Timing<personality>::FirstTextCycle;
-						this->fetch_line_buffer_->next_border_column = Timing<personality>::LastTextCycle;
+						this->fetch_line_buffer_->first_pixel_output_column = LineLayout<personality>::TextModeEndOfLeftBorder;
+						this->fetch_line_buffer_->next_border_column = LineLayout<personality>::TextModeEndOfPixels;
 						this->fetch_line_buffer_->pixel_count = 480;
 					break;
 
@@ -1200,7 +1200,7 @@ VerticalState Base<personality>::vertical_state() const {
 
 template <Personality personality>
 bool Base<personality>::is_horizontal_blank() const {
-	return fetch_pointer_.column < StandardTiming<personality>::FirstPixelCycle;
+	return fetch_pointer_.column < LineLayout<personality>::EndOfLeftErase || fetch_pointer_.column >= LineLayout<personality>::EndOfRightBorder;
 }
 
 template <Personality personality>

--- a/Components/9918/Implementation/ClockConverter.hpp
+++ b/Components/9918/Implementation/ClockConverter.hpp
@@ -70,25 +70,6 @@ template <Personality personality> struct StandardTiming {
 
 	/// The final internal cycle at which pixels will be output text mode.
 	constexpr static int LastTextCycle = 334 * CyclesPerLine / 342;
-
-	// For the below, the fixed portion of line layout is:
-	//
-	//	[0, EndOfRightBorder):					right border colour
-	//	[EndOfRightBorder, StartOfSync):		blank
-	//	[StartOfSync, EndOfSync):				sync
-	//	[EndOfSync, StartOfColourBurst):		blank
-	//	[StartOfColourBurst, EndOfColourBurst):	the colour burst
-	//	[EndOfColourBurst, StartOfLeftBorder):	blank
-	//
-	// The region from StartOfLeftBorder until the end is then filled with
-	// some combination of pixels and more border, depending on the vertical
-	// position of this line and the current screen mode.
-	constexpr static int EndOfRightBorder	= 15 * CyclesPerLine / 342;
-	constexpr static int StartOfSync		= 23 * CyclesPerLine / 342;
-	constexpr static int EndOfSync			= 49 * CyclesPerLine / 342;
-	constexpr static int StartOfColourBurst	= 51 * CyclesPerLine / 342;
-	constexpr static int EndOfColourBurst	= 65 * CyclesPerLine / 342;
-	constexpr static int StartOfLeftBorder	= 73 * CyclesPerLine / 342;
 };
 
 /// Provides concrete, specific timing for the nominated personality.

--- a/Components/9918/Implementation/ClockConverter.hpp
+++ b/Components/9918/Implementation/ClockConverter.hpp
@@ -60,16 +60,6 @@ template <Personality personality> struct StandardTiming {
 	/// The number of internal cycles that must elapse between a request to read or write and
 	/// it becoming a candidate for action.
 	constexpr static int VRAMAccessDelay = 6;
-
-	/// The first internal cycle at which pixels will be output in any mode other than text.
-	/// Pixels implicitly run from here to the end of the line.
-	constexpr static int FirstPixelCycle = 86 * CyclesPerLine / 342;
-
-	/// The first internal cycle at which pixels will be output text mode.
-	constexpr static int FirstTextCycle = 94 * CyclesPerLine / 342;
-
-	/// The final internal cycle at which pixels will be output text mode.
-	constexpr static int LastTextCycle = 334 * CyclesPerLine / 342;
 };
 
 /// Provides concrete, specific timing for the nominated personality.
@@ -183,6 +173,9 @@ template <Personality personality> struct LineLayout<personality, std::enable_if
 	constexpr static int EndOfLeftBorder	= 63;
 	constexpr static int EndOfPixels		= 319;
 	constexpr static int EndOfRightBorder	= 334;
+
+	constexpr static int TextModeEndOfLeftBorder	= 69;
+	constexpr static int TextModeEndOfPixels		= 309;
 };
 
 template <Personality personality> struct LineLayout<personality, std::enable_if_t<is_yamaha_vdp(personality)>> {
@@ -193,6 +186,9 @@ template <Personality personality> struct LineLayout<personality, std::enable_if
 	constexpr static int EndOfLeftBorder	= 258;
 	constexpr static int EndOfPixels		= 1282;
 	constexpr static int EndOfRightBorder	= 1341;
+
+	constexpr static int TextModeEndOfLeftBorder	= 294;
+	constexpr static int TextModeEndOfPixels		= 1254;
 };
 
 }

--- a/Components/9918/Implementation/ClockConverter.hpp
+++ b/Components/9918/Implementation/ClockConverter.hpp
@@ -162,8 +162,9 @@ template <Personality personality, typename Enable = void> struct LineLayout;
 //	[EndOfRightBorder, <end of line>]		blank
 //
 //	... with minor caveats:
-//		* horizontal adjust on the Yamaha VDPs is applied to EndOfLeftBorder and EndOfPixels; and
-//		* the Sega VDPs may programatically extend the left border.
+//		* horizontal adjust on the Yamaha VDPs is applied to EndOfLeftBorder and EndOfPixels;
+//		* the Sega VDPs may programatically extend the left border; and
+//		* text mode on all VDPs adjusts border width.
 
 template <Personality personality> struct LineLayout<personality, std::enable_if_t<is_classic_vdp(personality)>> {
 	constexpr static int EndOfSync			= 26;

--- a/Components/9918/Implementation/Fetch.hpp
+++ b/Components/9918/Implementation/Fetch.hpp
@@ -71,8 +71,7 @@ template<bool use_end, typename SequencerT> void Base<personality>::dispatch(Seq
 #define index(n)						\
 	if(use_end && end == n) return;		\
 	[[fallthrough]];					\
-	case n: fetcher.template fetch<(n + 171 - 16) % 171>(n);
-	// `template fetch` call includes an in-place internal -> sync-aligned conversion for now, during transition.
+	case n: fetcher.template fetch<n>(n);
 
 	switch(start) {
 		default: assert(false);

--- a/Components/9918/Implementation/Storage.hpp
+++ b/Components/9918/Implementation/Storage.hpp
@@ -216,20 +216,10 @@ template <Personality personality> struct Storage<personality, std::enable_if_t<
 	}
 
 	private:
-		// This emulator treats position 0 as being immediately after the standard pixel area.
-		// i.e. offset 1282 on Grauw's http://map.grauw.nl/articles/vdp-vram-timing/vdp-timing.png
-		static constexpr int ZeroAsGrauwIndex = 1282;
-		constexpr static int grauw_to_internal(int offset) {
-			return (offset + 1368 - ZeroAsGrauwIndex) % 1368;
-		}
-		constexpr static int internal_to_grauw(int offset) {
-			return (offset + ZeroAsGrauwIndex) % 1368;
-		}
-
 		template <typename GeneratorT> static constexpr size_t events_size() {
 			size_t size = 0;
 			for(int c = 0; c < 1368; c++) {
-				const auto event_type = GeneratorT::event(internal_to_grauw(c));
+				const auto event_type = GeneratorT::event(c);
 				size += event_type.has_value();
 			}
 			return size + 1;
@@ -240,7 +230,7 @@ template <Personality personality> struct Storage<personality, std::enable_if_t<
 			std::array<Event, size> result{};
 			size_t index = 0;
 			for(int c = 0; c < 1368; c++) {
-				const auto event = GeneratorT::event(internal_to_grauw(c));
+				const auto event = GeneratorT::event(c);
 				if(!event) {
 					continue;
 				}

--- a/Components/9918/Implementation/Storage.hpp
+++ b/Components/9918/Implementation/Storage.hpp
@@ -38,6 +38,8 @@ template <Personality personality> struct Storage<personality, std::enable_if_t<
 	int indirect_register_ = 0;
 	bool increment_indirect_register_ = false;
 
+	int adjustment_[2]{};
+
 	std::array<uint32_t, 16> palette_{};
 	std::array<uint32_t, 16> background_palette_{};
 	bool solid_background_ = true;

--- a/OSBindings/Mac/Clock Signal.xcodeproj/xcshareddata/xcschemes/Clock Signal.xcscheme
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/xcshareddata/xcschemes/Clock Signal.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1400"
-   version = "1.8">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">


### PR DESCRIPTION
Promised as a separate pull request; I'm actually doing this relative to the MSX 2 branch.

Sadly this change is necessary to support the V99x8 horizontal offset. Or, at least, it's the neatest way to get there.