### PR TITLE
Clear a path towards implementing the 80286

### DIFF
--- a/InstructionSets/x86/Implementation/PerformImplementation.hpp
+++ b/InstructionSets/x86/Implementation/PerformImplementation.hpp
@@ -211,7 +211,15 @@ template <
 		case Operation::IMUL_1:		Primitive::imul<IntT>(pair_high(), pair_low(), source_r(), context);		return;
 		case Operation::DIV:		Primitive::div<IntT>(pair_high(), pair_low(), source_r(), context);			return;
 		case Operation::IDIV:		Primitive::idiv<false, IntT>(pair_high(), pair_low(), source_r(), context);	return;
-		case Operation::IDIV_REP:	Primitive::idiv<true, IntT>(pair_high(), pair_low(), source_r(), context);	return;
+		case Operation::IDIV_REP:
+			if constexpr (ContextT::model == Model::i8086) {
+				Primitive::idiv<true, IntT>(pair_high(), pair_low(), source_r(), context);
+				break;
+			} else {
+				// TODO: perform LEAVE as of the 80186.
+				static_assert(int(Operation::IDIV_REP) == int(Operation::LEAVE));
+			}
+		return;
 
 		case Operation::INC:	Primitive::inc<IntT>(destination_rmw(), context);		break;
 		case Operation::DEC:	Primitive::dec<IntT>(destination_rmw(), context);		break;

--- a/InstructionSets/x86/Implementation/PerformImplementation.hpp
+++ b/InstructionSets/x86/Implementation/PerformImplementation.hpp
@@ -216,8 +216,10 @@ template <
 				Primitive::idiv<true, IntT>(pair_high(), pair_low(), source_r(), context);
 				break;
 			} else {
-				// TODO: perform LEAVE as of the 80186.
 				static_assert(int(Operation::IDIV_REP) == int(Operation::LEAVE));
+				if constexpr (std::is_same_v<IntT, uint16_t> || std::is_same_v<IntT, uint32_t>) {
+					Primitive::leave<IntT>();
+				}
 			}
 		return;
 

--- a/InstructionSets/x86/Implementation/PerformImplementation.hpp
+++ b/InstructionSets/x86/Implementation/PerformImplementation.hpp
@@ -317,8 +317,8 @@ template <
 				Primitive::setmo<IntT>(destination_w(), context);
 				break;
 			} else {
-				// TODO: perform ENTER as of the 80186.
 				static_assert(int(Operation::SETMO) == int(Operation::ENTER));
+				Primitive::enter<IntT>(instruction, context);
 			}
 		return;
 		case Operation::SETMOC:

--- a/InstructionSets/x86/Implementation/PerformImplementation.hpp
+++ b/InstructionSets/x86/Implementation/PerformImplementation.hpp
@@ -256,13 +256,13 @@ template <
 		case Operation::LDS:
 			if constexpr (data_size == DataSize::Word) {
 				Primitive::ld<Source::DS>(instruction, destination_w(), context);
-				context.registers.did_update(Source::DS);
+				context.segments.did_update(Source::DS);
 			}
 		return;
 		case Operation::LES:
 			if constexpr (data_size == DataSize::Word) {
 				Primitive::ld<Source::ES>(instruction, destination_w(), context);
-				context.registers.did_update(Source::ES);
+				context.segments.did_update(Source::ES);
 			}
 		return;
 
@@ -270,7 +270,7 @@ template <
 		case Operation::MOV:
 			Primitive::mov<IntT>(destination_w(), source_r());
 			if constexpr (std::is_same_v<IntT, uint16_t>) {
-				context.registers.did_update(instruction.destination().source());
+				context.segments.did_update(instruction.destination().source());
 			}
 		break;
 
@@ -341,7 +341,7 @@ template <
 		case Operation::POP:
 			destination_w() = Primitive::pop<IntT, false>(context);
 			if constexpr (std::is_same_v<IntT, uint16_t>) {
-				context.registers.did_update(instruction.destination().source());
+				context.segments.did_update(instruction.destination().source());
 			}
 		break;
 		case Operation::PUSH:
