### PR TITLE
Avoid illegal reads in Enterprise Nick

### DIFF
--- a/Machines/Enterprise/Nick.cpp
+++ b/Machines/Enterprise/Nick.cpp
@@ -196,6 +196,7 @@ void Nick::run_for(Cycles duration) {
 						reload_line_parameter_pointer_ = ram_[line_parameter_pointer_ + 1] & 0x01;
 					break;
 
+					// TODO: is this interpreted live, or locked in here? Consider mid-line changes.
 					// Second slot: margins and ALT/IND bits.
 					case 1:
 						// Determine the margins.

--- a/Machines/Enterprise/Nick.cpp
+++ b/Machines/Enterprise/Nick.cpp
@@ -196,7 +196,6 @@ void Nick::run_for(Cycles duration) {
 						reload_line_parameter_pointer_ = ram_[line_parameter_pointer_ + 1] & 0x01;
 					break;
 
-					// TODO: is this interpreted live, or locked in here? Consider mid-line changes.
 					// Second slot: margins and ALT/IND bits.
 					case 1:
 						// Determine the margins.

--- a/Machines/Enterprise/Nick.hpp
+++ b/Machines/Enterprise/Nick.hpp
@@ -75,7 +75,7 @@ class Nick {
 		uint8_t lines_remaining_ = 0x00;
 		uint8_t two_colour_mask_ = 0xff;
 		int left_margin_ = 0, right_margin_ = 0;
-		const uint16_t *alt_ind_palettes[4];
+		const uint16_t *alt_ind_palettes[4] = {palette_, palette_, palette_, palette_};
 		enum class Mode {
 			Vsync,
 			Pixel,


### PR DESCRIPTION
This could be triggered when rendering the very first line of output if happening to start mid-line.