### PR TITLE
Sketch the outline of a high-level emulation of the PC FDC

### DIFF
--- a/Components/8272/CommandDecoder.hpp
+++ b/Components/8272/CommandDecoder.hpp
@@ -134,7 +134,7 @@ class CommandDecoder {
 
 		/// @returns @c true if this command involves reading or writing data, in which case target() will be valid.
 		/// @c false otherwise.
-		bool is_access_command() const {
+		bool is_access() const {
 			switch(command()) {
 				case Command::ReadData:		case Command::ReadDeletedData:
 				case Command::WriteData:	case Command::WriteDeletedData:

--- a/Components/8272/CommandDecoder.hpp
+++ b/Components/8272/CommandDecoder.hpp
@@ -161,7 +161,7 @@ class CommandDecoder {
 			return result;
 		}
 		uint8_t drive_head() const {
-			return command_[1]&7;
+			return command_[1] & 7;
 		}
 
 		//

--- a/Components/8272/CommandDecoder.hpp
+++ b/Components/8272/CommandDecoder.hpp
@@ -1,0 +1,221 @@
+//
+//  CommandDecoder.hpp
+//  Clock Signal
+//
+//  Created by Thomas Harte on 24/11/2023.
+//  Copyright © 2023 Thomas Harte. All rights reserved.
+//
+
+#ifndef CommandDecoder_hpp
+#define CommandDecoder_hpp
+
+#include <cstdint>
+#include <cstddef>
+#include <vector>
+
+namespace Intel::i8272 {
+
+class CommandDecoder {
+	public:
+		enum class Command {
+			ReadData = 0x06,
+			ReadDeletedData = 0x0c,
+
+			WriteData = 0x05,
+			WriteDeletedData = 0x09,
+
+			ReadTrack = 0x02,
+			ReadID = 0x0a,
+			FormatTrack = 0x0d,
+
+			ScanLow = 0x11,
+			ScanLowOrEqual = 0x19,
+			ScanHighOrEqual = 0x1d,
+
+			Recalibrate = 0x07,
+			Seek = 0x0f,
+
+			SenseInterruptStatus = 0x08,
+			Specify = 0x03,
+			SenseDriveStatus = 0x04,
+
+			Invalid = 0x00,
+		};
+
+		/// Add a byte to the current command.
+		void push_back(uint8_t byte) {
+			command_.push_back(byte);
+		}
+
+		/// Reset decoding.
+		void clear() {
+			command_.clear();
+		}
+
+		/// @returns @c true if an entire command has been received; @c false if further bytes are needed.
+		bool has_command() const {
+			if(!command_.size()) {
+				return false;
+			}
+
+			static constexpr std::size_t required_lengths[32] = {
+				0,	0,	9,	3,	2,	9,	9,	2,
+				1,	9,	2,	0,	9,	6,	0,	3,
+				0,	9,	0,	0,	0,	0,	0,	0,
+				0,	9,	0,	0,	0,	9,	0,	0,
+			};
+
+			return command_.size() >= required_lengths[command_[0] & 0x1f];
+		}
+
+		/// @returns The command requested. Valid only if @c has_command() is @c true.
+		Command command() const {
+			const auto command = Command(command_[0] & 0x1f);
+
+			switch(command) {
+				case Command::ReadData:		case Command::ReadDeletedData:
+				case Command::WriteData:	case Command::WriteDeletedData:
+				case Command::ReadTrack:	case Command::ReadID:
+				case Command::FormatTrack:
+				case Command::ScanLow:		case Command::ScanLowOrEqual:
+				case Command::ScanHighOrEqual:
+				case Command::Recalibrate:	case Command::Seek:
+				case Command::SenseInterruptStatus:
+				case Command::Specify:		case Command::SenseDriveStatus:
+					return command;
+
+				default: return Command::Invalid;
+			}
+		}
+
+		//
+		// Commands that specify geometry; i.e.
+		//
+		//	* ReadData;
+		//	* ReadDeletedData;
+		//	* WriteData;
+		//	* WriteDeletedData;
+		//	* ReadTrack;
+		//	* ScanEqual;
+		//	* ScanLowOrEqual;
+		//	* ScanHighOrEqual.
+		//
+
+		/// @returns @c true if this command specifies geometry, in which case geomtry() is well-defined.
+		/// @c false otherwise.
+		bool has_geometry() const	{	return command_.size() == 9;	}
+		struct Geometry {
+			uint8_t cylinder, head, sector, size, end_of_track;
+		};
+		Geometry geometry() const {
+			Geometry result;
+			result.cylinder = command_[2];
+			result.head = command_[3];
+			result.sector = command_[4];
+			result.size = command_[5];
+			result.end_of_track = command_[6];
+			return result;
+		}
+
+		//
+		// Commands that imply data access; i.e.
+		//
+		//	* ReadData;
+		//	* ReadDeletedData;
+		//	* WriteData;
+		//	* WriteDeletedData;
+		//	* ReadTrack;
+		//	* ReadID;
+		//	* FormatTrack;
+		//	* ScanLow;
+		//	* ScanLowOrEqual;
+		//	* ScanHighOrEqual.
+		//
+
+		/// @returns @c true if this command involves reading or writing data, in which case target() will be valid.
+		/// @c false otherwise.
+		bool is_access_command() const {
+			switch(command()) {
+				case Command::ReadData:		case Command::ReadDeletedData:
+				case Command::WriteData:	case Command::WriteDeletedData:
+				case Command::ReadTrack:	case Command::ReadID:
+				case Command::FormatTrack:
+				case Command::ScanLow:		case Command::ScanLowOrEqual:
+				case Command::ScanHighOrEqual:
+					return true;
+
+				default:
+					return false;
+			}
+		}
+		struct AccessTarget {
+			uint8_t drive, head;
+			bool mfm, skip_deleted;
+		};
+		AccessTarget target() const {
+			AccessTarget result;
+			result.drive = command_[1] & 0x03;
+			result.head = (command_[1] >> 2) & 0x01;
+			result.mfm = command_[0] & 0x40;
+			result.skip_deleted = command_[0] & 0x20;
+			return result;
+		}
+		uint8_t drive_head() const {
+			return command_[1]&7;
+		}
+
+		//
+		// Command::FormatTrack
+		//
+
+		struct FormatSpecs {
+			uint8_t bytes_per_sector;
+			uint8_t sectors_per_track;
+			uint8_t gap3_length;
+			uint8_t filler;
+		};
+		FormatSpecs format_specs() const {
+			FormatSpecs result;
+			result.bytes_per_sector = command_[2];
+			result.sectors_per_track = command_[3];
+			result.gap3_length = command_[4];
+			result.filler = command_[5];
+			return result;
+		}
+
+		//
+		// Command::Seek
+		//
+
+		/// @returns The desired target track.
+		uint8_t seek_target() const {
+			return command_[2];
+		}
+
+		//
+		// Command::Specify
+		//
+
+		struct SpecifySpecs {
+			// The below are all in milliseconds.
+			uint8_t step_rate_time;
+			uint8_t head_unload_time;
+			uint8_t head_load_time;
+			bool use_dma;
+		};
+		SpecifySpecs specify_specs() const {
+			SpecifySpecs result;
+			result.step_rate_time = 16 - (command_[1] >> 4);				// i.e. 1 to 16ms
+			result.head_unload_time = uint8_t((command_[1] & 0x0f) << 4);	// i.e. 16 to 240ms
+			result.head_load_time = command_[2] & ~1;						// i.e. 2 to 254 ms in increments of 2ms
+			result.use_dma = !(command_[2] & 1);
+			return result;
+		}
+
+	private:
+		std::vector<uint8_t> command_;
+};
+
+}
+
+#endif /* CommandDecoder_hpp */

--- a/Components/8272/CommandDecoder.hpp
+++ b/Components/8272/CommandDecoder.hpp
@@ -15,33 +15,33 @@
 
 namespace Intel::i8272 {
 
+enum class Command {
+	ReadData = 0x06,
+	ReadDeletedData = 0x0c,
+
+	WriteData = 0x05,
+	WriteDeletedData = 0x09,
+
+	ReadTrack = 0x02,
+	ReadID = 0x0a,
+	FormatTrack = 0x0d,
+
+	ScanLow = 0x11,
+	ScanLowOrEqual = 0x19,
+	ScanHighOrEqual = 0x1d,
+
+	Recalibrate = 0x07,
+	Seek = 0x0f,
+
+	SenseInterruptStatus = 0x08,
+	Specify = 0x03,
+	SenseDriveStatus = 0x04,
+
+	Invalid = 0x00,
+};
+
 class CommandDecoder {
 	public:
-		enum class Command {
-			ReadData = 0x06,
-			ReadDeletedData = 0x0c,
-
-			WriteData = 0x05,
-			WriteDeletedData = 0x09,
-
-			ReadTrack = 0x02,
-			ReadID = 0x0a,
-			FormatTrack = 0x0d,
-
-			ScanLow = 0x11,
-			ScanLowOrEqual = 0x19,
-			ScanHighOrEqual = 0x1d,
-
-			Recalibrate = 0x07,
-			Seek = 0x0f,
-
-			SenseInterruptStatus = 0x08,
-			Specify = 0x03,
-			SenseDriveStatus = 0x04,
-
-			Invalid = 0x00,
-		};
-
 		/// Add a byte to the current command.
 		void push_back(uint8_t byte) {
 			command_.push_back(byte);

--- a/Components/8272/Results.hpp
+++ b/Components/8272/Results.hpp
@@ -1,0 +1,65 @@
+//
+//  Results.hpp
+//  Clock Signal
+//
+//  Created by Thomas Harte on 27/11/2023.
+//  Copyright © 2023 Thomas Harte. All rights reserved.
+//
+
+#ifndef Results_hpp
+#define Results_hpp
+
+#include "CommandDecoder.hpp"
+#include "Status.hpp"
+
+namespace Intel::i8272 {
+
+class Results {
+	public:
+		/// Serialises the response to Command::Invalid and Command::SenseInterruptStatus when no interrupt source was found.
+		void serialise_none() {
+			result_ = { 0x80 };
+		}
+
+		/// Serialises the response to Command::SenseInterruptStatus for a found drive.
+		void serialise(const Status &status, uint8_t cylinder) {
+			result_ = { cylinder, status[0] };
+		}
+
+		/// Serialises the seven-byte response to Command::SenseDriveStatus.
+		void serialise(uint8_t flags, uint8_t drive_side) {
+			result_ = { uint8_t(flags | drive_side) };
+		}
+
+		/// Serialises the response to:
+		///
+		///	* Command::ReadData;
+		///	* Command::ReadDeletedData;
+		///	* Command::WriteData;
+		///	* Command::WriteDeletedData;
+		///	* Command::ReadID;
+		///	* Command::ReadTrack;
+		///	* Command::FormatTrack;
+		///	* Command::ScanLow; and
+		/// * Command::ScanHighOrEqual.
+		void serialise(const Status &status, uint8_t cylinder, uint8_t head, uint8_t sector, uint8_t size) {
+			result_ = { size, sector, head, cylinder, status[2], status[1], status[0] };
+		}
+
+		/// @returns @c true if all result bytes are exhausted; @c false otherwise.
+		bool empty() const 	{	return result_.empty();	}
+
+		/// @returns The next byte of the result.
+		uint8_t next() {
+			const uint8_t next = result_.back();
+			result_.pop_back();
+			return next;
+		}
+
+	private:
+		std::vector<uint8_t> result_;
+};
+
+}
+
+#endif /* Results_hpp */

--- a/Components/8272/Status.hpp
+++ b/Components/8272/Status.hpp
@@ -114,8 +114,8 @@ class Status {
 			}
 		}
 
-		void end_sense_interrupt_status(int drive) 	{
-			status_[0] = uint8_t(drive);
+		void end_sense_interrupt_status(int drive, int head) 	{
+			status_[0] = uint8_t(drive | (head << 2));
 			main_status_ &= ~(1 << drive);
 		}
 

--- a/Components/8272/Status.hpp
+++ b/Components/8272/Status.hpp
@@ -114,11 +114,6 @@ class Status {
 			}
 		}
 
-		void end_sense_interrupt_status(int drive, int head) 	{
-			status_[0] = uint8_t(drive | (head << 2));
-			main_status_ &= ~(1 << drive);
-		}
-
 	private:
 		void set(uint8_t flag, bool value, uint8_t &target) {
 			if(value) {

--- a/Components/8272/Status.hpp
+++ b/Components/8272/Status.hpp
@@ -17,7 +17,7 @@ enum class MainStatus: uint8_t {
 	FDD2Seeking			= 0x04,
 	FDD3Seeking			= 0x08,
 
-	ReadOrWriteOngoing	= 0x10,
+	CommandInProgress	= 0x10,
 	InNonDMAExecution	= 0x20,
 	DataIsToProcessor	= 0x40,
 	DataReady			= 0x80,
@@ -107,9 +107,9 @@ class Status {
 		/// state appropriately.
 		void begin(const CommandDecoder &command) {
 			set(MainStatus::DataReady, false);
+			set(MainStatus::CommandInProgress, true);
 
 			if(command.is_access()) {
-				set(MainStatus::ReadOrWriteOngoing, true);
 				status_[0] = command.drive_head();
 			}
 		}

--- a/Components/8272/Status.hpp
+++ b/Components/8272/Status.hpp
@@ -1,0 +1,45 @@
+//
+//  Status.hpp
+//  Clock Signal
+//
+//  Created by Thomas Harte on 25/11/2023.
+//  Copyright © 2023 Thomas Harte. All rights reserved.
+//
+
+#ifndef Status_hpp
+#define Status_hpp
+
+namespace Intel::i8272 {
+
+class Status {
+	public:
+		uint8_t main() const {
+			return main_status_;
+		}
+
+		void reset() {
+			main_status_ = DataReady;
+			status_[0] = status_[1] = status_[2] = 0;
+		}
+
+	private:
+		uint8_t main_status_;
+		uint8_t status_[3];
+
+		enum MainStatus: uint8_t {
+			FDD0Seeking = 0x01,
+			FDD1Seeking = 0x02,
+			FDD2Seeking = 0x04,
+			FDD3Seeking = 0x08,
+
+			ReadOrWriteOngoing	= 0x10,
+			InNonDMAExecution	= 0x20,
+			DataIsToProcessor	= 0x40,
+			DataReady			= 0x80,
+		};
+
+};
+
+}
+
+#endif /* Status_hpp */

--- a/Components/8272/Status.hpp
+++ b/Components/8272/Status.hpp
@@ -11,37 +11,126 @@
 
 namespace Intel::i8272 {
 
+enum class MainStatus: uint8_t {
+	FDD0Seeking			= 0x01,
+	FDD1Seeking			= 0x02,
+	FDD2Seeking			= 0x04,
+	FDD3Seeking			= 0x08,
+
+	ReadOrWriteOngoing	= 0x10,
+	InNonDMAExecution	= 0x20,
+	DataIsToProcessor	= 0x40,
+	DataReady			= 0x80,
+};
+
+enum class Status0: uint8_t {
+	NormalTermination	= 0x00,
+	AbnormalTermination = 0x80,
+	InvalidCommand		= 0x40,
+	BecameNotReady		= 0xc0,
+
+	SeekEnded			= 0x20,
+	EquipmentFault		= 0x10,
+	NotReady			= 0x08,
+
+	HeadAddress			= 0x04,
+	UnitSelect			= 0x03,
+};
+
+enum class Status1: uint8_t {
+	EndOfCylinder		= 0x80,
+	DataError 			= 0x20,
+	OverRun				= 0x10,
+	NoData				= 0x04,
+	NotWriteable		= 0x02,
+	MissingAddressMark	= 0x01,
+};
+
+enum class Status2: uint8_t {
+	DeletedControlMark	= 0x40,
+	DataCRCError 		= 0x20,
+	WrongCyinder		= 0x10,
+	ScanEqualHit		= 0x08,
+	ScanNotSatisfied	= 0x04,
+	BadCylinder			= 0x02,
+	MissingDataAddressMark	= 0x01,
+};
+
+enum class Status3: uint8_t {
+	Fault				= 0x80,
+	WriteProtected 		= 0x40,
+	Ready				= 0x20,
+	Track9				= 0x10,
+	TwoSided			= 0x08,
+
+	HeadAddress			= 0x04,
+	UnitSelect			= 0x03,
+};
+
 class Status {
 	public:
 		Status() {
 			reset();
 		}
 
-		uint8_t main() const {
-			return main_status_;
-		}
-
 		void reset() {
-			main_status_ = DataReady;
+			main_status_ = 0;
+			set(MainStatus::DataReady, true);
 			status_[0] = status_[1] = status_[2] = 0;
 		}
 
+		/// @returns The main status register value.
+		uint8_t main() const {
+			return main_status_;
+		}
+		uint8_t operator [](int index) const {
+			return status_[index];
+		}
+
+		//
+		// Flag setters.
+		//
+		void set(MainStatus flag, bool value) {
+			set(uint8_t(flag), value, main_status_);
+		}
+		void start_seek(int drive) 	{	main_status_ |= 1 << drive;	}
+		void set(Status0 flag) {	set(uint8_t(flag), true, status_[0]);	}
+		void set(Status1 flag) {	set(uint8_t(flag), true, status_[1]);	}
+		void set(Status2 flag) {	set(uint8_t(flag), true, status_[2]);	}
+
+		//
+		// Flag getters.
+		//
+		bool get(MainStatus flag)	{	return main_status_ & uint8_t(flag);	}
+		bool get(Status2 flag)		{	return status_[2] & uint8_t(flag);		}
+
+		/// Begin execution of whatever @c CommandDecoder currently describes, setting internal
+		/// state appropriately.
+		void begin(const CommandDecoder &command) {
+			set(MainStatus::DataReady, false);
+
+			if(command.is_access_command()) {
+				set(MainStatus::ReadOrWriteOngoing, true);
+				status_[0] = command.drive_head();
+			}
+		}
+
+		void end_sense_interrupt_status(int drive) 	{
+			status_[0] = uint8_t(drive);
+			main_status_ &= ~(1 << drive);
+		}
+
 	private:
+		void set(uint8_t flag, bool value, uint8_t &target) {
+			if(value) {
+				target |= flag;
+			} else {
+				target &= ~flag;
+			}
+		}
+
 		uint8_t main_status_;
 		uint8_t status_[3];
-
-		enum MainStatus: uint8_t {
-			FDD0Seeking = 0x01,
-			FDD1Seeking = 0x02,
-			FDD2Seeking = 0x04,
-			FDD3Seeking = 0x08,
-
-			ReadOrWriteOngoing	= 0x10,
-			InNonDMAExecution	= 0x20,
-			DataIsToProcessor	= 0x40,
-			DataReady			= 0x80,
-		};
-
 };
 
 }

--- a/Components/8272/Status.hpp
+++ b/Components/8272/Status.hpp
@@ -97,6 +97,8 @@ class Status {
 		void set(Status1 flag) {	set(uint8_t(flag), true, status_[1]);	}
 		void set(Status2 flag) {	set(uint8_t(flag), true, status_[2]);	}
 
+		void set_status0(uint8_t value)	{	status_[0] = value;	}
+
 		//
 		// Flag getters.
 		//

--- a/Components/8272/Status.hpp
+++ b/Components/8272/Status.hpp
@@ -109,7 +109,7 @@ class Status {
 		void begin(const CommandDecoder &command) {
 			set(MainStatus::DataReady, false);
 
-			if(command.is_access_command()) {
+			if(command.is_access()) {
 				set(MainStatus::ReadOrWriteOngoing, true);
 				status_[0] = command.drive_head();
 			}

--- a/Components/8272/Status.hpp
+++ b/Components/8272/Status.hpp
@@ -60,9 +60,8 @@ enum class Status3: uint8_t {
 	Fault				= 0x80,
 	WriteProtected 		= 0x40,
 	Ready				= 0x20,
-	Track9				= 0x10,
+	Track0				= 0x10,
 	TwoSided			= 0x08,
-
 	HeadAddress			= 0x04,
 	UnitSelect			= 0x03,
 };

--- a/Components/8272/Status.hpp
+++ b/Components/8272/Status.hpp
@@ -13,6 +13,10 @@ namespace Intel::i8272 {
 
 class Status {
 	public:
+		Status() {
+			reset();
+		}
+
 		uint8_t main() const {
 			return main_status_;
 		}

--- a/Components/8272/i8272.cpp
+++ b/Components/8272/i8272.cpp
@@ -268,7 +268,6 @@ void i8272::posit_event(int event_type) {
 			}
 
 			// Jump to the proper place.
-			using Command = CommandDecoder::Command;
 			switch(command_.command()) {
 				case Command::ReadData:
 				case Command::ReadDeletedData:

--- a/Components/8272/i8272.cpp
+++ b/Components/8272/i8272.cpp
@@ -243,7 +243,7 @@ void i8272::posit_event(int event_type) {
 			}
 
 			// If this is not clearly a command that's safe to carry out in parallel to a seek, end all seeks.
-			is_access_command_ = command_.is_access_command();
+			is_access_command_ = command_.is_access();
 
 			if(is_access_command_) {
 				status_.set(MainStatus::ReadOrWriteOngoing, true);

--- a/Components/8272/i8272.cpp
+++ b/Components/8272/i8272.cpp
@@ -708,7 +708,7 @@ void i8272::posit_event(int event_type) {
 				// If a drive was found, return its results. Otherwise return a single 0x80.
 				if(found_drive != -1) {
 					drives_[found_drive].phase = Drive::NotSeeking;
-					status_.end_sense_interrupt_status(found_drive, 0);
+//					status_.end_sense_interrupt_status(found_drive, 0);
 					status_.set(Status0::SeekEnded);
 
 					result_stack_ = { drives_[found_drive].head_position, status_[0]};

--- a/Components/8272/i8272.cpp
+++ b/Components/8272/i8272.cpp
@@ -218,7 +218,7 @@ void i8272::posit_event(int event_type) {
 	wait_for_command:
 			expects_input_ = false;
 			set_data_mode(Storage::Disk::MFMController::DataMode::Scanning);
-			status_.set(MainStatus::ReadOrWriteOngoing, false);
+			status_.set(MainStatus::CommandInProgress, false);
 			status_.set(MainStatus::InNonDMAExecution, false);
 			command_.clear();
 
@@ -246,7 +246,6 @@ void i8272::posit_event(int event_type) {
 			is_access_command_ = command_.is_access();
 
 			if(is_access_command_) {
-				status_.set(MainStatus::ReadOrWriteOngoing, true);
 				for(int c = 0; c < 4; c++) {
 					if(drives_[c].phase == Drive::Seeking) {
 						drives_[c].phase = Drive::NotSeeking;

--- a/Components/8272/i8272.cpp
+++ b/Components/8272/i8272.cpp
@@ -737,7 +737,7 @@ void i8272::posit_event(int event_type) {
 			{
 				int drive = command_.target().drive;
 				select_drive(drive);
-				result_stack_= {
+				result_stack_ = {
 					uint8_t(
 						(command_.drive_head()) |	// drive and head number
 						0x08 |						// single sided

--- a/Components/8272/i8272.cpp
+++ b/Components/8272/i8272.cpp
@@ -709,7 +709,7 @@ void i8272::posit_event(int event_type) {
 				// If a drive was found, return its results. Otherwise return a single 0x80.
 				if(found_drive != -1) {
 					drives_[found_drive].phase = Drive::NotSeeking;
-					status_.end_sense_interrupt_status(found_drive);
+					status_.end_sense_interrupt_status(found_drive, 0);
 					status_.set(Status0::SeekEnded);
 
 					result_stack_ = { drives_[found_drive].head_position, status_[0]};

--- a/Components/8272/i8272.cpp
+++ b/Components/8272/i8272.cpp
@@ -276,7 +276,7 @@ void i8272::posit_event(int event_type) {
 			if(!command_.has_command()) {
 				goto wait_for_complete_command_sequence;
 			}
-			if(command_.has_geometry() == 9) {
+			if(command_.has_geometry()) {
 				cylinder_ = command_.geometry().cylinder;
 				head_ = command_.geometry().head;
 				sector_ = command_.geometry().sector;

--- a/Components/8272/i8272.cpp
+++ b/Components/8272/i8272.cpp
@@ -708,8 +708,9 @@ void i8272::posit_event(int event_type) {
 				// If a drive was found, return its results. Otherwise return a single 0x80.
 				if(found_drive != -1) {
 					drives_[found_drive].phase = Drive::NotSeeking;
+					status_.set_status0(uint8_t(found_drive | uint8_t(Status0::SeekEnded)));
 //					status_.end_sense_interrupt_status(found_drive, 0);
-					status_.set(Status0::SeekEnded);
+//					status_.set(Status0::SeekEnded);
 
 					result_stack_ = { drives_[found_drive].head_position, status_[0]};
 				} else {

--- a/Components/8272/i8272.hpp
+++ b/Components/8272/i8272.hpp
@@ -9,6 +9,8 @@
 #ifndef i8272_hpp
 #define i8272_hpp
 
+#include "CommandDecoder.hpp"
+
 #include "../../Storage/Disk/Controller/MFMDiskController.hpp"
 
 #include <cstdint>
@@ -54,7 +56,7 @@ class i8272 : public Storage::Disk::MFMController {
 		uint8_t status_[3] = {0, 0, 0};
 
 		// A buffer for accumulating the incoming command, and one for accumulating the result.
-		std::vector<uint8_t> command_;
+		CommandDecoder command_;
 		std::vector<uint8_t> result_stack_;
 		uint8_t input_ = 0;
 		bool has_input_ = false;

--- a/Components/8272/i8272.hpp
+++ b/Components/8272/i8272.hpp
@@ -10,6 +10,7 @@
 #define i8272_hpp
 
 #include "CommandDecoder.hpp"
+#include "Status.hpp"
 
 #include "../../Storage/Disk/Controller/MFMDiskController.hpp"
 
@@ -52,11 +53,12 @@ class i8272 : public Storage::Disk::MFMController {
 		std::unique_ptr<BusHandler> allocated_bus_handler_;
 
 		// Status registers.
-		uint8_t main_status_ = 0;
-		uint8_t status_[3] = {0, 0, 0};
+		Status status_;
 
-		// A buffer for accumulating the incoming command, and one for accumulating the result.
+		// The incoming command.
 		CommandDecoder command_;
+
+		// A buffer to accumulate the result.
 		std::vector<uint8_t> result_stack_;
 		uint8_t input_ = 0;
 		bool has_input_ = false;

--- a/Machines/PCCompatible/KeyboardMapper.hpp
+++ b/Machines/PCCompatible/KeyboardMapper.hpp
@@ -1,0 +1,104 @@
+//
+//  KeyboardMapper.hpp
+//  Clock Signal
+//
+//  Created by Thomas Harte on 24/11/2023.
+//  Copyright © 2023 Thomas Harte. All rights reserved.
+//
+
+#ifndef KeyboardMapper_hpp
+#define KeyboardMapper_hpp
+
+#include "../KeyboardMachine.hpp"
+
+namespace PCCompatible {
+
+class KeyboardMapper: public MachineTypes::MappedKeyboardMachine::KeyboardMapper {
+	public:
+		uint16_t mapped_key_for_key(Inputs::Keyboard::Key key) const override {
+			using k = Inputs::Keyboard::Key;
+			switch(key) {
+				case k::Escape:		return 1;
+
+				case k::k1:			return 2;
+				case k::k2:			return 3;
+				case k::k3:			return 4;
+				case k::k4:			return 5;
+				case k::k5:			return 6;
+				case k::k6:			return 7;
+				case k::k7:			return 8;
+				case k::k8:			return 9;
+				case k::k9:			return 10;
+				case k::k0:			return 11;
+
+				case k::Hyphen:		return 12;
+				case k::Equals:		return 13;
+				case k::Backspace:	return 14;
+
+				case k::Tab:		return 15;
+				case k::Q:			return 16;
+				case k::W:			return 17;
+				case k::E:			return 18;
+				case k::R:			return 19;
+				case k::T:			return 20;
+				case k::Y:			return 21;
+				case k::U:			return 22;
+				case k::I:			return 23;
+				case k::O:			return 24;
+				case k::P:			return 25;
+
+				case k::OpenSquareBracket:	return 26;
+				case k::CloseSquareBracket:	return 27;
+				case k::Enter:				return 28;
+
+				case k::LeftControl:
+				case k::RightControl:		return 29;
+
+				case k::A:			return 30;
+				case k::S:			return 31;
+				case k::D:			return 32;
+				case k::F:			return 33;
+				case k::G:			return 34;
+				case k::H:			return 35;
+				case k::J:			return 36;
+				case k::K:			return 37;
+				case k::L:			return 38;
+
+				case k::Semicolon:	return 39;
+				case k::Quote:		return 40;
+				case k::BackTick:	return 41;
+
+				case k::LeftShift:	return 42;
+				case k::Backslash:	return 43;
+
+				case k::Z:			return 55;
+				case k::X:			return 45;
+				case k::C:			return 46;
+				case k::V:			return 47;
+				case k::B:			return 48;
+				case k::N:			return 49;
+				case k::M:			return 50;
+
+				case k::Comma:			return 51;
+				case k::FullStop:		return 52;
+				case k::ForwardSlash:	return 53;
+				case k::RightShift:		return 54;
+
+				case k::LeftOption:
+				case k::RightOption:	return 56;
+				case k::Space:			return 57;
+				case k::CapsLock:		return 58;
+
+				case k::NumLock:		return 69;
+				case k::ScrollLock:		return 70;
+
+				default:	return MachineTypes::MappedKeyboardMachine::KeyNotMapped;
+			}
+
+			// TODO: extended functions, including all F keys and cursors.
+		}
+};
+
+}
+
+#endif /* KeyboardMapper_hpp */

--- a/Machines/PCCompatible/PCCompatible.cpp
+++ b/Machines/PCCompatible/PCCompatible.cpp
@@ -172,7 +172,7 @@ class FloppyController {
 			decoder_.clear();
 			status_.reset();
 
-			// Necessary to pass GlaBIOS [if this is called after reset?], but Why?
+			// Necessary to pass GlaBIOS' POST test, but: why?
 			//
 			// Cf. INT_13_0_2 and the CMP	AL, 11000000B following a CALL	FDC_WAIT_SENSE.
 			for(int c = 0; c < 4; c++) {

--- a/Machines/PCCompatible/PCCompatible.cpp
+++ b/Machines/PCCompatible/PCCompatible.cpp
@@ -83,6 +83,7 @@ class FloppyController {
 
 					case Command::SenseInterruptStatus:
 						pic_.apply_edge<6>(false);
+//						results_.serialise(status_, 0);
 						results_.serialise_none();
 					break;
 				}

--- a/Machines/PCCompatible/PCCompatible.cpp
+++ b/Machines/PCCompatible/PCCompatible.cpp
@@ -119,7 +119,7 @@ class FloppyController {
 						printf("FDC: Recalibrate\n");
 						drives_[decoder_.target().drive].track = 0;
 						drives_[decoder_.target().drive].raised_interrupt = true;
-						drives_[decoder_.target().drive].status = decoder_.target().drive;
+						drives_[decoder_.target().drive].status = decoder_.target().drive | uint8_t(Intel::i8272::Status0::SeekEnded);
 						pic_.apply_edge<6>(true);
 					break;
 
@@ -129,7 +129,7 @@ class FloppyController {
 						drives_[decoder_.target().drive].side = decoder_.target().head;
 
 						drives_[decoder_.target().drive].raised_interrupt = true;
-						drives_[decoder_.target().drive].status = decoder_.drive_head();
+						drives_[decoder_.target().drive].status = decoder_.drive_head() | uint8_t(Intel::i8272::Status0::SeekEnded);
 						pic_.apply_edge<6>(true);
 					break;
 				}

--- a/Machines/PCCompatible/PCCompatible.cpp
+++ b/Machines/PCCompatible/PCCompatible.cpp
@@ -82,6 +82,11 @@ class FloppyController {
 			}
 		}
 
+		uint8_t read() {
+			// TODO: is anything being serialised?
+			return 0x80;
+		}
+
 	private:
 		void reset() {
 			decoder_.clear();
@@ -823,9 +828,8 @@ class IO {
 					}
 				break;
 
-				case 0x03b8:	/* case 0x03b9:	case 0x03ba:	case 0x03bb:
-				case 0x03bc:	case 0x03bd:	case 0x03be:	case 0x03bf: */
-					mda_.write<8>(value);
+				case 0x03b8:
+					mda_.write<8>(uint8_t(value));
 				break;
 
 				case 0x03d0:	case 0x03d1:	case 0x03d2:	case 0x03d3:
@@ -838,15 +842,11 @@ class IO {
 				case 0x03f2:
 					fdc_.set_digital_output(uint8_t(value));
 				break;
+				case 0x03f4:
+					printf("TODO: FDC write of %02x at %04x\n", value, port);
+				break;
 				case 0x03f5:
 					fdc_.write(uint8_t(value));
-				break;
-
-				case 0x03f3:
-				case 0x03f4:
-				case 0x03f6:
-				case 0x03f7:
-					printf("TODO: FDC write of %02x at %04x\n", value, port);
 				break;
 
 				case 0x0278:	case 0x0279:	case 0x027a:
@@ -910,16 +910,16 @@ class IO {
 				break;
 
 				case 0x03f4:	return fdc_.status();
+				case 0x03f5:	return fdc_.read();
 
-				case 0x03f0:
-				case 0x03f1:
-				case 0x03f2:
-				case 0x03f3:
-				case 0x03f5:
-				case 0x03f6:
-				case 0x03f7:
-					printf("TODO: FDC read from %04x\n", port);
-				break;
+//				3F0-3F7 Floppy disk controller (except PCjr)
+//				3F0 Diskette controller status A
+//				3F1 Diskette controller status B
+//				3F2 controller control port
+//				3F4 controller status register
+//				3F5 data register (write 1-9 byte command, see INT 13)
+//				3F6 Diskette controller data
+//				3F7 Diskette digital input
 
 				case 0x02e8:	case 0x02e9:	case 0x02ea:	case 0x02eb:
 				case 0x02ec:	case 0x02ed:	case 0x02ee:	case 0x02ef:

--- a/Machines/PCCompatible/PCCompatible.cpp
+++ b/Machines/PCCompatible/PCCompatible.cpp
@@ -66,6 +66,10 @@ class FloppyController {
 			return status_.main();
 		}
 
+		void write(uint8_t value) {
+			decoder_.push_back(value);
+		}
+
 	private:
 		void reset() {
 			decoder_.clear();
@@ -822,10 +826,12 @@ class IO {
 				case 0x03f2:
 					fdc_.set_digital_output(uint8_t(value));
 				break;
+				case 0x03f5:
+					fdc_.write(uint8_t(value));
+				break;
 
 				case 0x03f3:
 				case 0x03f4:
-				case 0x03f5:
 				case 0x03f6:
 				case 0x03f7:
 					printf("TODO: FDC write of %02x at %04x\n", value, port);

--- a/Machines/PCCompatible/PCCompatible.cpp
+++ b/Machines/PCCompatible/PCCompatible.cpp
@@ -68,6 +68,18 @@ class FloppyController {
 
 		void write(uint8_t value) {
 			decoder_.push_back(value);
+
+			if(decoder_.has_command()) {
+				using Command = Intel::i8272::CommandDecoder::Command;
+				switch(decoder_.command()) {
+					default:
+						printf("TODO: implement FDC command %d\n", uint8_t(decoder_.command()));
+					break;
+
+//					case Command::Invalid:
+//					break;
+				}
+			}
 		}
 
 	private:

--- a/Machines/PCCompatible/PCCompatible.cpp
+++ b/Machines/PCCompatible/PCCompatible.cpp
@@ -45,7 +45,13 @@ namespace PCCompatible {
 
 class FloppyController {
 	public:
-		FloppyController(PIC &pic, DMA &dma) : pic_(pic), dma_(dma) {}
+		FloppyController(PIC &pic, DMA &dma) : pic_(pic), dma_(dma) {
+			// Default: one floppy drive only.
+			drives_[0].exists = true;
+			drives_[1].exists = false;
+			drives_[2].exists = false;
+			drives_[3].exists = false;
+		}
 
 		void set_digital_output(uint8_t control) {
 //			printf("FDC DOR: %02x\n", control);
@@ -227,7 +233,9 @@ class FloppyController {
 		} drives_[4];
 
 		std::string drive_name(int c) const {
-			return std::string("Drive ") + std::to_string(c + 1);
+			char name[3] = "A";
+			name[0] += c;
+			return std::string("Drive ") + name;
 		}
 
 		Activity::Observer *observer_ = nullptr;

--- a/Machines/PCCompatible/PCCompatible.cpp
+++ b/Machines/PCCompatible/PCCompatible.cpp
@@ -53,7 +53,12 @@ class FloppyController {
 			// b7, b6, b5, b4: enable motor for drive 4, 3, 2, 1;
 			// b3: 1 => enable DMA; 0 => disable;
 			// b2: 1 => enable FDC; 0 => hold at reset;
-			// b1, b0: drive select.
+			// b1, b0: drive select (usurps FDC?)
+
+			drives_[0].motor = control & 0x10;
+			drives_[1].motor = control & 0x20;
+			drives_[2].motor = control & 0x40;
+			drives_[3].motor = control & 0x80;
 
 			enable_dma_ = control & 0x08;
 
@@ -202,6 +207,7 @@ class FloppyController {
 			uint8_t status = 0;
 			uint8_t track = 0;
 			bool side = false;
+			bool motor = false;
 		} drives_[4];
 };
 

--- a/Machines/PCCompatible/PCCompatible.cpp
+++ b/Machines/PCCompatible/PCCompatible.cpp
@@ -45,6 +45,8 @@ class FloppyController {
 		FloppyController(PIC &pic, DMA &dma) : pic_(pic), dma_(dma) {}
 
 		void set_digital_output(uint8_t control) {
+			printf("FDC DOR: %02x\n", control);
+
 			// b7, b6, b5, b4: enable motor for drive 4, 3, 2, 1;
 			// b3: 1 => enable DMA; 0 => disable;
 			// b2: 1 => enable FDC; 0 => hold at reset;
@@ -64,6 +66,7 @@ class FloppyController {
 		}
 
 		uint8_t status() const {
+			printf("FDC: read status %02x\n", status_.main());
 			return status_.main();
 		}
 
@@ -78,10 +81,12 @@ class FloppyController {
 					break;
 
 					case Command::Invalid:
+						printf("FDC: Invalid\n");
 						results_.serialise_none();
 					break;
 
 					case Command::SenseInterruptStatus:
+						printf("FDC: SenseInterruptStatus\n");
 						pic_.apply_edge<6>(false);
 
 						if(interrupting_drives_) {
@@ -121,14 +126,17 @@ class FloppyController {
 				if(results_.empty()) {
 					status_.set(MainStatus::DataIsToProcessor, false);
 				}
+				printf("FDC read: %02x\n", result);
 				return result;
 			}
 
+			printf("FDC read?\n");
 			return 0x80;
 		}
 
 	private:
 		void reset() {
+			printf("FDC reset\n");
 			decoder_.clear();
 			status_.reset();
 			pic_.apply_edge<6>(true);

--- a/Machines/PCCompatible/PCCompatible.cpp
+++ b/Machines/PCCompatible/PCCompatible.cpp
@@ -63,7 +63,7 @@ class FloppyController {
 	private:
 		void reset() {
 			decoder_.clear();
-//			pic_.apply_edge<6>(true);
+			pic_.apply_edge<6>(true);
 		}
 
 		PIC &pic_;

--- a/Machines/PCCompatible/PCCompatible.cpp
+++ b/Machines/PCCompatible/PCCompatible.cpp
@@ -21,6 +21,7 @@
 #include "../../Components/6845/CRTC6845.hpp"
 #include "../../Components/8255/i8255.hpp"
 #include "../../Components/8272/CommandDecoder.hpp"
+#include "../../Components/8272/Status.hpp"
 #include "../../Components/AudioToggle/AudioToggle.hpp"
 
 #include "../../Numeric/RegisterSizes.hpp"
@@ -52,6 +53,7 @@ class FloppyController {
 
 			const bool hold_reset = !(control & 0x04);
 			if(!hold_reset && hold_reset_) {
+				// TODO: add a delay mechanism.
 				reset();
 			}
 			hold_reset_ = hold_reset;
@@ -60,9 +62,14 @@ class FloppyController {
 			}
 		}
 
+		uint8_t status() const {
+			return status_.main();
+		}
+
 	private:
 		void reset() {
 			decoder_.clear();
+			status_.reset();
 			pic_.apply_edge<6>(true);
 		}
 
@@ -71,7 +78,9 @@ class FloppyController {
 
 		bool hold_reset_ = false;
 		bool enable_dma_ = false;
+
 		Intel::i8272::CommandDecoder decoder_;
+		Intel::i8272::Status status_;
 };
 
 class KeyboardController {
@@ -815,7 +824,10 @@ class IO {
 				break;
 
 				case 0x03f3:
-				case 0x03f4:	case 0x03f5:	case 0x03f6:	case 0x03f7:
+				case 0x03f4:
+				case 0x03f5:
+				case 0x03f6:
+				case 0x03f7:
 					printf("TODO: FDC write of %02x at %04x\n", value, port);
 				break;
 
@@ -879,8 +891,15 @@ class IO {
 					// Ignore parallel port accesses.
 				break;
 
-				case 0x03f0:	case 0x03f1:	case 0x03f2:	case 0x03f3:
-				case 0x03f4:	case 0x03f5:	case 0x03f6:	case 0x03f7:
+				case 0x03f4:	return fdc_.status();
+
+				case 0x03f0:
+				case 0x03f1:
+				case 0x03f2:
+				case 0x03f3:
+				case 0x03f5:
+				case 0x03f6:
+				case 0x03f7:
 					printf("TODO: FDC read from %04x\n", port);
 				break;
 

--- a/Machines/PCCompatible/PCCompatible.cpp
+++ b/Machines/PCCompatible/PCCompatible.cpp
@@ -40,6 +40,9 @@
 
 namespace PCCompatible {
 
+//bool log = false;
+//std::string previous;
+
 class FloppyController {
 	public:
 		FloppyController(PIC &pic, DMA &dma) : pic_(pic), dma_(dma) {}
@@ -58,6 +61,7 @@ class FloppyController {
 			if(!hold_reset && hold_reset_) {
 				// TODO: add a delay mechanism.
 				reset();
+//				log = true;
 			}
 			hold_reset_ = hold_reset;
 			if(hold_reset_) {
@@ -115,6 +119,7 @@ class FloppyController {
 					using MainStatus = Intel::i8272::MainStatus;
 					status_.set(MainStatus::DataIsToProcessor, true);
 					status_.set(MainStatus::DataReady, true);
+					status_.set(MainStatus::CommandInProgress, true);
 				}
 			}
 		}
@@ -125,6 +130,7 @@ class FloppyController {
 				const uint8_t result = results_.next();
 				if(results_.empty()) {
 					status_.set(MainStatus::DataIsToProcessor, false);
+					status_.set(MainStatus::CommandInProgress, false);
 				}
 				printf("FDC read: %02x\n", result);
 				return result;
@@ -1084,8 +1090,6 @@ class ConcreteMachine:
 		}
 
 		// MARK: - TimedMachine.
-//		bool log = false;
-//		std::string previous;
 		void run_for(const Cycles duration) override {
 			const auto pit_ticks = duration.as_integral();
 			cpu_divisor_ += pit_ticks;

--- a/Machines/PCCompatible/PCCompatible.cpp
+++ b/Machines/PCCompatible/PCCompatible.cpp
@@ -55,13 +55,14 @@ class FloppyController {
 				reset();
 			}
 			hold_reset_ = hold_reset;
+			if(hold_reset_) {
+				pic_.apply_edge<6>(false);
+			}
 		}
 
 	private:
 		void reset() {
 			decoder_.clear();
-
-			// TODO: And?
 //			pic_.apply_edge<6>(true);
 		}
 

--- a/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
@@ -1127,6 +1127,7 @@
 
 /* Begin PBXFileReference section */
 		4238200B2B1295AD00964EFE /* Status.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Status.hpp; sourceTree = "<group>"; };
+		4238200C2B15998800964EFE /* Results.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Results.hpp; sourceTree = "<group>"; };
 		423BDC492AB24699008E37B6 /* 8088Tests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = 8088Tests.mm; sourceTree = "<group>"; };
 		42437B342ACF02A9006DFED1 /* Flags.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Flags.hpp; sourceTree = "<group>"; };
 		42437B352ACF0AA2006DFED1 /* Perform.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Perform.hpp; sourceTree = "<group>"; };
@@ -4556,6 +4557,7 @@
 				4267A9CB2B113958008A59BB /* CommandDecoder.hpp */,
 				4BBC951D1F368D83008F4C34 /* i8272.hpp */,
 				4238200B2B1295AD00964EFE /* Status.hpp */,
+				4238200C2B15998800964EFE /* Results.hpp */,
 			);
 			path = 8272;
 			sourceTree = "<group>";

--- a/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
@@ -1146,6 +1146,7 @@
 		4267A9C82B0D4EC2008A59BB /* PIC.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = PIC.hpp; sourceTree = "<group>"; };
 		4267A9C92B0D4F17008A59BB /* DMA.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = DMA.hpp; sourceTree = "<group>"; };
 		4267A9CA2B111ED2008A59BB /* KeyboardMapper.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = KeyboardMapper.hpp; sourceTree = "<group>"; };
+		4267A9CB2B113958008A59BB /* CommandDecoder.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = CommandDecoder.hpp; sourceTree = "<group>"; };
 		4281572E2AA0334300E16AA1 /* Carry.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Carry.hpp; sourceTree = "<group>"; };
 		428168372A16C25C008ECD27 /* LineLayout.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = LineLayout.hpp; sourceTree = "<group>"; };
 		428168392A37AFB4008ECD27 /* DispatcherTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = DispatcherTests.mm; sourceTree = "<group>"; };
@@ -4552,6 +4553,7 @@
 			children = (
 				4BBC951C1F368D83008F4C34 /* i8272.cpp */,
 				4BBC951D1F368D83008F4C34 /* i8272.hpp */,
+				4267A9CB2B113958008A59BB /* CommandDecoder.hpp */,
 			);
 			path = 8272;
 			sourceTree = "<group>";

--- a/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
@@ -1126,6 +1126,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		4238200B2B1295AD00964EFE /* Status.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Status.hpp; sourceTree = "<group>"; };
 		423BDC492AB24699008E37B6 /* 8088Tests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = 8088Tests.mm; sourceTree = "<group>"; };
 		42437B342ACF02A9006DFED1 /* Flags.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Flags.hpp; sourceTree = "<group>"; };
 		42437B352ACF0AA2006DFED1 /* Perform.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Perform.hpp; sourceTree = "<group>"; };
@@ -4552,8 +4553,9 @@
 			isa = PBXGroup;
 			children = (
 				4BBC951C1F368D83008F4C34 /* i8272.cpp */,
-				4BBC951D1F368D83008F4C34 /* i8272.hpp */,
 				4267A9CB2B113958008A59BB /* CommandDecoder.hpp */,
+				4BBC951D1F368D83008F4C34 /* i8272.hpp */,
+				4238200B2B1295AD00964EFE /* Status.hpp */,
 			);
 			path = 8272;
 			sourceTree = "<group>";

--- a/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
@@ -1145,6 +1145,7 @@
 		4267A9C72B0C26FA008A59BB /* PIT.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = PIT.hpp; sourceTree = "<group>"; };
 		4267A9C82B0D4EC2008A59BB /* PIC.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = PIC.hpp; sourceTree = "<group>"; };
 		4267A9C92B0D4F17008A59BB /* DMA.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = DMA.hpp; sourceTree = "<group>"; };
+		4267A9CA2B111ED2008A59BB /* KeyboardMapper.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = KeyboardMapper.hpp; sourceTree = "<group>"; };
 		4281572E2AA0334300E16AA1 /* Carry.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Carry.hpp; sourceTree = "<group>"; };
 		428168372A16C25C008ECD27 /* LineLayout.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = LineLayout.hpp; sourceTree = "<group>"; };
 		428168392A37AFB4008ECD27 /* DispatcherTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = DispatcherTests.mm; sourceTree = "<group>"; };
@@ -2368,6 +2369,7 @@
 				4267A9C72B0C26FA008A59BB /* PIT.hpp */,
 				4267A9C82B0D4EC2008A59BB /* PIC.hpp */,
 				4267A9C92B0D4F17008A59BB /* DMA.hpp */,
+				4267A9CA2B111ED2008A59BB /* KeyboardMapper.hpp */,
 			);
 			path = PCCompatible;
 			sourceTree = "<group>";

--- a/OSBindings/Mac/Clock Signal.xcodeproj/xcshareddata/xcschemes/Clock Signal.xcscheme
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/xcshareddata/xcschemes/Clock Signal.xcscheme
@@ -62,7 +62,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       enableASanStackUseAfterReturn = "YES"


### PR DESCRIPTION
This:
* factors out command and status logic from the existing low-level implementation; and
* implements high-level versions of the decode, execute and result phases along with the few instructions necessary to get past POST and into attempting to read the boot sector.

Additionally bundled:
* some expansion of the keyboard controller, to allow a little further machine interaction; and
* disk activity indicators.

The next step involves being able to accept and recognise disk images and direct them to the proper machine, which feels disjoint enough to be a separate work item.