### PR TITLE
Work towards x86 access violations.

### DIFF
--- a/InstructionSets/x86/Implementation/PerformImplementation.hpp
+++ b/InstructionSets/x86/Implementation/PerformImplementation.hpp
@@ -1408,7 +1408,7 @@ void cmps(const InstructionT &instruction, AddressT &eCX, AddressT &eSI, Address
 	}
 
 	IntT lhs = memory.template access<IntT, AccessType::Read>(instruction.data_segment(), eSI);
-	const IntT rhs = memory.template access<IntT, AccessType::Write>(Source::ES, eDI);
+	const IntT rhs = memory.template access<IntT, AccessType::Read>(Source::ES, eDI);
 	eSI += status.direction<AddressT>() * sizeof(IntT);
 	eDI += status.direction<AddressT>() * sizeof(IntT);
 

--- a/InstructionSets/x86/Implementation/PerformImplementation.hpp
+++ b/InstructionSets/x86/Implementation/PerformImplementation.hpp
@@ -1049,11 +1049,6 @@ void setmo(IntT &destination, Status &status) {
 }
 
 template <typename IntT>
-void setmoc(IntT &destination, uint8_t cl, Status &status) {
-	if(cl) setmo(destination, status);
-}
-
-template <typename IntT>
 inline void rcl(IntT &destination, uint8_t count, Status &status) {
 	/*
 		(* RCL and RCR instructions *)
@@ -1775,7 +1770,11 @@ template <
 		return;
 		case Operation::SETMOC:
 			if constexpr (model == Model::i8086) {
-				Primitive::setmoc(destination_w(), registers.cl(), status);
+				// Test CL out here to avoid taking a reference to memory if
+				// no write is going to occur.
+				if(registers.cl()) {
+					Primitive::setmo(destination_w(), status);
+				}
 				break;
 			} else {
 				// TODO.

--- a/InstructionSets/x86/Implementation/PerformImplementation.hpp
+++ b/InstructionSets/x86/Implementation/PerformImplementation.hpp
@@ -196,7 +196,7 @@ namespace Primitive {
 template <typename IntT, bool Preauthorised, typename MemoryT, typename RegistersT>
 void push(IntT &value, MemoryT &memory, RegistersT &registers) {
 	registers.sp_ -= sizeof(IntT);
-	memory.template access<IntT, Preauthorised ? AccessType::Preauthorised : AccessType::Write>(
+	memory.template access<IntT, Preauthorised ? AccessType::PreauthorisedWrite : AccessType::Write>(
 		InstructionSet::x86::Source::SS,
 		registers.sp_) = value;
 	memory.template write_back<IntT>();
@@ -204,7 +204,7 @@ void push(IntT &value, MemoryT &memory, RegistersT &registers) {
 
 template <typename IntT, bool Preauthorised, typename MemoryT, typename RegistersT>
 IntT pop(MemoryT &memory, RegistersT &registers) {
-	const auto value = memory.template access<IntT, Preauthorised ? AccessType::Preauthorised : AccessType::Read>(
+	const auto value = memory.template access<IntT, Preauthorised ? AccessType::PreauthorisedRead : AccessType::Read>(
 		InstructionSet::x86::Source::SS,
 		registers.sp_);
 	registers.sp_ += sizeof(IntT);
@@ -850,13 +850,13 @@ void call_far(InstructionT &instruction,
 		case Source::Immediate:	flow_controller.call(instruction.segment(), instruction.offset());	return;
 
 		case Source::Indirect:
-			source_address = address<model, Source::Indirect, uint16_t, AccessType::Preauthorised>(instruction, pointer, registers, memory);
+			source_address = address<model, Source::Indirect, uint16_t, AccessType::Read>(instruction, pointer, registers, memory);
 		break;
 		case Source::IndirectNoBase:
-			source_address = address<model, Source::IndirectNoBase, uint16_t, AccessType::Preauthorised>(instruction, pointer, registers, memory);
+			source_address = address<model, Source::IndirectNoBase, uint16_t, AccessType::Read>(instruction, pointer, registers, memory);
 		break;
 		case Source::DirectAddress:
-			source_address = address<model, Source::DirectAddress, uint16_t, AccessType::Preauthorised>(instruction, pointer, registers, memory);
+			source_address = address<model, Source::DirectAddress, uint16_t, AccessType::Read>(instruction, pointer, registers, memory);
 		break;
 	}
 
@@ -954,7 +954,7 @@ void lea(
 	RegistersT &registers
 ) {
 	// TODO: address size.
-	destination = IntT(address<model, uint16_t, AccessType::Preauthorised>(instruction, instruction.source(), registers, memory));
+	destination = IntT(address<model, uint16_t, AccessType::Read>(instruction, instruction.source(), registers, memory));
 }
 
 template <typename AddressT, typename InstructionT, typename MemoryT, typename RegistersT>

--- a/InstructionSets/x86/Implementation/PerformImplementation.hpp
+++ b/InstructionSets/x86/Implementation/PerformImplementation.hpp
@@ -903,9 +903,9 @@ void jump_far(InstructionT &instruction, ContextT &context) {
 	const Source source_segment = instruction.data_segment();
 	context.memory.preauthorise_read(source_segment, source_address, sizeof(uint16_t) * 2);
 
-	const uint16_t offset = context.memory.template access<uint16_t, AccessType::Read>(source_segment, source_address);
+	const uint16_t offset = context.memory.template access<uint16_t, AccessType::PreauthorisedRead>(source_segment, source_address);
 	source_address += 2;
-	const uint16_t segment =context. memory.template access<uint16_t, AccessType::Read>(source_segment, source_address);
+	const uint16_t segment = context.memory.template access<uint16_t, AccessType::PreauthorisedRead>(source_segment, source_address);
 	context.flow_controller.jump(segment, offset);
 }
 
@@ -945,11 +945,12 @@ void ld(
 	auto source_address = address<uint16_t, AccessType::Read>(instruction, pointer, context);
 	const Source source_segment = instruction.data_segment();
 
-	destination = context.memory.template access<uint16_t, AccessType::Read>(source_segment, source_address);
+	context.memory.preauthorise_read(source_segment, source_address, 4);
+	destination = context.memory.template access<uint16_t, AccessType::PreauthorisedRead>(source_segment, source_address);
 	source_address += 2;
 	switch(selector) {
-		case Source::DS:	context.registers.ds() = context.memory.template access<uint16_t, AccessType::Read>(source_segment, source_address);	break;
-		case Source::ES:	context.registers.es() = context.memory.template access<uint16_t, AccessType::Read>(source_segment, source_address);	break;
+		case Source::DS:	context.registers.ds() = context.memory.template access<uint16_t, AccessType::PreauthorisedRead>(source_segment, source_address);	break;
+		case Source::ES:	context.registers.es() = context.memory.template access<uint16_t, AccessType::PreauthorisedRead>(source_segment, source_address);	break;
 	}
 }
 
@@ -1919,8 +1920,8 @@ template <
 	context.memory.preauthorise_read(address, sizeof(uint16_t) * 2);
 	context.memory.preauthorise_stack_write(sizeof(uint16_t) * 3);
 
-	const uint16_t ip = context.memory.template access<uint16_t, AccessType::Read>(address);
-	const uint16_t cs = context.memory.template access<uint16_t, AccessType::Read>(address + 2);
+	const uint16_t ip = context.memory.template access<uint16_t, AccessType::PreauthorisedRead>(address);
+	const uint16_t cs = context.memory.template access<uint16_t, AccessType::PreauthorisedRead>(address + 2);
 
 	auto flags = context.status.get();
 	Primitive::push<uint16_t, true>(flags, context);

--- a/InstructionSets/x86/Implementation/PerformImplementation.hpp
+++ b/InstructionSets/x86/Implementation/PerformImplementation.hpp
@@ -862,6 +862,7 @@ void call_far(InstructionT &instruction,
 
 	const Source source_segment = instruction.data_segment();
 
+	// TODO: preauthorise reads.
 	const uint16_t offset = memory.template access<uint16_t, AccessType::Read>(source_segment, source_address);
 	source_address += 2;
 	const uint16_t segment = memory.template access<uint16_t, AccessType::Read>(source_segment, source_address);
@@ -1672,7 +1673,7 @@ template <
 		case Operation::ADD:	Primitive::add<false>(destination_rmw(), source_r(), status);			break;
 		case Operation::SBB:	Primitive::sub<true, true>(destination_rmw(), source_r(), status);		break;
 		case Operation::SUB:	Primitive::sub<false, true>(destination_rmw(), source_r(), status);		break;
-		case Operation::CMP:	Primitive::sub<false, false>(destination_rmw(), source_r(), status);	return;
+		case Operation::CMP:	Primitive::sub<false, false>(destination_r(), source_r(), status);		return;
 		case Operation::TEST:	Primitive::test(destination_r(), source_r(), status);					return;
 
 		case Operation::MUL:	Primitive::mul(pair_high(), pair_low(), source_r(), status);			return;

--- a/InstructionSets/x86/Implementation/PerformImplementation.hpp
+++ b/InstructionSets/x86/Implementation/PerformImplementation.hpp
@@ -193,18 +193,18 @@ namespace Primitive {
 
 // The below takes a reference in order properly to handle PUSH SP, which should place the value of SP after the
 // push onto the stack.
-template <typename IntT, bool preauthorised, typename MemoryT, typename RegistersT>
+template <typename IntT, bool Preauthorised, typename MemoryT, typename RegistersT>
 void push(IntT &value, MemoryT &memory, RegistersT &registers) {
 	registers.sp_ -= sizeof(IntT);
-	memory.template access<IntT, preauthorised ? AccessType::PreAuthorised : AccessType::Write>(
+	memory.template access<IntT, Preauthorised ? AccessType::Preauthorised : AccessType::Write>(
 		InstructionSet::x86::Source::SS,
 		registers.sp_) = value;
 	memory.template write_back<IntT>();
 }
 
-template <typename IntT, bool preauthorised, typename MemoryT, typename RegistersT>
+template <typename IntT, bool Preauthorised, typename MemoryT, typename RegistersT>
 IntT pop(MemoryT &memory, RegistersT &registers) {
-	const auto value = memory.template access<IntT, preauthorised ? AccessType::PreAuthorised : AccessType::Read>(
+	const auto value = memory.template access<IntT, Preauthorised ? AccessType::Preauthorised : AccessType::Read>(
 		InstructionSet::x86::Source::SS,
 		registers.sp_);
 	registers.sp_ += sizeof(IntT);
@@ -850,13 +850,13 @@ void call_far(InstructionT &instruction,
 		case Source::Immediate:	flow_controller.call(instruction.segment(), instruction.offset());	return;
 
 		case Source::Indirect:
-			source_address = address<model, Source::Indirect, uint16_t, AccessType::PreAuthorised>(instruction, pointer, registers, memory);
+			source_address = address<model, Source::Indirect, uint16_t, AccessType::Preauthorised>(instruction, pointer, registers, memory);
 		break;
 		case Source::IndirectNoBase:
-			source_address = address<model, Source::IndirectNoBase, uint16_t, AccessType::PreAuthorised>(instruction, pointer, registers, memory);
+			source_address = address<model, Source::IndirectNoBase, uint16_t, AccessType::Preauthorised>(instruction, pointer, registers, memory);
 		break;
 		case Source::DirectAddress:
-			source_address = address<model, Source::DirectAddress, uint16_t, AccessType::PreAuthorised>(instruction, pointer, registers, memory);
+			source_address = address<model, Source::DirectAddress, uint16_t, AccessType::Preauthorised>(instruction, pointer, registers, memory);
 		break;
 	}
 
@@ -954,7 +954,7 @@ void lea(
 	RegistersT &registers
 ) {
 	// TODO: address size.
-	destination = IntT(address<model, uint16_t, AccessType::PreAuthorised>(instruction, instruction.source(), registers, memory));
+	destination = IntT(address<model, uint16_t, AccessType::Preauthorised>(instruction, instruction.source(), registers, memory));
 }
 
 template <typename AddressT, typename InstructionT, typename MemoryT, typename RegistersT>

--- a/InstructionSets/x86/Instruction.hpp
+++ b/InstructionSets/x86/Instruction.hpp
@@ -163,7 +163,7 @@ enum class Operation: uint8_t {
 	XOR,
 	/// NOP; no further fields.
 	NOP,
-	/// POP from the stack to source.
+	/// POP from the stack to destination.
 	POP,
 	/// POP from the stack to the flags register.
 	POPF,

--- a/InstructionSets/x86/Perform.hpp
+++ b/InstructionSets/x86/Perform.hpp
@@ -31,8 +31,8 @@ enum class AccessType {
 	/// The requested value has already been authorised for whatever form of access is now intended, so there's no
 	/// need further to inspect. This is done e.g. by operations that will push multiple values to the stack to verify that
 	/// all necessary stack space is available ahead of pushing anything, though each individual push will then result in
-	/// a further `PreAuthorised` access.
-	PreAuthorised,
+	/// a further `Preauthorised` access.
+	Preauthorised,
 };
 
 /// Performs @c instruction  querying @c registers and/or @c memory as required, using @c io for port input/output,

--- a/InstructionSets/x86/Perform.hpp
+++ b/InstructionSets/x86/Perform.hpp
@@ -15,6 +15,26 @@
 
 namespace InstructionSet::x86 {
 
+/// Explains the type of access that `perform` intends to perform; is provided as a template parameter to whatever
+/// the caller supplies as `MemoryT` and `RegistersT` when obtaining a reference to whatever the processor
+/// intends to reference.
+///
+/// `perform` guarantees to validate all accesses before modifying any state, giving the caller opportunity to generate
+/// any exceptions that might be applicable.
+enum class AccessType {
+	/// The requested value will be read from.
+	Read,
+	/// The requested value will be written to.
+	Write,
+	/// The requested value will be read from and then written to.
+	ReadModifyWrite,
+	/// The requested value has already been authorised for whatever form of access is now intended, so there's no
+	/// need further to inspect. This is done e.g. by operations that will push multiple values to the stack to verify that
+	/// all necessary stack space is available ahead of pushing anything, though each individual push will then result in
+	/// a further `PreAuthorised` access.
+	PreAuthorised,
+};
+
 /// Performs @c instruction  querying @c registers and/or @c memory as required, using @c io for port input/output,
 /// and providing any flow control effects to @c flow_controller.
 ///

--- a/InstructionSets/x86/Perform.hpp
+++ b/InstructionSets/x86/Perform.hpp
@@ -36,24 +36,38 @@ enum class AccessType {
 	PreauthorisedWrite,
 };
 
+template <
+	Model model_,
+	typename FlowControllerT,
+	typename RegistersT,
+	typename MemoryT,
+	typename IOT
+> struct ExecutionContext {
+	FlowControllerT flow_controller;
+	Status status;
+	RegistersT registers;
+	MemoryT memory;
+	IOT io;
+	static constexpr Model model = model_;
+};
+
 /// Performs @c instruction  querying @c registers and/or @c memory as required, using @c io for port input/output,
 /// and providing any flow control effects to @c flow_controller.
 ///
 /// Any change in processor status will be applied to @c status.
 template <
-	Model model,
 	typename InstructionT,
-	typename FlowControllerT,
-	typename RegistersT,
-	typename MemoryT,
-	typename IOT
+	typename ContextT
 > void perform(
 	const InstructionT &instruction,
-	Status &status,
-	FlowControllerT &flow_controller,
-	RegistersT &registers,
-	MemoryT &memory,
-	IOT &io
+	ContextT &context
+);
+
+template <
+	typename ContextT
+> void interrupt(
+	int index,
+	ContextT &context
 );
 
 }

--- a/InstructionSets/x86/Perform.hpp
+++ b/InstructionSets/x86/Perform.hpp
@@ -32,7 +32,8 @@ enum class AccessType {
 	/// need further to inspect. This is done e.g. by operations that will push multiple values to the stack to verify that
 	/// all necessary stack space is available ahead of pushing anything, though each individual push will then result in
 	/// a further `Preauthorised` access.
-	Preauthorised,
+	PreauthorisedRead,
+	PreauthorisedWrite,
 };
 
 /// Performs @c instruction  querying @c registers and/or @c memory as required, using @c io for port input/output,

--- a/OSBindings/Mac/Clock SignalTests/8088Tests.mm
+++ b/OSBindings/Mac/Clock SignalTests/8088Tests.mm
@@ -25,7 +25,7 @@ namespace {
 
 // The tests themselves are not duplicated in this repository;
 // provide their real path here.
-constexpr char TestSuiteHome[] = "/Users/tharte/Projects/ProcessorTests/8088/v1";
+constexpr char TestSuiteHome[] = "/Users/thomasharte/Projects/ProcessorTests/8088/v1";
 
 using Status = InstructionSet::x86::Status;
 struct Registers {
@@ -186,6 +186,11 @@ struct Memory {
 		if(type == AccessType::Read) {
 			*reinterpret_cast<IntT *>(&read_value_) = value;
 			return *reinterpret_cast<IntT *>(&read_value_);
+		}
+
+		// If the CPU has indicated a write, it should be safe to fuzz the value now.
+		if(type == AccessType::Write) {
+			value = IntT(~0);
 		}
 
 		return value;

--- a/OSBindings/Mac/Clock SignalTests/8088Tests.mm
+++ b/OSBindings/Mac/Clock SignalTests/8088Tests.mm
@@ -25,7 +25,7 @@ namespace {
 
 // The tests themselves are not duplicated in this repository;
 // provide their real path here.
-constexpr char TestSuiteHome[] = "/Users/thomasharte/Projects/ProcessorTests/8088/v1";
+constexpr char TestSuiteHome[] = "/Users/tharte/Projects/ProcessorTests/8088/v1";
 
 using Status = InstructionSet::x86::Status;
 struct Registers {
@@ -668,7 +668,7 @@ struct FailedExecution {
 	XCTAssertLessThanOrEqual(execution_failures.size(), 4138);
 
 	// Current accepted failures:
-	//	* 68 instances of DAA with invalid BCD input, and 64 of DAS;
+	//	* 65 instances of DAA with invalid BCD input, and 64 of DAS;
 	//	* 2484 instances of LEA from a register, which officially has undefined results;
 	//	* 42 instances of AAM 00h for which I can't figure out what to do with flags; and
 	//	* 1486 instances of IDIV, most either with a rep or repne that on the 8086 specifically negatives the result,

--- a/OSBindings/Mac/Clock SignalTests/8088Tests.mm
+++ b/OSBindings/Mac/Clock SignalTests/8088Tests.mm
@@ -133,7 +133,9 @@ struct Memory {
 		return physical_address << 4;
 	}
 
-	void preauthorise_stack(uint32_t) {}
+	void preauthorise_stack_write(uint32_t) {}
+	void preauthorise_stack_read(uint32_t) {}
+	void preauthorise_read(InstructionSet::x86::Source, uint16_t, uint32_t) {}
 
 	// Entry point used by the flow controller so that it can mark up locations at which the flags were written,
 	// so that defined-flag-only masks can be applied while verifying RAM contents.
@@ -233,10 +235,6 @@ class FlowController {
 		FlowController(Memory &memory, Registers &registers, Status &status) :
 			memory_(memory), registers_(registers), status_(status) {}
 
-		void did_iret() {}
-		void did_near_ret() {}
-		void did_far_ret() {}
-
 		void interrupt(int index) {
 			// TODO: reauthorise and possibly double fault?
 			const uint16_t address = static_cast<uint16_t>(index) << 2;
@@ -254,17 +252,6 @@ class FlowController {
 
 			registers_.cs_ = new_cs;
 			registers_.ip_ = new_ip;
-		}
-
-		void call(uint16_t address) {
-			push(registers_.ip_);
-			jump(address);
-		}
-
-		void call(uint16_t segment, uint16_t offset) {
-			push(registers_.cs_);
-			push(registers_.ip_);
-			jump(segment, offset);
 		}
 
 		void jump(uint16_t address) {

--- a/OSBindings/Mac/Clock SignalTests/8088Tests.mm
+++ b/OSBindings/Mac/Clock SignalTests/8088Tests.mm
@@ -25,7 +25,7 @@ namespace {
 
 // The tests themselves are not duplicated in this repository;
 // provide their real path here.
-constexpr char TestSuiteHome[] = "/Users/thomasharte/Projects/ProcessorTests/8088/v1";
+constexpr char TestSuiteHome[] = "/Users/tharte/Projects/ProcessorTests/8088/v1";
 
 using Status = InstructionSet::x86::Status;
 struct Registers {
@@ -132,6 +132,8 @@ struct Memory {
 		}
 		return physical_address << 4;
 	}
+
+	void preauthorise_stack(uint32_t) {}
 
 	// Entry point used by the flow controller so that it can mark up locations at which the flags were written,
 	// so that defined-flag-only masks can be applied while verifying RAM contents.

--- a/OSBindings/Mac/Clock SignalTests/8088Tests.mm
+++ b/OSBindings/Mac/Clock SignalTests/8088Tests.mm
@@ -170,10 +170,20 @@ struct Memory {
 	}
 
 	template <typename IntT, AccessType type> struct ReturnType;
+
+	// Reads: return a value directly.
 	template <typename IntT> struct ReturnType<IntT, AccessType::Read> { using type = IntT; };
+
+	// Byte writes: return a reference directly to the byte.
+	template <> struct ReturnType<uint8_t, AccessType::Write> { using type = uint8_t &; };
+	template <> struct ReturnType<uint8_t, AccessType::ReadModifyWrite> { using type = uint8_t &; };
+	template <> struct ReturnType<uint8_t, AccessType::Preauthorised> { using type = uint8_t &; };
+
+	// Larger writes: I'm on the fence here as to the proper approach to latching and writeback here;
+	// so offered as a separate case but with a conclusion yet to reach.
 	template <typename IntT> struct ReturnType<IntT, AccessType::Write> { using type = IntT &; };
 	template <typename IntT> struct ReturnType<IntT, AccessType::ReadModifyWrite> { using type = IntT &; };
-	template <typename IntT> struct ReturnType<IntT, AccessType::PreAuthorised> { using type = IntT &; };
+	template <typename IntT> struct ReturnType<IntT, AccessType::Preauthorised> { using type = IntT &; };
 
 	// Entry point for the 8086; simply notes that memory was accessed.
 	template <typename IntT, AccessType type>

--- a/OSBindings/Mac/Clock SignalTests/8088Tests.mm
+++ b/OSBindings/Mac/Clock SignalTests/8088Tests.mm
@@ -665,7 +665,15 @@ struct FailedExecution {
 	}
 
 	// Lock in current failure rate.
-	XCTAssertLessThanOrEqual(execution_failures.size(), 1654);
+	XCTAssertLessThanOrEqual(execution_failures.size(), 4138);
+
+	// Current accepted failures:
+	//	* 68 instances of DAA with invalid BCD input, and 64 of DAS;
+	//	* 2484 instances of LEA from a register, which officially has undefined results;
+	//	* 42 instances of AAM 00h for which I can't figure out what to do with flags; and
+	//	* 1486 instances of IDIV, most either with a rep or repne that on the 8086 specifically negatives the result,
+	//		but some admittedly still unexplained (primarily setting overflow even though the result doesn't overflow;
+	//		a couple of online 8086 emulators also didn't throw so maybe this is an 8086 quirk?)
 
 	for(const auto &failure: execution_failures) {
 		NSLog(@"Failed %s — %s", failure.test_name.c_str(), failure.reason.c_str());

--- a/OSBindings/Mac/Clock SignalTests/8088Tests.mm
+++ b/OSBindings/Mac/Clock SignalTests/8088Tests.mm
@@ -173,17 +173,18 @@ struct Memory {
 
 	// Reads: return a value directly.
 	template <typename IntT> struct ReturnType<IntT, AccessType::Read> { using type = IntT; };
+	template <typename IntT> struct ReturnType<IntT, AccessType::PreauthorisedRead> { using type = IntT; };
 
 	// Byte writes: return a reference directly to the byte.
 	template <> struct ReturnType<uint8_t, AccessType::Write> { using type = uint8_t &; };
 	template <> struct ReturnType<uint8_t, AccessType::ReadModifyWrite> { using type = uint8_t &; };
-	template <> struct ReturnType<uint8_t, AccessType::Preauthorised> { using type = uint8_t &; };
+	template <> struct ReturnType<uint8_t, AccessType::PreauthorisedWrite> { using type = uint8_t &; };
 
 	// Larger writes: I'm on the fence here as to the proper approach to latching and writeback here;
 	// so offered as a separate case but with a conclusion yet to reach.
 	template <typename IntT> struct ReturnType<IntT, AccessType::Write> { using type = IntT &; };
 	template <typename IntT> struct ReturnType<IntT, AccessType::ReadModifyWrite> { using type = IntT &; };
-	template <typename IntT> struct ReturnType<IntT, AccessType::Preauthorised> { using type = IntT &; };
+	template <typename IntT> struct ReturnType<IntT, AccessType::PreauthorisedWrite> { using type = IntT &; };
 
 	// Entry point for the 8086; simply notes that memory was accessed.
 	template <typename IntT, AccessType type>


### PR DESCRIPTION
The memory controller for a given machine now receives a type with each call to `access` which may be:
* read, which effectively means to throw if the described address isn't readable;
* write, which effectively means to throw if the described address isn't writeable;
* read-modify-write, which effectively means to throw if the described address isn't readable or writeable; and
* preauthorised read or write, which means not to validate because the access was validated earlier.

RAM accesses can be preauthorised based on segment, absolute or stack-relative position. All accesses are validated before `perform` modifies state.

I've also cleaned up the arguments provided to and beyond `perform` by bundling them into a single context object, and minimised what the flow controller does.

Kicked off into the long grass: come to a full determination on the best way to handle writeback for 16-bit values built from non-adjacent words. Thoughts:
* I could template out a memory return type based on access type and integer size, and provide something that RAIIs its own way into a writeback upon either of the write types, but that'd necessarily be fairly heavy because it'd need to keep an overt reference to underlying memory; but
* also, I could just add a write-immediately route into `Memory`, which is used by everything hitting the stack amongst other use cases, and then I'd be back to guaranteeing only a single split value can ever potentially be on-loan within the space of an operation, and it'd be overtly safe to keep that context within `Memory`.

For now I think I'm likely to merge this and get on with some other step, while thoughts percolate.