### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,5 @@
-name: SDL/Ubuntu
-
+name: Build
 on: [pull_request]
-
 jobs:
   build-mac:
     name: Build Mac UI

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -3,6 +3,15 @@ name: SDL/Ubuntu
 on: [pull_request]
 
 jobs:
+  build-mac:
+    name: Build Mac UI
+    runs-on: macos-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Make
+      working-directory: OSBindings/Mac
+      run: xcodebuild CODE_SIGN_IDENTITY=-
   build-sdl:
     name: Build SDL UI
     runs-on: ubuntu-latest

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -10,7 +10,9 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
     - name: Install dependencies
-      run: sudo apt-get --allow-releaseinfo-change update && sudo apt-get --fix-missing install gcc-10 libsdl2-dev scons
+      run: |
+        sudo apt-get --allow-releaseinfo-change update
+        sudo apt-get --fix-missing install gcc-10 libsdl2-dev scons
     - name: Make
       working-directory: OSBindings/SDL
       run: scons -j$(nproc --all)

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -6,9 +6,9 @@ jobs:
   build-sdl:
     name: Build SDL UI
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout
+      uses: actions/checkout@v3
     - name: Install dependencies
       run: sudo apt-get --allow-releaseinfo-change update && sudo apt-get --fix-missing install gcc-10 libsdl2-dev scons
     - name: Make

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Install dependencies
       run: sudo apt-get --allow-releaseinfo-change update && sudo apt-get --fix-missing install gcc-10 libsdl2-dev scons
     - name: Make

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -3,8 +3,8 @@ name: SDL/Ubuntu
 on: [pull_request]
 
 jobs:
-  build:
-
+  build-sdl:
+    name: Build SDL UI
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Here are some proposed improvements to the continuous integration, primarily adding a job to build the Mac UI. My intention is that the existing job to build the SDL UI could be expanded later to also run on macOS (and Windows, if it builds there) and a third job can be added later to build the Qt UI on whichever operating systems it supports.