### PR TITLE
Minor Mac UI wording changes

### DIFF
--- a/OSBindings/Mac/Clock Signal/AppDelegate.swift
+++ b/OSBindings/Mac/Clock Signal/AppDelegate.swift
@@ -18,7 +18,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 		if (MTLCopyAllDevices().count == 0) {
 			let alert = NSAlert()
 			alert.messageText = "This application requires a Metal-capable GPU"
-			alert.addButton(withTitle: "Exit")
+			alert.addButton(withTitle: "Quit")
 			alert.runModal()
 
 			let application = notification.object as! NSApplication

--- a/OSBindings/Mac/Clock Signal/AppDelegate.swift
+++ b/OSBindings/Mac/Clock Signal/AppDelegate.swift
@@ -17,7 +17,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 		// that this project supports reascends to 10.14.
 		if (MTLCopyAllDevices().count == 0) {
 			let alert = NSAlert()
-			alert.messageText = "This application requires a Metal-capable GPU"
+			alert.messageText = "This application requires a Metal-capable GPU."
 			alert.addButton(withTitle: "Quit")
 			alert.runModal()
 

--- a/OSBindings/Mac/Clock Signal/Base.lproj/MainMenu.xib
+++ b/OSBindings/Mac/Clock Signal/Base.lproj/MainMenu.xib
@@ -65,7 +65,7 @@
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <menu key="submenu" title="File" id="bib-Uj-vzu">
                         <items>
-                            <menuItem title="New" keyEquivalent="n" id="Was-JA-tGl">
+                            <menuItem title="New…" keyEquivalent="n" id="Was-JA-tGl">
                                 <connections>
                                     <action selector="newDocument:" target="-1" id="4Si-XN-c54"/>
                                 </connections>


### PR DESCRIPTION
A few minor changes to the Mac UI wording:

* Add a period at the end of the sentence "This application requires a Metal-capable GPU"
* Change the "Exit" button that closes that dialog to "Quit" to conform to standard macOS terminology
* Add ellipsis at end of "New" menu item since that menu item causes a dialog box to appear