### PR TITLE
Mildly clean up around NIBs.

### DIFF
--- a/Storage/Disk/DiskImage/Formats/NIB.cpp
+++ b/Storage/Disk/DiskImage/Formats/NIB.cpp
@@ -79,9 +79,9 @@ std::shared_ptr<::Storage::Disk::Track> NIB::get_track_at_position(::Storage::Di
 	}
 
 	// NIB files leave sync bytes implicit and make no guarantees
-	// about overall track positioning. The attempt works by locating
-	// any single run of FF that is sufficiently long and marking the last
-	// five as including slip bits.
+	// about overall track positioning. This attempt to map to real
+	// flux locates any single run of FF that is sufficiently long
+	// and marks the last few as including slip bits.
 	std::set<size_t> sync_locations;
 	for(size_t index = 0; index < track_data.size(); ++index) {
 		// Count the number of FFs starting from here.
@@ -92,7 +92,7 @@ std::shared_ptr<::Storage::Disk::Track> NIB::get_track_at_position(::Storage::Di
 			++length;
 		}
 
-		// If that's at least five, regress and mark all as syncs.
+		// If that's long enough, regress and mark syncs.
 		if(length >= MinimumSyncByteCount) {
 			for(int c = 0; c < int(MinimumSyncByteCount); c++) {
 				end = (end + track_data.size() - 1) % track_data.size();

--- a/Storage/Disk/DiskImage/Formats/NIB.cpp
+++ b/Storage/Disk/DiskImage/Formats/NIB.cpp
@@ -55,6 +55,8 @@ long NIB::file_offset(Track::Address address) {
 }
 
 std::shared_ptr<::Storage::Disk::Track> NIB::get_track_at_position(::Storage::Disk::Track::Address address) {
+	static constexpr size_t MinimumSyncByteCount = 4;
+
 	// NIBs contain data for a fixed quantity of integer-position tracks underneath a single head only.
 	//
 	// Therefore:
@@ -91,8 +93,8 @@ std::shared_ptr<::Storage::Disk::Track> NIB::get_track_at_position(::Storage::Di
 		}
 
 		// If that's at least five, regress and mark all as syncs.
-		if(length >= 5) {
-			for(int c = 0; c < 5; c++) {
+		if(length >= MinimumSyncByteCount) {
+			for(int c = 0; c < int(MinimumSyncByteCount); c++) {
 				end = (end + track_data.size() - 1) % track_data.size();
 				sync_locations.insert(end);
 			}


### PR DESCRIPTION
I'm pretty sure that four is the actual minimum number of sync bytes; in the worst case the controller will be repeatedly catching bit 0 so:
* after one sync byte it'll have climbed to bit 2;
* then 4;
* then 6;
* then on the fourth it'll attempt to start reading at bit 8, and slip down to 7.