### PR TITLE
Use full 16-bit stack pointer for all 'new' instructions.

### DIFF
--- a/Processors/65816/Implementation/65816Base.cpp
+++ b/Processors/65816/Implementation/65816Base.cpp
@@ -14,10 +14,7 @@ uint16_t ProcessorBase::value_of(Register r) const {
 	switch (r) {
 		case Register::ProgramCounter:			return registers_.pc;
 		case Register::LastOperationAddress:	return last_operation_pc_;
-		case Register::StackPointer:
-			return
-				(registers_.s.full & (registers_.emulation_flag ? 0xff : 0xffff)) |
-				(registers_.emulation_flag ? 0x100 : 0x000);
+		case Register::StackPointer:			return registers_.s.full;
 		case Register::Flags:					return get_flags();
 		case Register::A:						return registers_.a.full;
 		case Register::X:						return registers_.x.full;

--- a/Processors/65816/Implementation/65816Implementation.hpp
+++ b/Processors/65816/Implementation/65816Implementation.hpp
@@ -191,6 +191,13 @@ template <typename BusHandler, bool uses_ready_line> void Processor<BusHandler, 
 					--registers_.s.full;
 				break;
 
+				case CyclePushNotEmulation:
+					bus_address_ = registers_.s.full;
+					bus_value_ = data_buffer_.next_output_descending();
+					bus_operation_ = MOS6502Esque::Write;
+					--registers_.s.full;
+				break;
+
 				case CyclePullIfNotEmulation:
 					if(registers_.emulation_flag) {
 						continue;
@@ -200,6 +207,13 @@ template <typename BusHandler, bool uses_ready_line> void Processor<BusHandler, 
 				case CyclePull:
 					++registers_.s.full;
 					stack_access(data_buffer_.next_input(), MOS6502Esque::Read);
+				break;
+
+				case CyclePullNotEmulation:
+					++registers_.s.full;
+					bus_address_ = registers_.s.full;
+					bus_value_ = data_buffer_.next_input();
+					bus_operation_ = MOS6502Esque::Read;
 				break;
 
 				case CycleAccessStack:

--- a/Processors/65816/Implementation/65816Storage.cpp
+++ b/Processors/65816/Implementation/65816Storage.cpp
@@ -667,7 +667,7 @@ struct CPU::WDC65816::ProcessorStorageConstructor {
 		target(OperationPerform);
 	}
 
-	// 22b(ii). Stack; s, PLx, ignoring emulation mode. E.g. PLD.
+	// 22b(ii). Stack; s, PLx, ignoring emulation mode. I.e. PLD.
 	static void stack_pull_no_emulation(AccessType, bool is8bit, const std::function<void(MicroOp)> &target) {
 		target(CycleFetchPCThrowaway);	// IO.
 		target(CycleFetchPCThrowaway);	// IO.
@@ -678,7 +678,7 @@ struct CPU::WDC65816::ProcessorStorageConstructor {
 		target(OperationPerform);
 	}
 
-	// 22c. Stack; s, PHx.
+	// 22c(i). Stack; s, PHx, respecting emulation mode. E.g. PHP.
 	static void stack_push(AccessType, bool is8bit, const std::function<void(MicroOp)> &target) {
 		target(CycleFetchPCThrowaway);	// IO.
 
@@ -686,6 +686,16 @@ struct CPU::WDC65816::ProcessorStorageConstructor {
 
 		if(!is8bit) target(CyclePush);	// REG high.
 		target(CyclePush);				// REG [low].
+	}
+
+	// 22c(i). Stack; s, PHx, ignoring emulation mode. I.e. PHD.
+	static void stack_push_no_emulation(AccessType, bool is8bit, const std::function<void(MicroOp)> &target) {
+		target(CycleFetchPCThrowaway);	// IO.
+
+		target(OperationPerform);
+
+		if(!is8bit) target(CyclePushNotEmulation);	// REG high.
+		target(CyclePushNotEmulation);				// REG [low].
 	}
 
 	// 22d. Stack; s, PEA.
@@ -829,7 +839,7 @@ ProcessorStorage::ProcessorStorage() {
 	/* 0x08 PHP s */			op(stack_push, PHP, AccessMode::Always8Bit);
 	/* 0x09 ORA # */			op(immediate, ORA);
 	/* 0x0a ASL A */			op(accumulator, ASL);
-	/* 0x0b PHD s */			op(stack_push, PHD, AccessMode::Always16Bit);
+	/* 0x0b PHD s */			op(stack_push_no_emulation, PHD, AccessMode::Always16Bit);
 	/* 0x0c TSB a */			op(absolute_rmw, TSB);
 	/* 0x0d ORA a */			op(absolute, ORA);
 	/* 0x0e ASL a */			op(absolute_rmw, ASL);

--- a/Processors/65816/Implementation/65816Storage.cpp
+++ b/Processors/65816/Implementation/65816Storage.cpp
@@ -319,7 +319,7 @@ struct CPU::WDC65816::ProcessorStorageConstructor {
 		target(CycleFetchIncrementPC);			// New PCH.
 
 		target(OperationCopyPBRToData);			// Copy PBR to the data register.
-		target(CyclePush);						// PBR.
+		target(CyclePushNotEmulation);			// PBR.
 		target(CycleFetchPreviousThrowaway);	// IO.
 
 		target(CycleFetchPC);					// New PBR.
@@ -327,8 +327,8 @@ struct CPU::WDC65816::ProcessorStorageConstructor {
 		target(OperationConstructAbsolute);		// Calculate data address.
 		target(OperationPerform);				// [JSL]
 
-		target(CyclePush);						// PCH.
-		target(CyclePush);						// PCL.
+		target(CyclePushNotEmulation);			// PCH.
+		target(CyclePushNotEmulation);			// PCL.
 	}
 
 	// 5. Absolute long, X;	al, x.

--- a/Processors/65816/Implementation/65816Storage.cpp
+++ b/Processors/65816/Implementation/65816Storage.cpp
@@ -668,12 +668,12 @@ struct CPU::WDC65816::ProcessorStorageConstructor {
 	}
 
 	// 22b(ii). Stack; s, PLx, ignoring emulation mode. I.e. PLD.
-	static void stack_pull_no_emulation(AccessType, bool is8bit, const std::function<void(MicroOp)> &target) {
+	static void stack_pld(AccessType, bool, const std::function<void(MicroOp)> &target) {
 		target(CycleFetchPCThrowaway);	// IO.
 		target(CycleFetchPCThrowaway);	// IO.
 
-		if(!is8bit) target(CyclePullNotEmulation);	// REG low.
-		target(CyclePullNotEmulation);				// REG [high].
+		target(CyclePullNotEmulation);	// REG low.
+		target(CyclePullNotEmulation);	// REG [high].
 
 		target(OperationPerform);
 	}
@@ -689,13 +689,13 @@ struct CPU::WDC65816::ProcessorStorageConstructor {
 	}
 
 	// 22c(i). Stack; s, PHx, ignoring emulation mode. I.e. PHD.
-	static void stack_push_no_emulation(AccessType, bool is8bit, const std::function<void(MicroOp)> &target) {
+	static void stack_phd(AccessType, bool, const std::function<void(MicroOp)> &target) {
 		target(CycleFetchPCThrowaway);	// IO.
 
 		target(OperationPerform);
 
-		if(!is8bit) target(CyclePushNotEmulation);	// REG high.
-		target(CyclePushNotEmulation);				// REG [low].
+		target(CyclePushNotEmulation);	// REG high.
+		target(CyclePushNotEmulation);	// REG [low].
 	}
 
 	// 22d. Stack; s, PEA.
@@ -839,7 +839,7 @@ ProcessorStorage::ProcessorStorage() {
 	/* 0x08 PHP s */			op(stack_push, PHP, AccessMode::Always8Bit);
 	/* 0x09 ORA # */			op(immediate, ORA);
 	/* 0x0a ASL A */			op(accumulator, ASL);
-	/* 0x0b PHD s */			op(stack_push_no_emulation, PHD, AccessMode::Always16Bit);
+	/* 0x0b PHD s */			op(stack_phd, PHD);
 	/* 0x0c TSB a */			op(absolute_rmw, TSB);
 	/* 0x0d ORA a */			op(absolute, ORA);
 	/* 0x0e ASL a */			op(absolute_rmw, ASL);
@@ -873,7 +873,7 @@ ProcessorStorage::ProcessorStorage() {
 	/* 0x28 PLP s */			op(stack_pull, PLP, AccessMode::Always8Bit);
 	/* 0x29 AND # */			op(immediate, AND);
 	/* 0x2a ROL A */			op(accumulator, ROL);
-	/* 0x2b PLD s */			op(stack_pull_no_emulation, PLD, AccessMode::Always16Bit);
+	/* 0x2b PLD s */			op(stack_pld, PLD);
 	/* 0x2c BIT a */			op(absolute, BIT);
 	/* 0x2d AND a */			op(absolute, AND);
 	/* 0x2e ROL a */			op(absolute_rmw, ROL);

--- a/Processors/65816/Implementation/65816Storage.cpp
+++ b/Processors/65816/Implementation/65816Storage.cpp
@@ -754,9 +754,9 @@ struct CPU::WDC65816::ProcessorStorageConstructor {
 		target(CycleFetchPCThrowaway);	// IO.
 		target(CycleFetchPCThrowaway);	// IO.
 
-		target(CyclePull);				// New PCL.
-		target(CyclePull);				// New PCH.
-		target(CyclePull);				// New PBR.
+		target(CyclePullNotEmulation);	// New PCL.
+		target(CyclePullNotEmulation);	// New PCH.
+		target(CyclePullNotEmulation);	// New PBR.
 
 		target(OperationPerform);		// [RTL]
 	}

--- a/Processors/65816/Implementation/65816Storage.cpp
+++ b/Processors/65816/Implementation/65816Storage.cpp
@@ -718,8 +718,8 @@ struct CPU::WDC65816::ProcessorStorageConstructor {
 
 		target(CycleFetchIncrementData);		// AAL.
 		target(CycleFetchData);					// AAH.
-		target(CyclePush);						// AAH.
-		target(CyclePush);						// AAL.
+		target(CyclePushNotEmulation);			// AAH.
+		target(CyclePushNotEmulation);			// AAL.
 	}
 
 	// 22f. Stack; s, PER.

--- a/Processors/65816/Implementation/65816Storage.cpp
+++ b/Processors/65816/Implementation/65816Storage.cpp
@@ -705,8 +705,8 @@ struct CPU::WDC65816::ProcessorStorageConstructor {
 
 		target(OperationCopyInstructionToData);
 
-		target(CyclePush);				// AAH.
-		target(CyclePush);				// AAL.
+		target(CyclePushNotEmulation);	// AAH.
+		target(CyclePushNotEmulation);	// AAL.
 	}
 
 	// 22e. Stack; s, PEI.

--- a/Processors/65816/Implementation/65816Storage.cpp
+++ b/Processors/65816/Implementation/65816Storage.cpp
@@ -730,8 +730,8 @@ struct CPU::WDC65816::ProcessorStorageConstructor {
 
 		target(OperationConstructPER);
 
-		target(CyclePush);						// AAH.
-		target(CyclePush);						// AAL.
+		target(CyclePushNotEmulation);			// AAH.
+		target(CyclePushNotEmulation);			// AAL.
 	}
 
 	// 22g. Stack; s, RTI.

--- a/Processors/65816/Implementation/65816Storage.hpp
+++ b/Processors/65816/Implementation/65816Storage.hpp
@@ -58,6 +58,11 @@ enum MicroOp: uint8_t {
 	/// Performs as CyclePull if the 65816 is not in emulation mode; otherwise skips itself.
 	CyclePullIfNotEmulation,
 
+	/// Pushes a single byte from the data buffer to the stack, always using its full 16-bit address.
+	CyclePushNotEmulation,
+	/// Pulls a single byte to the data buffer from the stack, always using its full 16-bit address.
+	CyclePullNotEmulation,
+
 	/// Issues a BusOperation::None and regresses the micro-op counter until an established
 	/// STP or WAI condition is satisfied.
 	CycleRepeatingNone,


### PR DESCRIPTION
While admitting that the stack pointer is 16-bit even in emulation mode.