### PR TITLE
Be consistent in shadowing IIgs *physical* addresses.

### DIFF
--- a/Machines/Apple/AppleIIgs/AppleIIgs.cpp
+++ b/Machines/Apple/AppleIIgs/AppleIIgs.cpp
@@ -954,7 +954,7 @@ class ConcreteMachine:
 					// get by adding periodic NOPs within their copy-to-shadow step.
 					//
 					// Maybe the interaction with 2.8Mhz refresh isn't as straightforward as I think?
-					const bool is_shadowed = memory_.is_shadowed(address);
+					const bool is_shadowed = memory_.is_shadowed(region, address);
 					is_1Mhz |= is_shadowed;
 
 					// Use a very broad test for flushing video: any write to $e0 or $e1, or any write that is shadowed.

--- a/Machines/Apple/AppleIIgs/MemoryMap.hpp
+++ b/Machines/Apple/AppleIIgs/MemoryMap.hpp
@@ -633,18 +633,15 @@ class MemoryMap {
 										// adjust as required.
 
 		// The below encapsulates an assumption that Apple intends to shadow physical addresses (i.e. after mapping).
-		// If the Apple shadows logical addresses (i.e. prior to mapping) then see commented out alternatives.
+		// I couldn't really find clear documentation on this.
 
 		const Region &region(uint32_t address) {	return regions[region_map[address >> 8]];	}
 		uint8_t read(const Region &region, uint32_t address) {
 			return region.read ? region.read[address] : 0xff;
 		}
 
-		bool is_shadowed(uint32_t address) const {
-			// Logical mapping alternative:
-			// shadow_pages[((&region.write[address] - ram_base) >> 10) & 127] & shadow_banks[address >> 17]
-
-			return shadow_pages[(address >> 10) & 127] & shadow_banks[address >> 17];
+		bool is_shadowed(const Region &region, uint32_t address) const {
+			return shadow_pages[((&region.write[address] - ram_base) >> 10) & 127] & shadow_banks[address >> 17];
 
 			// Quick notes on contortions above:
 			//
@@ -666,11 +663,8 @@ class MemoryMap {
 			}
 
 			region.write[address] = value;
-			const bool shadowed = is_shadowed(address);
+			const bool shadowed = is_shadowed(region, address);
 			shadow_base[shadowed][(&region.write[address] - ram_base) & shadow_mask[shadowed]] = value;
-
-			// Logical mapping alternative:
-			// shadow_base[shadowed][address & shadow_mask[shadowed]]
 		}
 };
 

--- a/OSBindings/Mac/Clock SignalTests/IIgsMemoryMapTests.mm
+++ b/OSBindings/Mac/Clock SignalTests/IIgsMemoryMapTests.mm
@@ -369,7 +369,7 @@ namespace {
 			while(logical < [next intValue]) {
 				[[maybe_unused]] const auto &region =
 					self->_memoryMap.regions[self->_memoryMap.region_map[logical]];
-				const bool isShadowed = _memoryMap.is_shadowed(logical << 8);
+				const bool isShadowed = _memoryMap.is_shadowed(region, logical << 8);
 
 				XCTAssertEqual(
 					isShadowed,


### PR DESCRIPTION
Indecision had led to a mild contradiction here:
* shadowing was enabled by logical address;
* ... but applied by physical address.

Some titles seem to: (i) enable auxiliary memory; (ii) enable super-high-resolution shadowing; and (iii) write all graphics via bank 0. I am therefore doubling down on physical addresses being the things that are shadowed — i.e. the process is:
1. map from logical to physical address;
2. shadow from physical address to second physical address if enabled.

This seems to resolve the issue where many pieces of super-high-resolution software were missing the bottom half of their display.

E.g.

![Clock Signal Screen Shot 03-01-2024, 15 12 40 GMT-5](https://github.com/TomHarte/CLK/assets/1162152/ff3d987b-628c-49fe-a7e6-c10b9cff761a)