@@ -349,10 +349,26 @@ template <
 																	// hence PUSH is sometimes read-modify-write.
 		break;
 
-		case Operation::POPF:	Primitive::popf(context);			return;
-		case Operation::PUSHF:	Primitive::pushf(context);			return;
-		case Operation::POPA:	Primitive::popa<IntT>(context);		return;
-		case Operation::PUSHA:	Primitive::pusha<IntT>(context);	return;
+		case Operation::POPF:
+			if constexpr (std::is_same_v<IntT, uint16_t> || std::is_same_v<IntT, uint32_t>) {
+				Primitive::popf(context);
+			}
+		return;
+		case Operation::PUSHF:
+			if constexpr (std::is_same_v<IntT, uint16_t> || std::is_same_v<IntT, uint32_t>) {
+				Primitive::pushf(context);
+			}
+		return;
+		case Operation::POPA:
+			if constexpr (std::is_same_v<IntT, uint16_t> || std::is_same_v<IntT, uint32_t>) {
+				Primitive::popa<IntT>(context);
+			}
+		return;
+		case Operation::PUSHA:
+			if constexpr (std::is_same_v<IntT, uint16_t> || std::is_same_v<IntT, uint32_t>) {
+				Primitive::pusha<IntT>(context);
+			}
+		return;
 
 		case Operation::CMPS:
 			Primitive::cmps<IntT, AddressT, Repetition::None>(instruction, eCX(), eSI(), eDI(), context);

--- a/InstructionSets/x86/Implementation/PerformImplementation.hpp
+++ b/InstructionSets/x86/Implementation/PerformImplementation.hpp
@@ -348,8 +348,11 @@ template <
 			Primitive::push<IntT, false>(source_rmw(), context);	// PUSH SP modifies SP before pushing it;
 																	// hence PUSH is sometimes read-modify-write.
 		break;
-		case Operation::POPF:	Primitive::popf(context);								return;
-		case Operation::PUSHF:	Primitive::pushf(context);								return;
+
+		case Operation::POPF:	Primitive::popf(context);			return;
+		case Operation::PUSHF:	Primitive::pushf(context);			return;
+		case Operation::POPA:	Primitive::popa<IntT>(context);		return;
+		case Operation::PUSHA:	Primitive::pusha<IntT>(context);	return;
 
 		case Operation::CMPS:
 			Primitive::cmps<IntT, AddressT, Repetition::None>(instruction, eCX(), eSI(), eDI(), context);

--- a/InstructionSets/x86/Implementation/PerformImplementation.hpp
+++ b/InstructionSets/x86/Implementation/PerformImplementation.hpp
@@ -328,8 +328,8 @@ template <
 				}
 				break;
 			} else {
-				// TODO: perform BOUND as of the 80186.
 				static_assert(int(Operation::SETMOC) == int(Operation::BOUND));
+				Primitive::bound<IntT>(instruction, destination_r(), source_r(), context);
 			}
 		return;
 

