### PR TITLE
SDL build improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,11 @@ name: Build
 on: [pull_request]
 jobs:
   build-mac:
-    name: Build Mac UI
-    runs-on: macos-latest
+    name: Mac UI on ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -11,15 +14,38 @@ jobs:
       working-directory: OSBindings/Mac
       run: xcodebuild CODE_SIGN_IDENTITY=-
   build-sdl:
-    name: Build SDL UI
-    runs-on: ubuntu-latest
+    name: SDL UI on ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
       uses: actions/checkout@v4
     - name: Install dependencies
+      shell: bash
       run: |
-        sudo apt-get --allow-releaseinfo-change update
-        sudo apt-get --fix-missing install gcc-10 libsdl2-dev scons
+        case $RUNNER_OS in
+          Linux)
+            sudo apt-get --allow-releaseinfo-change update
+            sudo apt-get --fix-missing install gcc-10 libsdl2-dev scons
+            ;;
+          macOS)
+            brew install scons sdl2
+            ;;
+        esac
     - name: Make
       working-directory: OSBindings/SDL
-      run: scons -j$(nproc --all)
+      shell: bash
+      run: |
+        case $RUNNER_OS in
+          Linux)
+            jobs=$(nproc --all)
+            ;;
+          macOS)
+            jobs=$(sysctl -n hw.activecpu)
+            ;;
+          *)
+            jobs=1
+        esac
+        scons -j"$jobs"

