### PR TITLE
Add means for tracking segment register changes.

### DIFF
--- a/InstructionSets/x86/Implementation/BCD.hpp
+++ b/InstructionSets/x86/Implementation/BCD.hpp
@@ -30,6 +30,8 @@ void aaas(
 			--ax.halves.high;
 		}
 		context.flags.template set_from<Flag::Carry, Flag::AuxiliaryCarry>(1);
+	} else {
+		context.flags.template set_from<Flag::Carry>(0);
 	}
 	ax.halves.low &= 0x0f;
 }

--- a/InstructionSets/x86/Implementation/PerformImplementation.hpp
+++ b/InstructionSets/x86/Implementation/PerformImplementation.hpp
@@ -253,7 +253,12 @@ template <
 		return;
 
 		case Operation::LEA:	Primitive::lea<IntT>(instruction, destination_w(), context);	return;
-		case Operation::MOV:	Primitive::mov<IntT>(destination_w(), source_r());				break;
+		case Operation::MOV:
+			Primitive::mov<IntT>(destination_w(), source_r());
+			if constexpr (std::is_same_v<IntT, uint16_t>) {
+				context.registers.did_update(instruction.destination.source());
+			}
+		break;
 
 		case Operation::JO:		jcc(context.flags.template condition<Condition::Overflow>());		return;
 		case Operation::JNO:	jcc(!context.flags.template condition<Condition::Overflow>());		return;
@@ -319,7 +324,12 @@ template <
 
 		case Operation::XLAT:	Primitive::xlat<AddressT>(instruction, context);		return;
 
-		case Operation::POP:	destination_w() = Primitive::pop<IntT, false>(context);	break;
+		case Operation::POP:
+			destination_w() = Primitive::pop<IntT, false>(context);
+			if constexpr (std::is_same_v<IntT, uint16_t>) {
+				context.registers.did_update(instruction.destination.source());
+			}
+		break;
 		case Operation::PUSH:
 			Primitive::push<IntT, false>(source_rmw(), context);	// PUSH SP modifies SP before pushing it;
 																	// hence PUSH is sometimes read-modify-write.

--- a/InstructionSets/x86/Implementation/PerformImplementation.hpp
+++ b/InstructionSets/x86/Implementation/PerformImplementation.hpp
@@ -246,10 +246,16 @@ template <
 		case Operation::LAHF:	Primitive::lahf(context.registers.ah(), context);		return;
 
 		case Operation::LDS:
-			if constexpr (data_size == DataSize::Word) Primitive::ld<Source::DS>(instruction, destination_w(), context);
+			if constexpr (data_size == DataSize::Word) {
+				Primitive::ld<Source::DS>(instruction, destination_w(), context);
+				context.registers.did_update(Source::DS);
+			}
 		return;
 		case Operation::LES:
-			if constexpr (data_size == DataSize::Word) Primitive::ld<Source::ES>(instruction, destination_w(), context);
+			if constexpr (data_size == DataSize::Word) {
+				Primitive::ld<Source::ES>(instruction, destination_w(), context);
+				context.registers.did_update(Source::ES);
+			}
 		return;
 
 		case Operation::LEA:	Primitive::lea<IntT>(instruction, destination_w(), context);	return;

--- a/InstructionSets/x86/Implementation/PerformImplementation.hpp
+++ b/InstructionSets/x86/Implementation/PerformImplementation.hpp
@@ -256,7 +256,7 @@ template <
 		case Operation::MOV:
 			Primitive::mov<IntT>(destination_w(), source_r());
 			if constexpr (std::is_same_v<IntT, uint16_t>) {
-				context.registers.did_update(instruction.destination.source());
+				context.registers.did_update(instruction.destination().source());
 			}
 		break;
 
@@ -327,7 +327,7 @@ template <
 		case Operation::POP:
 			destination_w() = Primitive::pop<IntT, false>(context);
 			if constexpr (std::is_same_v<IntT, uint16_t>) {
-				context.registers.did_update(instruction.destination.source());
+				context.registers.did_update(instruction.destination().source());
 			}
 		break;
 		case Operation::PUSH:

