### PR TITLE
Fix LD_RUNPATH_SEARCH_PATHS for High Sierra

### DIFF
--- a/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
@@ -6651,7 +6651,7 @@
 				INFOPLIST_FILE = "Clock Signal/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(LD_RUNPATH_SEARCH_PATHS_$(IS_MACCATALYST))",
-					/System/Library/PrivateFrameworks/Swift/libswiftCore.dylib,
+					"@loader_path/../Frameworks",
 				);
 				MTL_TREAT_WARNINGS_AS_ERRORS = YES;
 				OTHER_CPLUSPLUSFLAGS = (
@@ -6696,7 +6696,7 @@
 				INFOPLIST_FILE = "Clock Signal/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(LD_RUNPATH_SEARCH_PATHS_$(IS_MACCATALYST))",
-					/System/Library/PrivateFrameworks/Swift/libswiftCore.dylib,
+					"@loader_path/../Frameworks",
 				);
 				MTL_TREAT_WARNINGS_AS_ERRORS = YES;
 				OTHER_CPLUSPLUSFLAGS = (


### PR DESCRIPTION
This fixes failure of Clock Signal to launch on macOS High Sierra as reported in #1191.

-----

Users wishing to use the binary of release 23.09.10 without recompiling it can copy it to the Desktop and then run these commands in the Terminal:

```
install_name_tool -delete_rpath /System/Library/PrivateFrameworks/Swift/libswiftCore.dylib -add_rpath @loader_path/../Frameworks "$HOME/Desktop/Clock Signal.app/Contents/MacOS/Clock Signal"
codesign -fs - "$HOME/Desktop/Clock Signal.app/Contents/MacOS/Clock Signal"
```

The `install_name_tool` command replaces the invalid runtime path with the correct one. This is of course a modification of the program, and any modification to a program breaks its code signature and makes the OS refuse to run it. The `codesign` command creates a new ad-hoc code signature that allows the app to run again.