--- a/Machines/Apple/AppleII/Video.hpp
+++ b/Machines/Apple/AppleII/Video.hpp
@@ -469,9 +469,9 @@ template <class BusHandler, bool is_iie> class Video: public VideoBase {
 							// Supply the real phase value if this is an Apple build.
 							// TODO: eliminate UGLY HACK.
 #if defined(__APPLE__) && !defined(IGNORE_APPLE)
-							constexpr int phase = 224;
+							constexpr uint8_t phase = 224;
 #else
-							constexpr int phase = 192;
+							constexpr uint8_t phase = 192;
 #endif
 
 							crt_.output_colour_burst((colour_burst_end - colour_burst_start) * 14, phase);

--- a/Machines/Apple/AppleII/Video.hpp
+++ b/Machines/Apple/AppleII/Video.hpp
@@ -471,7 +471,7 @@ template <class BusHandler, bool is_iie> class Video: public VideoBase {
 #if defined(__APPLE__) && !defined(IGNORE_APPLE)
 							constexpr int phase = 224;
 #else
-							constexpr int phase = 0;
+							constexpr int phase = 192;
 #endif
 
 							crt_.output_colour_burst((colour_burst_end - colour_burst_start) * 14, phase);

--- a/OSBindings/SDL/SConstruct
+++ b/OSBindings/SDL/SConstruct
@@ -142,5 +142,8 @@ env.Append(CCFLAGS = ['--std=c++17', '--std=c++1z', '-Wall', '-O2', '-DNDEBUG'])
 # Add additional libraries to link against.
 env.Append(LIBS = ['libz', 'pthread', 'GL'])
 
+if env['PLATFORM'] == 'darwin':
+	env.Append(FRAMEWORKS = ['Accelerate'])
+
 # Build target.
 env.Program(target = 'clksignal', source = SOURCES)

--- a/OSBindings/SDL/SConstruct
+++ b/OSBindings/SDL/SConstruct
@@ -144,7 +144,7 @@ env.Append(LIBS = ['libz', 'pthread'])
 
 # Add additional platform-specific compiler flags, libraries, and frameworks.
 if env['PLATFORM'] == 'darwin':
-	env.Append(CCFLAGS = ['-DGL_SILENCE_DEPRECATION'])
+	env.Append(CCFLAGS = ['-DGL_SILENCE_DEPRECATION', '-DIGNORE_APPLE'])
 	env.Append(FRAMEWORKS = ['Accelerate', 'OpenGL'])
 else:
 	env.Append(LIBS = ['GL'])

--- a/OSBindings/SDL/SConstruct
+++ b/OSBindings/SDL/SConstruct
@@ -143,6 +143,7 @@ env.Append(CCFLAGS = ['--std=c++17', '--std=c++1z', '-Wall', '-O2', '-DNDEBUG'])
 env.Append(LIBS = ['libz', 'pthread', 'GL'])
 
 if env['PLATFORM'] == 'darwin':
+	env.Append(CCFLAGS = ['-DGL_SILENCE_DEPRECATION'])
 	env.Append(FRAMEWORKS = ['Accelerate'])
 
 # Build target.

--- a/OSBindings/SDL/SConstruct
+++ b/OSBindings/SDL/SConstruct
@@ -140,11 +140,14 @@ SOURCES += glob.glob('../../Storage/Tape/Parsers/*.cpp')
 env.Append(CCFLAGS = ['--std=c++17', '--std=c++1z', '-Wall', '-O2', '-DNDEBUG'])
 
 # Add additional libraries to link against.
-env.Append(LIBS = ['libz', 'pthread', 'GL'])
+env.Append(LIBS = ['libz', 'pthread'])
 
+# Add additional platform-specific compiler flags, libraries, and frameworks.
 if env['PLATFORM'] == 'darwin':
 	env.Append(CCFLAGS = ['-DGL_SILENCE_DEPRECATION'])
-	env.Append(FRAMEWORKS = ['Accelerate'])
+	env.Append(FRAMEWORKS = ['Accelerate', 'OpenGL'])
+else:
+	env.Append(LIBS = ['GL'])
 
 # Build target.
 env.Program(target = 'clksignal', source = SOURCES)

--- a/OSBindings/SDL/SConstruct
+++ b/OSBindings/SDL/SConstruct
@@ -1,4 +1,5 @@
 import glob
+import os
 import sys
 
 # Establish UTF-8 encoding for Python 2.
@@ -7,7 +8,7 @@ if sys.version_info < (3, 0):
 	sys.setdefaultencoding('utf-8')
 
 # Create build environment.
-env = Environment()
+env = Environment(ENV = {'PATH' : os.environ['PATH']})
 
 # Determine compiler and linker flags for SDL.
 env.ParseConfig('sdl2-config --cflags')

--- a/OSBindings/SDL/main.cpp
+++ b/OSBindings/SDL/main.cpp
@@ -19,7 +19,7 @@
 #include <memory>
 #include <sys/stat.h>
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 #include "../../Analyser/Static/StaticAnalyser.hpp"
 #include "../../Machines/Utility/MachineForTarget.hpp"


### PR DESCRIPTION
Here are several improvements to the scons/SDL/OpenGL build, especially for macOS.

### Update GitHub workflow: also build SDL UI on macOS

### Import PATH into scons environment

Fixes

```
/bin/sh: sdl2-config: command not found
```

when sdl2-config is not in a standard system bin directory (e.g. MacPorts).

### Use the right include path for SDL.h

Fixes

```
main.cpp:22:10: fatal error: 'SDL2/SDL.h' file not found
```

when SDL2 is not in a standard system include directory (e.g. MacPorts).

### Link with Accelerate framework on macOS

Fixes

```
Undefined symbols for architecture x86_64:
  "_vDSP_dotpr_s1_15", referenced from:
      Outputs::Speaker::LowpassBase<Outputs::Speaker::PushLowpass<true>, true>::resample_input_buffer(int) in Audio.o
      Outputs::Speaker::LowpassBase<Outputs::Speaker::PullLowpass<GI::AY38910::AY38910<true> >, true>::resample_input_buffer(int) in AmstradCPC.o
      Outputs::Speaker::LowpassBase<Outputs::Speaker::PullLowpass<Audio::Toggle>, false>::resample_input_buffer(int) in AppleII.o
      Outputs::Speaker::LowpassBase<Outputs::Speaker::PullLowpass<Outputs::Speaker::CompoundSource<Apple::IIgs::Sound::GLU, Audio::Toggle> >, false>::resample_input_buffer(int) in AppleIIgs.o
      Outputs::Speaker::LowpassBase<Outputs::Speaker::PullLowpass<Apple::Macintosh::Audio>, false>::process(unsigned long) in Macintosh.o
      Outputs::Speaker::LowpassBase<Outputs::Speaker::PullLowpass<Apple::Macintosh::Audio>, false>::update_filter_coefficients(Outputs::Speaker::LowpassBase<Outputs::Speaker::PullLowpass<Apple::Macintosh::Audio>, false>::FilterParameters const&) in Macintosh.o
      Outputs::Speaker::LowpassBase<Outputs::Speaker::PullLowpass<Atari2600::TIASound>, false>::process(unsigned long) in Atari2600.o
      ...
ld: symbol(s) not found for architecture x86_64
```

### Silence macOS OpenGL deprecation warnings

Removes warnings like this:

```
main.cpp:900:2: warning: 'glGetIntegerv' is deprecated: first deprecated in macOS 10.14 - OpenGL API deprecated. (Define GL_SILENCE_DEPRECATION to silence these warnings) [-Wdeprecated-declarations]
```

### Link with OpenGL framework on macOS

Fixes

```
ld: library not found for -lGL
```

### Improve Macintosh video & Apple II colors on macOS

Hacks in AppleII/Video.cpp, AppleII/Video.hpp, and Macintosh/Video.cpp assume that building on macOS means building for Metal unless `IGNORE_APPLE` is defined. By defining this in the macOS SDL build, Macintosh video is now sized and positioned correctly and Apple II colors are now just as wrong as they are on other OpenGL builds instead of being wrong in a unique way.

See #872

### Fix OpenGL Apple II colors
    
Adjust phase by 90 degress.
    
Closes #872

### Change phase from `int` to `uint8_t`
    
`output_colour_burst` expects a `uint8_t` so may as well make that clear.