--- a/InstructionSets/x86/Implementation/Stack.hpp
+++ b/InstructionSets/x86/Implementation/Stack.hpp
@@ -95,27 +95,25 @@ template <typename IntT, typename ContextT>
 void popa(
 	ContextT &context
 ) {
-	if constexpr (!std::is_same_v<IntT, uint8_t>) {
-		context.memory.preauthorise_stack_read(sizeof(IntT) * 8);
-		if constexpr (std::is_same_v<IntT, uint32_t>) {
-			context.registers.edi() = pop<uint32_t, true>(context);
-			context.registers.esi() = pop<uint32_t, true>(context);
-			context.registers.ebp() = pop<uint32_t, true>(context);
-			context.registers.esp() += 4;
-			context.registers.ebx() = pop<uint32_t, true>(context);
-			context.registers.edx() = pop<uint32_t, true>(context);
-			context.registers.ecx() = pop<uint32_t, true>(context);
-			context.registers.eax() = pop<uint32_t, true>(context);
-		} else {
-			context.registers.di() = pop<uint16_t, true>(context);
-			context.registers.si() = pop<uint16_t, true>(context);
-			context.registers.bp() = pop<uint16_t, true>(context);
-			context.registers.sp() += 2;
-			context.registers.bx() = pop<uint16_t, true>(context);
-			context.registers.dx() = pop<uint16_t, true>(context);
-			context.registers.cx() = pop<uint16_t, true>(context);
-			context.registers.ax() = pop<uint16_t, true>(context);
-		}
+	context.memory.preauthorise_stack_read(sizeof(IntT) * 8);
+	if constexpr (std::is_same_v<IntT, uint32_t>) {
+		context.registers.edi() = pop<uint32_t, true>(context);
+		context.registers.esi() = pop<uint32_t, true>(context);
+		context.registers.ebp() = pop<uint32_t, true>(context);
+		context.registers.esp() += 4;
+		context.registers.ebx() = pop<uint32_t, true>(context);
+		context.registers.edx() = pop<uint32_t, true>(context);
+		context.registers.ecx() = pop<uint32_t, true>(context);
+		context.registers.eax() = pop<uint32_t, true>(context);
+	} else {
+		context.registers.di() = pop<uint16_t, true>(context);
+		context.registers.si() = pop<uint16_t, true>(context);
+		context.registers.bp() = pop<uint16_t, true>(context);
+		context.registers.sp() += 2;
+		context.registers.bx() = pop<uint16_t, true>(context);
+		context.registers.dx() = pop<uint16_t, true>(context);
+		context.registers.cx() = pop<uint16_t, true>(context);
+		context.registers.ax() = pop<uint16_t, true>(context);
 	}
 }
 
@@ -123,28 +121,26 @@ template <typename IntT, typename ContextT>
 void pusha(
 	ContextT &context
 ) {
-	if constexpr (!std::is_same_v<IntT, uint8_t>) {
-		context.memory.preauthorise_stack_read(sizeof(IntT) * 8);
-		IntT initial_sp = context.registers.sp();
-		if constexpr (std::is_same_v<IntT, uint32_t>) {
-			push<uint32_t, true>(context.registers.eax(), context);
-			push<uint32_t, true>(context.registers.ecx(), context);
-			push<uint32_t, true>(context.registers.edx(), context);
-			push<uint32_t, true>(context.registers.ebx(), context);
-			push<uint32_t, true>(initial_sp, context);
-			push<uint32_t, true>(context.registers.ebp(), context);
-			push<uint32_t, true>(context.registers.esi(), context);
-			push<uint32_t, true>(context.registers.esi(), context);
-		} else {
-			push<uint16_t, true>(context.registers.ax(), context);
-			push<uint16_t, true>(context.registers.cx(), context);
-			push<uint16_t, true>(context.registers.dx(), context);
-			push<uint16_t, true>(context.registers.bx(), context);
-			push<uint16_t, true>(initial_sp, context);
-			push<uint16_t, true>(context.registers.bp(), context);
-			push<uint16_t, true>(context.registers.si(), context);
-			push<uint16_t, true>(context.registers.si(), context);
-	}
+	context.memory.preauthorise_stack_read(sizeof(IntT) * 8);
+	IntT initial_sp = context.registers.sp();
+	if constexpr (std::is_same_v<IntT, uint32_t>) {
+		push<uint32_t, true>(context.registers.eax(), context);
+		push<uint32_t, true>(context.registers.ecx(), context);
+		push<uint32_t, true>(context.registers.edx(), context);
+		push<uint32_t, true>(context.registers.ebx(), context);
+		push<uint32_t, true>(initial_sp, context);
+		push<uint32_t, true>(context.registers.ebp(), context);
+		push<uint32_t, true>(context.registers.esi(), context);
+		push<uint32_t, true>(context.registers.esi(), context);
+	} else {
+		push<uint16_t, true>(context.registers.ax(), context);
+		push<uint16_t, true>(context.registers.cx(), context);
+		push<uint16_t, true>(context.registers.dx(), context);
+		push<uint16_t, true>(context.registers.bx(), context);
+		push<uint16_t, true>(initial_sp, context);
+		push<uint16_t, true>(context.registers.bp(), context);
+		push<uint16_t, true>(context.registers.si(), context);
+		push<uint16_t, true>(context.registers.si(), context);
 	}
 }
 

--- a/InstructionSets/x86/Implementation/Stack.hpp
+++ b/InstructionSets/x86/Implementation/Stack.hpp
@@ -144,6 +144,21 @@ void pusha(
 	}
 }
 
+template <typename IntT, typename ContextT>
+void leave(
+	ContextT &context
+) {
+	// TODO: should use StackAddressSize to determine assignment of bp to sp.
+	// Probably make that a static constexpr on registers.
+	if constexpr (std::is_same_v<IntT, uint32_t>) {
+		context.registers.esp() = context.registers.ebp();
+		context.registers.ebp() = pop<uint32_t, false>(context);
+	} else {
+		context.registers.sp() = context.registers.bp();
+		context.registers.bp() = pop<uint16_t, false>(context);
+	}
+}
+
 }
 
 #endif /* Stack_hpp */

