### PR TITLE
Handle C, E, F operations in Disk II state machine

### DIFF
--- a/Components/DiskII/DiskII.cpp
+++ b/Components/DiskII/DiskII.cpp
@@ -91,12 +91,15 @@ void DiskII::run_for(const Cycles cycles) {
 		state_ = state_machine_[size_t(address)];
 		switch(state_ & 0xf) {
 			default:	shift_register_ = 0;										break;	// clear
-			case 0x8:																break;	// nop
+
+			case 0x8:
+			case 0xc:																break;	// nop
 
 			case 0x9:	shift_register_ = uint8_t(shift_register_ << 1);			break;	// shift left, bringing in a zero
 			case 0xd:	shift_register_ = uint8_t((shift_register_ << 1) | 1);		break;	// shift left, bringing in a one
 
-			case 0xa:	// shift right, bringing in write protected status
+			case 0xa:
+			case 0xe:	// shift right, bringing in write protected status
 				shift_register_ = (shift_register_ >> 1) | (is_write_protected() ? 0x80 : 0x00);
 
 				// If the controller is in the sense write protect loop but the register will never change,
@@ -108,7 +111,9 @@ void DiskII::run_for(const Cycles cycles) {
 					return;
 				}
 			break;
-			case 0xb:	shift_register_ = data_input_;								break;	// load data register from data bus
+
+			case 0xb:
+			case 0xf:	shift_register_ = data_input_;								break;	// load data register from data bus
 		}
 
 		// Currently writing?


### PR DESCRIPTION
This shouldn't matter since these operations are not requested by the state machine but this is what those operations should do according to Understanding the Apple II, Table 9.3, page 9-15.