### PR TITLE
Fix Apple II inverse text errors.

### DIFF
--- a/Machines/Apple/AppleII/VideoSwitches.hpp
+++ b/Machines/Apple/AppleII/VideoSwitches.hpp
@@ -39,7 +39,7 @@ template <typename TimeUnit> class VideoSwitches {
 			set of potential flashing characters and alternate video modes.
 		*/
 		VideoSwitches(bool is_iie, TimeUnit delay, std::function<void(TimeUnit)> &&target) : delay_(delay), deferrer_(std::move(target)) {
-			character_zones_[0].xor_mask = 0;
+			character_zones_[0].xor_mask = 0xff;
 			character_zones_[0].address_mask = 0x3f;
 			character_zones_[1].xor_mask = 0;
 			character_zones_[1].address_mask = 0x3f;
@@ -49,7 +49,7 @@ template <typename TimeUnit> class VideoSwitches {
 			character_zones_[3].address_mask = 0x3f;
 
 			if(is_iie) {
-				character_zones_[0].xor_mask =
+				character_zones_[1].xor_mask =
 				character_zones_[2].xor_mask =
 				character_zones_[3].xor_mask = 0xff;
 				character_zones_[2].address_mask =
@@ -88,7 +88,7 @@ template <typename TimeUnit> class VideoSwitches {
 
 				if(alternative_character_set) {
 					character_zones_[1].address_mask = 0xff;
-					character_zones_[1].xor_mask = 0;
+					character_zones_[1].xor_mask = 0xff;
 				} else {
 					character_zones_[1].address_mask = 0x3f;
 					character_zones_[1].xor_mask = flash_mask();
@@ -286,7 +286,9 @@ template <typename TimeUnit> class VideoSwitches {
 			// Update character set flashing; flashing is applied only when the alternative
 			// character set is not selected.
 			flash_ = (flash_ + 1) % (2 * flash_length);
-			character_zones_[1].xor_mask = flash_mask() * !internal_.alternative_character_set;
+			if(!internal_.alternative_character_set) {
+				character_zones_[1].xor_mask = flash_mask();
+			}
 		}
 
 	private:


### PR DESCRIPTION
Resolves #1294

![Clock Signal Screen Shot 01-01-2024, 22 13 40 GMT-5](https://github.com/TomHarte/CLK/assets/1162152/b4644957-bd31-426c-85b2-0d6cc00925a8)
![Clock Signal Screen Shot 01-01-2024, 22 14 13 GMT-5](https://github.com/TomHarte/CLK/assets/1162152/eda67445-10a1-4057-9f5d-ce2055ef4a91)
![Clock Signal Screen Shot 01-01-2024, 22 14 15 GMT-5](https://github.com/TomHarte/CLK/assets/1162152/fdfdbbb8-21cf-4481-bd42-ce45aaee1f4c)
![Clock Signal Screen Shot 01-01-2024, 22 14 29 GMT-5](https://github.com/TomHarte/CLK/assets/1162152/d7ceec3d-d9f5-45fc-a06d-0b5ef1e20402)
![Clock Signal Screen Shot 01-01-2024, 22 14 32 GMT-5](https://github.com/TomHarte/CLK/assets/1162152/1e7f5eaa-129f-4482-a01b-bdff246495a1)
