### PR TITLE
Extend BCD testing to the 65C02; clean up implementation

### DIFF
--- a/Numeric/Carry.hpp
+++ b/Numeric/Carry.hpp
@@ -1,0 +1,31 @@
+//
+//  Carry.hpp
+//  Clock Signal
+//
+//  Created by Thomas Harte on 30/08/2023.
+//  Copyright © 2023 Thomas Harte. All rights reserved.
+//
+
+#ifndef Carry_hpp
+#define Carry_hpp
+
+namespace Numeric {
+
+/// @returns @c true if there was carry out of @c bit when @c source1 and @c source2 were added, producing @c result.
+template <int bit, typename IntT> bool carried_out(IntT source1, IntT source2, IntT result) {
+	// 0 and 0 => didn't.
+	// 0 and 1 or 1 and 0 => did if 0.
+	// 1 and 1 => did.
+	return IntT(1 << bit) & (source1 | source2) & ((source1 & source2) | ~result);
+}
+
+/// @returns @c true if there was carry into @c bit when @c source1 and @c source2 were added, producing @c result.
+template <int bit, typename IntT> bool carried_in(IntT source1, IntT source2, IntT result) {
+	// 0 and 0 or 1 and 1 => did if 1
+	// 0 and 1 or 1 and 0 => did if 0
+	return IntT(1 << bit) & (source1 ^ source2 ^ result);
+}
+
+}
+
+#endif /* Carry_hpp */

--- a/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
@@ -1101,6 +1101,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		4281572E2AA0334300E16AA1 /* Carry.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Carry.hpp; sourceTree = "<group>"; };
 		428168372A16C25C008ECD27 /* LineLayout.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = LineLayout.hpp; sourceTree = "<group>"; };
 		428168392A37AFB4008ECD27 /* DispatcherTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = DispatcherTests.mm; sourceTree = "<group>"; };
 		42AD552E2A0C4D5000ACE410 /* 68000.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = 68000.hpp; sourceTree = "<group>"; };
@@ -3313,6 +3314,7 @@
 				4B66E1A8297719270057ED0F /* NumericCoder.hpp */,
 				4BB5B995281B1D3E00522DA9 /* RegisterSizes.hpp */,
 				4BFEA2F12682A90200EBF94C /* Sizes.hpp */,
+				4281572E2AA0334300E16AA1 /* Carry.hpp */,
 			);
 			name = Numeric;
 			path = ../../Numeric;