--- a/InstructionSets/x86/Instruction.hpp
+++ b/InstructionSets/x86/Instruction.hpp
@@ -444,7 +444,7 @@ enum class Source: uint8_t {
 	T0 = 0, T1 = 1, T2 = 2, T3 = 3, T4 = 4, T5 = 5, T6 = 6, T7 = 7,
 	D0 = 0, D1 = 1, D2 = 2, D3 = 3, D4 = 4, D5 = 5, D6 = 6, D7 = 7,
 
-	// Selectors.
+	// Segment registers.
 	ES, CS, SS, DS, FS, GS,
 
 	/// @c None can be treated as a source that produces 0 when encountered;
@@ -472,6 +472,9 @@ enum class Source: uint8_t {
 };
 constexpr bool is_register(Source source) {
 	return source < Source::None;
+}
+constexpr bool is_segment_register(Source source) {
+	return is_register(source) && source >= Source::ES;
 }
 
 enum class Repetition: uint8_t {

--- a/OSBindings/Mac/Clock SignalTests/8088Tests.mm
+++ b/OSBindings/Mac/Clock SignalTests/8088Tests.mm
@@ -285,7 +285,7 @@ struct Memory {
 		}
 
 		// An additional entry point for the flow controller; on the original 8086 interrupt vectors aren't relative
-		// to a selector, they're just at an absolute location.
+		// to a segment, they're just at an absolute location.
 		template <typename IntT, AccessType type>
 		typename InstructionSet::x86::Accessor<IntT, type>::type access(uint32_t address, Tag tag) {
 			if constexpr (type == AccessType::PreauthorisedRead) {

--- a/OSBindings/Mac/Clock SignalTests/8088Tests.mm
+++ b/OSBindings/Mac/Clock SignalTests/8088Tests.mm
@@ -79,6 +79,7 @@ struct Registers {
 	uint16_t &ss()	{	return ss_;				}
 
 	using Source = InstructionSet::x86::Source;
+	/// Posted by @c perform after any operation which *might* have affected a segment register.
 	void did_update(Source segment) {
 		switch(segment) {
 			default: break;

--- a/OSBindings/Mac/Clock SignalTests/8088Tests.mm
+++ b/OSBindings/Mac/Clock SignalTests/8088Tests.mm
@@ -348,6 +348,7 @@ class FlowController {
 
 		void jump(uint16_t segment, uint16_t address) {
 			registers_.cs_ = segment;
+			registers_.did_update(Registers::Source::CS);
 			registers_.ip_ = address;
 		}
 

--- a/OSBindings/Mac/Clock SignalTests/8088Tests.mm
+++ b/OSBindings/Mac/Clock SignalTests/8088Tests.mm
@@ -249,15 +249,13 @@ struct Memory {
 		}
 
 		uint32_t segment_base(InstructionSet::x86::Source segment) {
-			uint32_t physical_address;
 			using Source = InstructionSet::x86::Source;
 			switch(segment) {
-				default:			physical_address = registers_.ds_;	break;
-				case Source::ES:	physical_address = registers_.es_;	break;
-				case Source::CS:	physical_address = registers_.cs_;	break;
-				case Source::SS:	physical_address = registers_.ss_;	break;
+				default:			return registers_.ds_base_;
+				case Source::ES:	return registers_.es_base_;
+				case Source::CS:	return registers_.cs_base_;
+				case Source::SS:	return registers_.ss_base_;
 			}
-			return physical_address << 4;
 		}
 
 		uint32_t address(InstructionSet::x86::Source segment, uint16_t offset) {
@@ -555,6 +553,11 @@ struct FailedExecution {
 	registers.sp_ = [value[@"sp"] intValue];
 	registers.ss_ = [value[@"ss"] intValue];
 	registers.ip_ = [value[@"ip"] intValue];
+
+	registers.did_update(Registers::Source::ES);
+	registers.did_update(Registers::Source::CS);
+	registers.did_update(Registers::Source::DS);
+	registers.did_update(Registers::Source::SS);
 
 	const uint16_t flags_value = [value[@"flags"] intValue];
 	flags.set(flags_value);

--- a/OSBindings/Mac/Clock SignalTests/8088Tests.mm
+++ b/OSBindings/Mac/Clock SignalTests/8088Tests.mm
@@ -703,6 +703,7 @@ struct FailedExecution {
 			non_exception_registers.sp() = execution_support.registers.sp();
 			non_exception_registers.ax() = execution_support.registers.ax();
 			non_exception_registers.cs() = execution_support.registers.cs();
+			non_exception_registers.cs_base_ = execution_support.registers.cs_base_;
 
 			if(non_exception_registers == execution_support.registers) {
 				failure_list = &permitted_failures;

--- a/OSBindings/Mac/Clock SignalTests/8088Tests.mm
+++ b/OSBindings/Mac/Clock SignalTests/8088Tests.mm
@@ -103,7 +103,11 @@ struct Registers {
 			cs_ == rhs.cs_ &&
 			ds_ == rhs.ds_ &&
 			si_ == rhs.si_ &&
-			ip_ == rhs.ip_;
+			ip_ == rhs.ip_ &&
+			es_base_ == rhs.es_base_ &&
+			cs_base_ == rhs.cs_base_ &&
+			ds_base_ == rhs.ds_base_ &&
+			ss_base_ == rhs.ss_base_;
 	}
 };
 struct Memory {


### PR DESCRIPTION
While also fixing AAA/AAS's effect on the carry flag.

Segment register changes are observed by the test runner for no reason more sophisticated than eliminating a small shift, primarily for the sake of testing that the changes are caught at all. But they're essential to supporting protected modes, where changes actually trigger a selector reload.