### PR TITLE
Improve IDIV marginally; require acceptable failures to have a reason.

### DIFF
--- a/InstructionSets/x86/Decoder.cpp
+++ b/InstructionSets/x86/Decoder.cpp
@@ -33,7 +33,7 @@ std::pair<int, typename Decoder<model>::InstructionT> Decoder<model>::decode(con
 
 /// Sets the operation and verifies that the current repetition, if any, is compatible, discarding it otherwise.
 #define SetOperation(op)	\
-	operation_ = rep_operation(op, repetition_);
+	operation_ = rep_operation<model>(op, repetition_);
 
 /// Helper macro for those that follow.
 #define SetOpSrcDestSize(op, src, dest, size)	\

--- a/InstructionSets/x86/Implementation/PerformImplementation.hpp
+++ b/InstructionSets/x86/Implementation/PerformImplementation.hpp
@@ -207,10 +207,11 @@ template <
 			Primitive::test<IntT>(destination_r(), source_r(), context);
 		return;
 
-		case Operation::MUL:	Primitive::mul<IntT>(pair_high(), pair_low(), source_r(), context);			return;
-		case Operation::IMUL_1:	Primitive::imul<IntT>(pair_high(), pair_low(), source_r(), context);		return;
-		case Operation::DIV:	Primitive::div<IntT>(pair_high(), pair_low(), source_r(), context);			return;
-		case Operation::IDIV:	Primitive::idiv<IntT>(pair_high(), pair_low(), source_r(), context);		return;
+		case Operation::MUL:		Primitive::mul<IntT>(pair_high(), pair_low(), source_r(), context);			return;
+		case Operation::IMUL_1:		Primitive::imul<IntT>(pair_high(), pair_low(), source_r(), context);		return;
+		case Operation::DIV:		Primitive::div<IntT>(pair_high(), pair_low(), source_r(), context);			return;
+		case Operation::IDIV:		Primitive::idiv<false, IntT>(pair_high(), pair_low(), source_r(), context);	return;
+		case Operation::IDIV_REP:	Primitive::idiv<true, IntT>(pair_high(), pair_low(), source_r(), context);	return;
 
 		case Operation::INC:	Primitive::inc<IntT>(destination_rmw(), context);		break;
 		case Operation::DEC:	Primitive::dec<IntT>(destination_rmw(), context);		break;

--- a/InstructionSets/x86/Instruction.cpp
+++ b/InstructionSets/x86/Instruction.cpp
@@ -105,14 +105,15 @@ std::string InstructionSet::x86::to_string(Operation operation, DataSize size, M
 		case Operation::HLT:	return "hlt";
 		case Operation::WAIT:	return "wait";
 
-		case Operation::ADC:	return "adc";
-		case Operation::ADD:	return "add";
-		case Operation::SBB:	return "sbb";
-		case Operation::SUB:	return "sub";
-		case Operation::MUL:	return "mul";
-		case Operation::IMUL_1:	return "imul";
-		case Operation::DIV:	return "div";
-		case Operation::IDIV:	return "idiv";
+		case Operation::ADC:		return "adc";
+		case Operation::ADD:		return "add";
+		case Operation::SBB:		return "sbb";
+		case Operation::SUB:		return "sub";
+		case Operation::MUL:		return "mul";
+		case Operation::IMUL_1:		return "imul";
+		case Operation::DIV:		return "div";
+		case Operation::IDIV:		return "idiv";
+		case Operation::IDIV_REP:	return "idiv";
 
 		case Operation::INC:	return "inc";
 		case Operation::DEC:	return "dec";

--- a/InstructionSets/x86/Instruction.hpp
+++ b/InstructionSets/x86/Instruction.hpp
@@ -470,6 +470,9 @@ enum class Source: uint8_t {
 	/// getter is used).
 	IndirectNoBase = Indirect - 1,
 };
+constexpr bool is_register(Source source) {
+	return source < Source::None;
+}
 
 enum class Repetition: uint8_t {
 	None, RepE, RepNE, Rep,

--- a/InstructionSets/x86/Instruction.hpp
+++ b/InstructionSets/x86/Instruction.hpp
@@ -231,6 +231,8 @@ enum class Operation: uint8_t {
 	SETMOC,
 	/// Set destination to ~0.
 	SETMO,
+	/// Perform an IDIV and negative the result.
+	IDIV_REP,
 
 	//
 	// 80186 additions.
@@ -474,8 +476,15 @@ enum class Repetition: uint8_t {
 };
 
 /// @returns @c true if @c operation supports repetition mode @c repetition; @c false otherwise.
+template <Model model>
 constexpr Operation rep_operation(Operation operation, Repetition repetition) {
 	switch(operation) {
+		case Operation::IDIV:
+			if constexpr (model == Model::i8086) {
+				return repetition != Repetition::None ? Operation::IDIV_REP : Operation::IDIV;
+			}
+		[[fallthrough]];
+
 		default: return operation;
 
 		case Operation::INS:


### PR DESCRIPTION
Failures accepted, related to undocumented or undefined behaviour of the 8086:
* my `AAM 00h` doesn't modify status before throwing a divide error but the 8086's does;
* my `LEA reg` loads the value of the register whereas the 8086's loads whatever address was last calculated; and
* the test set's `rep idiv` sometimes doesn't advance the instruction pointer.

Additionally:
* my `IDIV byte` doesn't throw as often as the 8086's, it seems. I can't find an example where it should have thrown per the spec and have observed other 16-bit x86 emulations doing the same as mine. So I provisionally think this is an 8086 quirk.

In net though: since I'm now testing for and permitting only these failures, if any other failures are introduced then they should show up more clearly and hence be easier to diagnose.