--- a/OSBindings/Mac/Clock SignalTests/BCDTest.swift
+++ b/OSBindings/Mac/Clock SignalTests/BCDTest.swift
@@ -11,10 +11,10 @@ import XCTest
 
 class BCDTest: XCTestCase, CSTestMachineTrapHandler {
 
-	func testBCD() {
+	func testBCD(processor: CSTestMachine6502Processor) {
 		if let filename = Bundle(for: type(of: self)).path(forResource: "BCDTEST_beeb", ofType: nil) {
 			if let bcdTest = try? Data(contentsOf: URL(fileURLWithPath: filename)) {
-				let machine = CSTestMachine6502(processor: .processor6502)
+				let machine = CSTestMachine6502(processor: processor)
 				machine.trapHandler = self
 
 				machine.setData(bcdTest, atAddress: 0x2900)
@@ -38,6 +38,14 @@ class BCDTest: XCTestCase, CSTestMachineTrapHandler {
 				XCTAssert(machine.value(forAddress:0x84) == 0, output)
 			}
 		}
+	}
+
+	func test6502BCD() {
+		testBCD(processor: .processor6502)
+	}
+
+	func test65C02BCD() {
+		testBCD(processor: .processor65C02)
 	}
 
 	private var output: String = ""

--- a/OSBindings/Mac/Clock SignalTests/BCDTest.swift
+++ b/OSBindings/Mac/Clock SignalTests/BCDTest.swift
@@ -53,8 +53,10 @@ class BCDTest: XCTestCase, CSTestMachineTrapHandler {
 		let machine6502 = testMachine as! CSTestMachine6502
 
 		// Only OSWRCH is trapped, so...
-		let character = machine6502.value(for: .A)
-		output.append(Character(UnicodeScalar(character)!))
+		let character = Character(UnicodeScalar(machine6502.value(for: .A))!)
+		if character != "\r" {		// The test internally uses \r\n; keep only one of those.
+			output.append(character)
+		}
 	}
 
 }

--- a/OSBindings/Mac/Clock SignalTests/BCDTest.swift
+++ b/OSBindings/Mac/Clock SignalTests/BCDTest.swift
@@ -48,10 +48,6 @@ class BCDTest: XCTestCase, CSTestMachineTrapHandler {
 		testBCD(processor: .processor65C02)
 	}
 
-//	func test6816BCD() {
-//		testBCD(processor: .processor65816)
-//	}
-
 	private var output: String = ""
 	func testMachine(_ testMachine: CSTestMachine, didTrapAtAddress address: UInt16) {
 		let machine6502 = testMachine as! CSTestMachine6502

--- a/OSBindings/Mac/Clock SignalTests/BCDTest.swift
+++ b/OSBindings/Mac/Clock SignalTests/BCDTest.swift
@@ -48,6 +48,10 @@ class BCDTest: XCTestCase, CSTestMachineTrapHandler {
 		testBCD(processor: .processor65C02)
 	}
 
+//	func test6816BCD() {
+//		testBCD(processor: .processor65816)
+//	}
+
 	private var output: String = ""
 	func testMachine(_ testMachine: CSTestMachine, didTrapAtAddress address: UInt16) {
 		let machine6502 = testMachine as! CSTestMachine6502

--- a/Processors/6502/6502.hpp
+++ b/Processors/6502/6502.hpp
@@ -15,6 +15,7 @@
 
 #include "../6502Esque/6502Esque.hpp"
 #include "../6502Esque/Implementation/LazyFlags.hpp"
+#include "../../Numeric/Carry.hpp"
 #include "../../Numeric/RegisterSizes.hpp"
 #include "../../ClockReceiver/ClockReceiver.hpp"
 

--- a/Processors/6502/Implementation/6502Implementation.hpp
+++ b/Processors/6502/Implementation/6502Implementation.hpp
@@ -347,6 +347,8 @@ template <Personality personality, typename T, bool uses_ready_line> void Proces
 							a_ = result;
 
 							if(is_65c02(personality)) {
+								// 65C02 fix: N and Z are set correctly based on the final BCD result, at the cost of
+								// an extra cycle.
 								flags_.set_nz(a_);
 								read_mem(operand_, address_.full);
 								break;

--- a/Processors/6502/Implementation/6502Implementation.hpp
+++ b/Processors/6502/Implementation/6502Implementation.hpp
@@ -337,10 +337,10 @@ template <Personality personality, typename T, bool uses_ready_line> void Proces
 							flags_.negative_result = uint8_t(result);
 							flags_.overflow = (( (result ^ a_) & (result ^ operand_) ) & 0x80) >> 1;
 
+							// i.e. if there was carry out of bit 7 already, or if the top nibble is too large (in which
+							// case there will be carry after the fix-up).
+							flags_.carry |= result >= 0xa0;
 							if(flags_.carry) {
-								result += 0x60;
-							} else if (result >= 0xa0) {
-								flags_.carry = 1;	// There'll now definitely be carry.
 								result += 0x60;
 							}
 

--- a/Processors/6502/Implementation/6502Implementation.hpp
+++ b/Processors/6502/Implementation/6502Implementation.hpp
@@ -337,7 +337,7 @@ template <Personality personality, typename T, bool uses_ready_line> void Proces
 							flags_.negative_result = uint8_t(result);
 							flags_.overflow = (( (result ^ a_) & (result ^ operand_) ) & 0x80) >> 1;
 
-							if(Numeric::carried_out<7>(a_, operand_, result)) {
+							if(flags_.carry) {
 								result += 0x60;
 							} else if (result >= 0xa0) {
 								flags_.carry = 1;	// There'll now definitely be carry.

--- a/Processors/6502/Implementation/6502Implementation.hpp
+++ b/Processors/6502/Implementation/6502Implementation.hpp
@@ -298,6 +298,13 @@ template <Personality personality, typename T, bool uses_ready_line> void Proces
 							// The bottom nibble is adjusted if there was carry into the top nibble;
 							// this doesn't cause additional carry.
 							if(!Numeric::carried_in<4>(a_, operand_, result)) {
+								// 65C02 difference: carry from the calculation below is applied as
+								// borrow to the nibble above.
+								if constexpr (is_65c02(personality)) {
+									if((result & 0xf) < 0x6) {
+										result -= 0x10;
+									}
+								}
 								result = (result & 0xf0) | ((result + 0x0a) & 0xf);
 							}
 
@@ -308,7 +315,7 @@ template <Personality personality, typename T, bool uses_ready_line> void Proces
 
 							a_ = result;
 
-							if(is_65c02(personality)) {
+							if constexpr (is_65c02(personality)) {
 								// 65C02 fix: set the N and Z flags based on the final, decimal result.
 								flags_.set_nz(a_);
 								read_mem(operand_, address_.full);
@@ -351,7 +358,7 @@ template <Personality personality, typename T, bool uses_ready_line> void Proces
 
 							a_ = result;
 
-							if(is_65c02(personality)) {
+							if constexpr (is_65c02(personality)) {
 								// 65C02 fix: N and Z are set correctly based on the final BCD result, at the cost of
 								// an extra cycle.
 								flags_.set_nz(a_);


### PR DESCRIPTION
While also fixing invalid-BCD `SBC`s on the 65C02.