### PR TITLE
Add missing <cstdint> includes for GCC 13

### DIFF
--- a/Activity/Observer.hpp
+++ b/Activity/Observer.hpp
@@ -9,6 +9,7 @@
 #ifndef ActivityObserver_h
 #define ActivityObserver_h
 
+#include <cstdint>
 #include <string>
 
 namespace Activity {

--- a/Analyser/Static/Commodore/File.hpp
+++ b/Analyser/Static/Commodore/File.hpp
@@ -9,6 +9,7 @@
 #ifndef File_hpp
 #define File_hpp
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/Machines/Utility/ROMCatalogue.hpp
+++ b/Machines/Utility/ROMCatalogue.hpp
@@ -10,6 +10,7 @@
 #define ROMCatalogue_hpp
 
 #include <algorithm>
+#include <cstdint>
 #include <functional>
 #include <map>
 #include <optional>

--- a/Machines/Utility/StringSerialiser.hpp
+++ b/Machines/Utility/StringSerialiser.hpp
@@ -9,6 +9,7 @@
 #ifndef StringSerialiser_hpp
 #define StringSerialiser_hpp
 
+#include <cstdint>
 #include <string>
 
 namespace Utility {

--- a/Reflection/Struct.hpp
+++ b/Reflection/Struct.hpp
@@ -13,6 +13,7 @@
 #include <cstdarg>
 #include <cstring>
 #include <cstddef>
+#include <cstdint>
 #include <string>
 #include <typeindex>
 #include <typeinfo>

--- a/Storage/Data/Commodore.hpp
+++ b/Storage/Data/Commodore.hpp
@@ -9,6 +9,7 @@
 #ifndef Storage_Data_Commodore_hpp
 #define Storage_Data_Commodore_hpp
 
+#include <cstdint>
 #include <string>
 
 namespace Storage::Data::Commodore {


### PR DESCRIPTION
Sprinkle includes of the `<cstdint>` header as needed to make the build succeed with GCC 13, this fixes both with SDL and Qt builds.