### PR TITLE
Include TargetConditionals.h where needed

### DIFF
--- a/Outputs/OpenGL/OpenGL.hpp
+++ b/Outputs/OpenGL/OpenGL.hpp
@@ -14,6 +14,7 @@
 
 // TODO: figure out correct include paths for other platforms.
 #ifdef __APPLE__
+	#include <TargetConditionals.h>
 	#if TARGET_OS_IPHONE
 	#else
 		// These remain so that I can, at least for now, build the kiosk version under macOS.


### PR DESCRIPTION
Building the scons/SDL version of Clock Signal on macOS with llvm.org clang 17.0.6 fails:

```
Outputs/OpenGL/OpenGL.hpp:17:6: error: 'TARGET_OS_IPHONE' is not defined, evaluates to 0 [-Werror,-Wundef-prefix=TARGET_OS_]
   17 |         #if TARGET_OS_IPHONE
      |             ^
```

This PR fixes it by including the header that defines `TARGET_OS_IPHONE`.