### PR TITLE
Convert address bit check to bool

### DIFF
--- a/Machines/PCCompatible/PCCompatible.cpp
+++ b/Machines/PCCompatible/PCCompatible.cpp
@@ -477,7 +477,7 @@ class MDA {
 
 		template <int address>
 		void write(uint8_t value) {
-			if constexpr (address & 0x8) {
+			if constexpr (!!(address & 0x8)) {
 				outputter_.set_control(value);
 			} else {
 				if constexpr (address & 0x1) {
@@ -490,7 +490,7 @@ class MDA {
 
 		template <int address>
 		uint8_t read() {
-			if constexpr (address & 0x8) {
+			if constexpr (!!(address & 0x8)) {
 				return outputter_.control();
 			} else {
 				return crtc_.get_register();


### PR DESCRIPTION
Fixes this error with Clang from Xcode 13.2.1:

```
Machines/PCCompatible/PCCompatible.cpp:473:18: Constexpr if condition evaluates to 8, which cannot be narrowed to type 'bool'
```

The issue is described [here](https://stackoverflow.com/questions/54899466/constexpr-if-with-a-non-bool-condition). I've seen you use this `!!` idiom elsewhere in the code and didn't know why; this must be why.

For reasons I don't understand, only the first change was needed to get it to compile. I made the second change for consistency.