### PR TITLE
6502: add final read cycle to illegal NOPs.

### DIFF
--- a/OSBindings/Mac/Clock SignalTests/65816ComparativeTests.mm
+++ b/OSBindings/Mac/Clock SignalTests/65816ComparativeTests.mm
@@ -131,10 +131,10 @@ template <bool has_emulation, typename Processor> void print_registers(FILE *fil
 	using Register = CPU::MOS6502Esque::Register;
 	fprintf(file, "\"pc\": %d, ", (processor.value_of(Register::ProgramCounter) + pc_offset) & 65535);
 	fprintf(file, "\"s\": %d, ", processor.value_of(Register::StackPointer));
-	fprintf(file, "\"p\": %d, ", processor.value_of(Register::Flags));
 	fprintf(file, "\"a\": %d, ", processor.value_of(Register::A));
 	fprintf(file, "\"x\": %d, ", processor.value_of(Register::X));
 	fprintf(file, "\"y\": %d, ", processor.value_of(Register::Y));
+	fprintf(file, "\"p\": %d, ", processor.value_of(Register::Flags));
 	if constexpr (has_emulation) {
 		fprintf(file, "\"dbr\": %d, ", processor.value_of(Register::DataBank));
 		fprintf(file, "\"d\": %d, ", processor.value_of(Register::Direct));
@@ -169,7 +169,8 @@ template <CPU::MOS6502Esque::Type type> void generate() {
 	for(int operation = 0; operation < (has_emulation ? 512 : 256); operation++) {
 		// Make tests repeatable, at least for any given instance of
 		// the runtime.
-		srand(65816 + operation);
+		constexpr auto type_offset = int(CPU::MOS6502Esque::Type::TWDC65816) - int(type);
+		srand(65816 + operation + type_offset);
 
 		const bool is_emulated = operation & 256;
 		const uint8_t opcode = operation & 255;

--- a/Processors/6502/Implementation/6502Storage.cpp
+++ b/Processors/6502/Implementation/6502Storage.cpp
@@ -68,10 +68,13 @@ using namespace CPU::MOS6502;
 
 #define ZeroNop()							Program(Zero, CycleFetchOperandFromAddress)
 #define ZeroXNop()							Program(ZeroX, CycleFetchOperandFromAddress)
-#define AbsoluteNop()						Program(Absolute)
-#define AbsoluteXNop()						Program(AbsoluteX)
+#define AbsoluteNop()						Program(Absolute, CycleFetchOperandFromAddress)
+#define AbsoluteXNop()						Program(AbsoluteX, CycleFetchOperandFromAddress)
 #define ImpliedNop()						{OperationMoveToNextProgram}
 #define ImmediateNop()						Program(OperationIncrementPC)
+
+#define AbsoluteNopNoFetch()				Program(Absolute)
+#define AbsoluteXNopNoFetch()				Program(AbsoluteX)
 
 #define JAM									{CycleFetchOperand, OperationScheduleJam}
 
@@ -425,10 +428,10 @@ ProcessorStorage::ProcessorStorage(Personality personality) {
 			}
 		} else {
 			for(int location = 0x0f; location <= 0xef; location += 0x20) {
-				Install(location, AbsoluteNop());
+				Install(location, AbsoluteNopNoFetch());
 			}
 			for(int location = 0x1f; location <= 0xff; location += 0x20) {
-				Install(location, AbsoluteXNop());
+				Install(location, AbsoluteXNopNoFetch());
 			}
 			for(int c = 0x07; c <= 0xe7; c += 0x20) {
 				Install(c, ZeroNop());


### PR DESCRIPTION
TODO: should this affect the 65C02 safety NOPs? My expectation is that it should, but I've conservatively omitted them for now.