### PR TITLE
Attempt to implement the XT keyboard controller.

### DIFF
--- a/Machines/PCCompatible/PCCompatible.cpp
+++ b/Machines/PCCompatible/PCCompatible.cpp
@@ -65,11 +65,11 @@ class KeyboardController {
 		}
 
 		void run_for(Cycles cycles) {
-			if(reset_delay_ < 0) {
+			if(reset_delay_ <= 0) {
 				return;
 			}
 			reset_delay_ -= cycles.as<int>();
-			if(reset_delay_ < 0) {
+			if(reset_delay_ <= 0) {
 				post(0xaa);
 			}
 		}

--- a/Machines/PCCompatible/PCCompatible.cpp
+++ b/Machines/PCCompatible/PCCompatible.cpp
@@ -89,6 +89,8 @@ class MDA {
 		struct CRTCOutputter {
 			CRTCOutputter() :
 				crt(882, 9, 382, 3, Outputs::Display::InputDataType::Red2Green2Blue2)
+				// TODO: really this should be a Luminance8 and set an appropriate modal tint colour;
+				// consider whether that's worth building into the scan target.
 			{
 //				crt.set_visible_area(Outputs::Display::Rect(0.1072f, 0.1f, 0.842105263157895f, 0.842105263157895f));
 				crt.set_display_type(Outputs::Display::DisplayType::RGB);

--- a/Machines/PCCompatible/PCCompatible.cpp
+++ b/Machines/PCCompatible/PCCompatible.cpp
@@ -133,6 +133,7 @@ class MDA {
 						}
 					}
 
+					// TODO: cursor.
 					if(pixels) {
 						const uint8_t attributes = ram[((state.refresh_address << 1) + 1) & 0xfff];
 						const uint8_t glyph = ram[((state.refresh_address << 1) + 0) & 0xfff];

--- a/Machines/PCCompatible/PCCompatible.cpp
+++ b/Machines/PCCompatible/PCCompatible.cpp
@@ -76,7 +76,10 @@ class KeyboardController {
 
 		uint8_t read() {
 			pic_.apply_edge<1>(false);
-			return input_;
+
+			const uint8_t key = input_;
+			input_ = 0;
+			return key;
 		}
 
 	private:

--- a/Machines/PCCompatible/PCCompatible.cpp
+++ b/Machines/PCCompatible/PCCompatible.cpp
@@ -259,6 +259,13 @@ class i8255PortHandler : public Intel::i8255::PortHandler {
 		void set_value(int port, uint8_t value) {
 			switch(port) {
 				case 1:
+					// b7: 0 => enable keyboard read; 1 => don't;
+					// b6: 0 => hold keyboard clock low; 1 => don't;
+					// b5: 1 => disable IO check; 0 => don't;
+					// b4: 1 => disable memory parity check; 0 => don't;
+					// b3: [5150] cassette motor control; [5160] high or low switches select;
+					// b2: [5150] high or low switches select; [5160] 1 => disable turbo mode;
+					// b1, b0: speaker control.
 					high_switches_ = value & 0x08;
 					speaker_.set_control(value & 0x01, value & 0x02);
 				break;
@@ -266,8 +273,20 @@ class i8255PortHandler : public Intel::i8255::PortHandler {
 			printf("PPI: %02x to %d\n", value, port);
 		}
 
+// KB Status Port 61h high bits:
+//; 01 - normal operation. wait for keypress, when one comes in,
+//;		force data line low (forcing keyboard to buffer additional
+//;		keypresses) and raise IRQ1 high
+//; 11 - stop forcing data line low. lower IRQ1 and don't raise it again.
+//;		drop all incoming keypresses on the floor.
+//; 10 - lower IRQ1 and force clock line low, resetting keyboard
+//; 00 - force clock line low, resetting keyboard, but on a 01->00 transition,
+//;		IRQ1 would remain high
+
 		uint8_t get_value(int port) {
 			switch(port) {
+
+
 				case 2:
 					// Common:
 					//

--- a/Machines/PCCompatible/PIC.hpp
+++ b/Machines/PCCompatible/PIC.hpp
@@ -114,13 +114,11 @@ class PIC {
 		int acknowledge() {
 			awaiting_eoi_ = true;
 
-			// TODO: there's bound to be a better solution than this search?
-			// TODO: is this the right priority order?
-			in_service_ = 0x80;
-			int id = 7;
-			while(!(in_service_ & requests_)) {
-				in_service_ >>= 1;
-				--id;
+			in_service_ = 0x01;
+			int id = 0;
+			while(!(in_service_ & requests_) && in_service_) {
+				in_service_ <<= 1;
+				++id;
 			}
 
 			if(in_service_) {


### PR DESCRIPTION
Also marginally beefs up the MDA to respect attributes other than blink (it also still ignores the hardware cursor), and switches it to green output — albeit it very fictionally in terms of internal wiring.

There are now no key-related failures reported during boot.

Doesn't actually wire up keyboard input. I'll fill that in if and when there's something that can receive it. There's too much guesswork here for me at present; satisfying the one BIOS I happen to be testing doesn't actually establish all that much.

<img width="1224" alt="Screenshot 2023-11-23 at 22 23 45" src="https://github.com/TomHarte/CLK/assets/1162152/8ab50c1f-986d-4a3c-a8b1-efd343c3862a">