--- a/InstructionSets/x86/Instruction.hpp
+++ b/InstructionSets/x86/Instruction.hpp
@@ -240,10 +240,10 @@ enum class Operation: uint8_t {
 
 	/// Checks whether the signed value in the destination register is within the bounds
 	/// stored at the location indicated by the source register, which will point to two
-	/// 16- or 32-bit words, the first being a signed lower bound and the signed upper.
+	/// 16- or 32-bit words, the first being a signed lower bound and the second
+	/// a signed upper.
 	/// Raises a bounds exception if not.
 	BOUND = SETMOC,
-
 
 	/// Create stack frame. See operand() for the nesting level and offset()
 	/// for the dynamic storage size.
@@ -272,42 +272,70 @@ enum class Operation: uint8_t {
 	// 80286 additions.
 	//
 
-	// TODO: expand detail on all operations below.
-
-	/// Adjusts requested privilege level.
+	/// Read a segment selector from the destination and one from the source.
+	/// If the destination RPL is less than the source, set ZF and set the destination RPL to the source.
+	/// Otherwise clear ZF and don't modify the destination selector.
 	ARPL,
-	/// Clears the task-switched flag.
+	/// Clears the task-switched flag in CR0.
 	CLTS,
 	/// Loads access rights.
 	LAR,
 
-	/// Loads the global descriptor table.
+	/// Loads the global descriptor table register from the source.
+	/// 32-bit operand: read a 16-bit limit followed by a 32-bit base.
+	/// 16-bit operand: read a 16-bit limit followed by a 24-bit base.
 	LGDT,
-	/// Loads the interrupt descriptor table.
-	LIDT,
-	/// Loads the local descriptor table.
-	LLDT,
-	/// Stores the global descriptor table.
+	/// Stores the global descriptor table register at the destination;
+	/// Always stores a 16-bit limit followed by a 32-bit base though
+	/// the highest byte may be zero.
 	SGDT,
-	/// Stores the interrupt descriptor table.
+
+	/// Loads the interrupt descriptor table register from the source.
+	/// 32-bit operand: read a 16-bit limit followed by a 32-bit base.
+	/// 16-bit operand: read a 16-bit limit followed by a 24-bit base.
+	LIDT,
+	/// Stores the interrupt descriptor table register at the destination.
+	/// Always stores a 16-bit limit followed by a 32-bit base though
+	/// the highest byte may be zero.
 	SIDT,
-	/// Stores the local descriptor table.
+
+	/// Loads the local descriptor table register.
+	/// The source will contain a segment selector pointing into the local descriptor table.
+	/// That selector is loaded into the local descriptor table register, along with the corresponding
+	///  segment limit and base from the global descriptor table.
+	LLDT,
+	/// Stores the local descriptor table register.
 	SLDT,
 
-	/// Verifies a segment for reading.
+	/// Verifies the segment indicated by source for reading, setting ZF.
+	///
+	/// ZF is set if: (i) the selector is not null; (ii) the selector is within GDT or LDT bounds;
+	/// (iii) the selector points to code or data; (iv) the segment is readable;
+	/// (v) the segment is either a conforming code segment, or the segment's DPL
+	/// is greater than or equal to both the CPL and the selector's RPL.
+	///
+	/// Otherwise ZF is clear.
 	VERR,
-	/// Verifies a segment for writing.
+	/// Verifies a segment for writing. Operates as per VERR but checks for writeability
+	/// rather than readability.
 	VERW,
 
-	/// Loads the machine status word.
+	/// Loads a 16-bit value from source into the machine status word.
+	/// The low order four bits of the source are copied into CR0, with the caveat
+	/// that if PE is set, the processor will enter protected mode, but if PE is clear
+	/// then there will be no change in protected mode.
+	///
+	/// Usurped in function by MOV CR0 as of the 80286.
 	LMSW,
-	/// Stores the machine status word.
+	/// Stores the machine status word, i.e. copies the low 16 bits of CR0 into the destination.
 	SMSW,
-	/// Loads a segment limit
+
+	/// Load the segment limit from descriptor specified by source into destination,
+	/// setting ZF if successful.
 	LSL,
-	/// Loads the task register.
+	/// Load the source operand into the segment selector field of the task register.
 	LTR,
-	/// Stores the task register.
+	/// Store the segment seleector of the task register into the destination.
 	STR,
 
 	/// Three-operand form of IMUL; multiply the immediate by the source and write to the destination.
@@ -319,6 +347,8 @@ enum class Operation: uint8_t {
 	//
 	// 80386 additions.
 	//
+
+	// TODO: expand detail on all operations below.
 
 	/// Loads a pointer to FS.
 	LFS,

--- a/InstructionSets/x86/Instruction.hpp
+++ b/InstructionSets/x86/Instruction.hpp
@@ -245,8 +245,8 @@ enum class Operation: uint8_t {
 	/// Raises a bounds exception if not.
 	BOUND = SETMOC,
 
-	/// Create stack frame. See operand() for the nesting level and offset()
-	/// for the dynamic storage size.
+	/// Create stack frame. See the Instruction getters `nesting_level()`
+	/// and `dynamic_storage_size()`.
 	ENTER,
 	/// Procedure exit; copies BP to SP, then pops a new BP from the stack.
 	LEAVE,
@@ -815,6 +815,11 @@ template<bool is_32bit> class Instruction {
 			return ops[has_operand()];
 		}
 
+		/// @returns The nesting level argument supplied to an ENTER.
+		constexpr ImmediateT nesting_level() const	{
+			return operand();
+		}
+
 		/// @returns The immediate segment value provided with this instruction, if any. Relevant for far calls and jumps; e.g.  `JMP 1234h:5678h` will
 		/// have a segment value of `1234h`.
 		constexpr uint16_t segment() const		{
@@ -831,6 +836,11 @@ template<bool is_32bit> class Instruction {
 		/// has an offset of `19h`.
 		constexpr DisplacementT displacement() const {
 			return DisplacementT(offset());
+		}
+
+		/// @returns The dynamic storage size argument supplied to an ENTER.
+		constexpr ImmediateT dynamic_storage_size() const	{
+			return displacement();
 		}
 
 		// Standard comparison operator.

--- a/InstructionSets/x86/Interrupts.hpp
+++ b/InstructionSets/x86/Interrupts.hpp
@@ -12,11 +12,26 @@
 namespace InstructionSet::x86 {
 
 enum Interrupt {
-	DivideError		= 0,
-	SingleStep		= 1,
-	NMI				= 2,
-	OneByte			= 3,
-	OnOverflow		= 4,
+	DivideError					= 0,
+	SingleStep					= 1,
+	NMI							= 2,
+	Breakpoint					= 3,
+	Overflow					= 4,
+	BoundRangeExceeded			= 5,
+	InvalidOpcode				= 6,
+	DeviceNotAvailable			= 7,
+	DoubleFault					= 8,
+	CoprocessorSegmentOverrun	= 9,
+	InvalidTSS					= 10,
+	SegmentNotPresent			= 11,
+	StackSegmentFault			= 12,
+	GeneralProtectionFault		= 13,
+	PageFault					= 14,
+	/* 15 is reserved */
+	FloatingPointException		= 16,
+	AlignmentCheck				= 17,
+	MachineCheck				= 18,
+
 };
 
 }

--- a/OSBindings/Mac/Clock SignalTests/8088Tests.mm
+++ b/OSBindings/Mac/Clock SignalTests/8088Tests.mm
@@ -33,71 +33,75 @@ constexpr char TestSuiteHome[] = "/Users/tharte/Projects/ProcessorTests/8088/v1"
 
 using Flags = InstructionSet::x86::Flags;
 struct Registers {
-	CPU::RegisterPair16 ax_;
-	uint8_t &al()	{	return ax_.halves.low;	}
-	uint8_t &ah()	{	return ax_.halves.high;	}
-	uint16_t &ax()	{	return ax_.full;		}
+	public:
+		static constexpr bool is_32bit = false;
 
-	CPU::RegisterPair16 &axp()	{	return ax_;	}
+		uint8_t &al()	{	return ax_.halves.low;	}
+		uint8_t &ah()	{	return ax_.halves.high;	}
+		uint16_t &ax()	{	return ax_.full;		}
 
-	CPU::RegisterPair16 cx_;
-	uint8_t &cl()	{	return cx_.halves.low;	}
-	uint8_t &ch()	{	return cx_.halves.high;	}
-	uint16_t &cx()	{	return cx_.full;		}
+		CPU::RegisterPair16 &axp()	{	return ax_;	}
 
-	CPU::RegisterPair16 dx_;
-	uint8_t &dl()	{	return dx_.halves.low;	}
-	uint8_t &dh()	{	return dx_.halves.high;	}
-	uint16_t &dx()	{	return dx_.full;		}
+		uint8_t &cl()	{	return cx_.halves.low;	}
+		uint8_t &ch()	{	return cx_.halves.high;	}
+		uint16_t &cx()	{	return cx_.full;		}
 
-	CPU::RegisterPair16 bx_;
-	uint8_t &bl()	{	return bx_.halves.low;	}
-	uint8_t &bh()	{	return bx_.halves.high;	}
-	uint16_t &bx()	{	return bx_.full;		}
+		uint8_t &dl()	{	return dx_.halves.low;	}
+		uint8_t &dh()	{	return dx_.halves.high;	}
+		uint16_t &dx()	{	return dx_.full;		}
 
-	uint16_t sp_;
-	uint16_t &sp()	{	return sp_;				}
+		uint8_t &bl()	{	return bx_.halves.low;	}
+		uint8_t &bh()	{	return bx_.halves.high;	}
+		uint16_t &bx()	{	return bx_.full;		}
 
-	uint16_t bp_;
-	uint16_t &bp()	{	return bp_;				}
+		uint16_t &sp()	{	return sp_;				}
+		uint16_t &bp()	{	return bp_;				}
+		uint16_t &si()	{	return si_;				}
+		uint16_t &di()	{	return di_;				}
 
-	uint16_t si_;
-	uint16_t &si()	{	return si_;				}
+		uint16_t ip_;
+		uint16_t &ip()	{	return ip_;				}
 
-	uint16_t di_;
-	uint16_t &di()	{	return di_;				}
+		uint16_t &es()	{	return es_;				}
+		uint16_t &cs()	{	return cs_;				}
+		uint16_t &ds()	{	return ds_;				}
+		uint16_t &ss()	{	return ss_;				}
 
-	uint16_t es_, cs_, ds_, ss_;
+		const uint16_t es() const	{	return es_;				}
+		const uint16_t cs() const	{	return cs_;				}
+		const uint16_t ds() const	{	return ds_;				}
+		const uint16_t ss() const	{	return ss_;				}
 
-	uint16_t ip_;
-	uint16_t &ip()	{	return ip_;				}
+		bool operator ==(const Registers &rhs) const {
+			return
+				ax_.full == rhs.ax_.full &&
+				cx_.full == rhs.cx_.full &&
+				dx_.full == rhs.dx_.full &&
+				bx_.full == rhs.bx_.full &&
+				sp_ == rhs.sp_ &&
+				bp_ == rhs.bp_ &&
+				si_ == rhs.si_ &&
+				di_ == rhs.di_ &&
+				es_ == rhs.es_ &&
+				cs_ == rhs.cs_ &&
+				ds_ == rhs.ds_ &&
+				si_ == rhs.si_ &&
+				ip_ == rhs.ip_;
+		}
 
-	uint16_t &es()	{	return es_;				}
-	uint16_t &cs()	{	return cs_;				}
-	uint16_t &ds()	{	return ds_;				}
-	uint16_t &ss()	{	return ss_;				}
+		// TODO: make the below private and use a friend class for test population, to ensure Perform
+		// is free of direct accesses.
+//	private:
+		CPU::RegisterPair16 ax_;
+		CPU::RegisterPair16 cx_;
+		CPU::RegisterPair16 dx_;
+		CPU::RegisterPair16 bx_;
 
-	const uint16_t es() const	{	return es_;				}
-	const uint16_t cs() const	{	return cs_;				}
-	const uint16_t ds() const	{	return ds_;				}
-	const uint16_t ss() const	{	return ss_;				}
-
-	bool operator ==(const Registers &rhs) const {
-		return
-			ax_.full == rhs.ax_.full &&
-			cx_.full == rhs.cx_.full &&
-			dx_.full == rhs.dx_.full &&
-			bx_.full == rhs.bx_.full &&
-			sp_ == rhs.sp_ &&
-			bp_ == rhs.bp_ &&
-			si_ == rhs.si_ &&
-			di_ == rhs.di_ &&
-			es_ == rhs.es_ &&
-			cs_ == rhs.cs_ &&
-			ds_ == rhs.ds_ &&
-			si_ == rhs.si_ &&
-			ip_ == rhs.ip_;
-	}
+		uint16_t sp_;
+		uint16_t bp_;
+		uint16_t si_;
+		uint16_t di_;
+		uint16_t es_, cs_, ds_, ss_;
 };
 class Segments {
 	public:
@@ -163,14 +167,14 @@ struct Memory {
 		// Preauthorisation call-ins.
 		//
 		void preauthorise_stack_write(uint32_t length) {
-			uint16_t sp = registers_.sp_;
+			uint16_t sp = registers_.sp();
 			while(length--) {
 				--sp;
 				preauthorise(InstructionSet::x86::Source::SS, sp);
 			}
 		}
 		void preauthorise_stack_read(uint32_t length) {
-			uint16_t sp = registers_.sp_;
+			uint16_t sp = registers_.sp();
 			while(length--) {
 				preauthorise(InstructionSet::x86::Source::SS, sp);
 				++sp;
@@ -261,7 +265,7 @@ struct Memory {
 		std::unordered_set<uint32_t> preauthorisations;
 		std::unordered_map<uint32_t, Tag> tags;
 		std::vector<uint8_t> memory;
-		const Registers &registers_;
+		Registers &registers_;
 		const Segments &segments_;
 
 		void preauthorise(uint32_t address) {

--- a/OSBindings/Mac/Clock SignalTests/8088Tests.mm
+++ b/OSBindings/Mac/Clock SignalTests/8088Tests.mm
@@ -127,10 +127,10 @@ class Segments {
 
 		bool operator ==(const Segments &rhs) const {
 			return
-				es_base_ != rhs.es_base_ &&
-				cs_base_ != rhs.cs_base_ &&
-				ds_base_ != rhs.ds_base_ &&
-				ss_base_ != rhs.ss_base_;
+				es_base_ == rhs.es_base_ &&
+				cs_base_ == rhs.cs_base_ &&
+				ds_base_ == rhs.ds_base_ &&
+				ss_base_ == rhs.ss_base_;
 		}
 
 	private:


### PR DESCRIPTION
Primarily:
1. fully document 80286 `Operation` semantics;
2. implement the 80186 instructions; and
3. create a separate object for handling segment mappings, rather than overloading the meaning of the register store.

The segment handler will receive descriptor pointers, handle VERR/VERW, etc.