### PR TITLE
Fix Disk II sense-write-protect clocking preference

### DIFF
--- a/Components/DiskII/DiskII.cpp
+++ b/Components/DiskII/DiskII.cpp
@@ -164,7 +164,7 @@ void DiskII::decide_clocking_preference() {
 	// If in sense-write-protect mode, clocking is just-in-time if the shift register hasn't yet filled with the value that
 	// corresponds to the current write protect status. Otherwise it is none.
 	if((inputs_ & ~input_flux) == input_command) {
-		clocking_preference_ = (shift_register_ == (is_write_protected() ? 0xff : 0x00)) ? ClockingHint::Preference::None : ClockingHint::Preference::JustInTime;
+		clocking_preference_ = ((shift_register_ == (is_write_protected() ? 0xff : 0x00)) && ((state_ & 0xf) == 0xa || (state_ & 0xf) == 0xe)) ? ClockingHint::Preference::None : ClockingHint::Preference::JustInTime;
 	}
 
 	// Announce a change if there was one.

--- a/Components/DiskII/DiskII.cpp
+++ b/Components/DiskII/DiskII.cpp
@@ -149,7 +149,7 @@ void DiskII::decide_clocking_preference() {
 	//	none, given that drives are not running, the shift register has already emptied or stopped and there's no flux about to be received.
 	if(!(inputs_ & ~input_flux)) {
 		const bool is_stuck_at_nop =
-			!flux_duration_ && state_machine_[(state_ & 0xf0) | inputs_ | ((shift_register_&0x80) >> 6)] == state_ && (state_ &0xf) == 0x8;
+			!flux_duration_ && state_machine_[(state_ & 0xf0) | inputs_ | ((shift_register_ & 0x80) >> 6)] == state_ && ((state_ & 0xf) == 0x8 || (state_ & 0xf) == 0xc);
 
 		clocking_preference_ =
 			(drive_is_sleeping_[0] && drive_is_sleeping_[1] && (!shift_register_ || is_stuck_at_nop) && (inputs_&input_flux))


### PR DESCRIPTION
Ensure we're actually in the sense-write-protect loop before deciding that we don't need to process anymore.

Closes #1218