### PR TITLE
Disk II: Don't overwrite data bus when not asked to

### DIFF
--- a/Components/DiskII/DiskII.cpp
+++ b/Components/DiskII/DiskII.cpp
@@ -294,7 +294,7 @@ int DiskII::read_address(int address) {
 		break;
 	}
 	decide_clocking_preference();
-	return (address & 1) ? 0xff : shift_register_;
+	return (address & 1) ? DidNotLoad : shift_register_;
 }
 
 void DiskII::set_activity_observer(Activity::Observer *observer) {


### PR DESCRIPTION
DiskII.hpp defines `DidNotLoad` to `-1` and says it is sometimes return by `read_address`:

https://github.com/TomHarte/CLK/blob/e9420fc48daa0b98f042cc0a202b928ad203ccda/Components/DiskII/DiskII.hpp#L47-L51

Places that call `read_address` check whether `DidNotLoad` was returned before using the returned value to overwrite the data bus:

https://github.com/TomHarte/CLK/blob/e9420fc48daa0b98f042cc0a202b928ad203ccda/Machines/Apple/AppleII/DiskIICard.cpp#L52-L53

https://github.com/TomHarte/CLK/blob/e9420fc48daa0b98f042cc0a202b928ad203ccda/Machines/Oric/Oric.cpp#L522

But `read_address` never actually returns `DidNotLoad` nor is it used anywhere else in DiskII.cpp. Instead `read_address` returns `0xff`:

https://github.com/TomHarte/CLK/blob/e9420fc48daa0b98f042cc0a202b928ad203ccda/Components/DiskII/DiskII.cpp#L297

This PR changes this `0xff` to `DidNotLoad` and I can see by adding logging that DiskIICard now recognizes that it sometimes shouldn't overwrite the data bus whereas before I think it was overwriting the data bus with `0xff`.

I noticed this issue while reading the code, not chasing any particular issue, and this change doesn't appear to break any of the Apple II disks I tried to boot, nor does it fix any issue I'm investigating, but it seems like a correct change.