### PR TITLE
Use named fields during CRTC execution.

### DIFF
--- a/Components/6845/CRTC6845.hpp
+++ b/Components/6845/CRTC6845.hpp
@@ -108,7 +108,7 @@ template <class BusHandlerT, Personality personality, CursorType cursor_type> cl
 			switch(selected_register_) {
 				case 0:	layout_.horizontal.total = value;		break;
 				case 1: layout_.horizontal.displayed = value;	break;
-				case 2:	layout_.horizontal.start_blank = value;	break;
+				case 2:	layout_.horizontal.start_sync = value;	break;
 				case 3:
 					if constexpr (is_ega) {
 					} else {
@@ -124,12 +124,9 @@ template <class BusHandlerT, Personality personality, CursorType cursor_type> cl
 						layout_.vertical.total = value & 0x7f;
 					}
 				break;
-				case 5:
-					layout_.vertical.adjust = value & 0x1f;
-				break;
-				case 6:
-					layout_.vertical.displayed = value & 0x7f;
-				break;
+				case 5:	layout_.vertical.adjust = value & 0x1f;		break;
+				case 6:	layout_.vertical.displayed = value & 0x7f;	break;
+				case 7:	layout_.vertical.start_sync = value & 0x7f;	break;
 			}
 
 			static constexpr uint8_t masks[] = {
@@ -197,7 +194,7 @@ template <class BusHandlerT, Personality personality, CursorType cursor_type> cl
 				}
 
 				// Check for start of horizontal sync.
-				if(character_counter_ == layout_.horizontal.start_blank) {
+				if(character_counter_ == layout_.horizontal.start_sync) {
 					hsync_counter_ = 0;
 					bus_state_.hsync = true;
 				}
@@ -288,7 +285,7 @@ template <class BusHandlerT, Personality personality, CursorType cursor_type> cl
 						line_counter_ = (line_counter_ + 1) & 0x7f;
 
 						// Check for start of vertical sync.
-						if(line_counter_ == registers_[7]) {
+						if(line_counter_ == layout_.vertical.start_sync) {
 							bus_state_.vsync = true;
 							vsync_counter_ = 0;
 						}
@@ -343,13 +340,14 @@ template <class BusHandlerT, Personality personality, CursorType cursor_type> cl
 			struct {
 				uint8_t total;
 				uint8_t displayed;
-				uint8_t start_blank;
+				uint8_t start_sync;
 				uint8_t sync_width;
 			} horizontal;
 
 			struct {
 				uint8_t total;
 				uint8_t displayed;
+				uint8_t start_sync;
 				uint8_t sync_lines;
 				uint8_t adjust;
 			} vertical;

--- a/Components/6845/CRTC6845.hpp
+++ b/Components/6845/CRTC6845.hpp
@@ -105,6 +105,14 @@ template <class BusHandlerT, Personality personality, CursorType cursor_type> cl
 		void set_register(uint8_t value) {
 			static constexpr bool is_ega = is_egavga(personality);
 
+			auto load_low = [value](uint16_t &target) {
+				target = (target & 0xff00) | value;
+			};
+			auto load_high = [value](uint16_t &target) {
+				constexpr uint8_t mask = RefreshMask >> 8;
+				target = uint16_t((target & 0x00ff) | ((value & mask) << 8));
+			};
+
 			switch(selected_register_) {
 				case 0:	layout_.horizontal.total = value;		break;
 				case 1: layout_.horizontal.displayed = value;	break;
@@ -127,6 +135,25 @@ template <class BusHandlerT, Personality personality, CursorType cursor_type> cl
 				case 5:	layout_.vertical.adjust = value & 0x1f;		break;
 				case 6:	layout_.vertical.displayed = value & 0x7f;	break;
 				case 7:	layout_.vertical.start_sync = value & 0x7f;	break;
+				case 8:
+					switch(value & 3) {
+						default:	layout_.interlace_mode_ = InterlaceMode::Off;					break;
+						case 0b01:	layout_.interlace_mode_ = InterlaceMode::InterlaceSync;			break;
+						case 0b11:	layout_.interlace_mode_ = InterlaceMode::InterlaceSyncAndVideo;	break;
+					}
+				break;
+				case 9:	layout_.vertical.end_row = value & 0x1f;	break;
+				case 10:
+					layout_.vertical.start_cursor = value & 0x1f;
+					// TODO: blink mode.
+				break;
+				case 11:
+					layout_.vertical.end_cursor = value & 0x1f;
+				break;
+				case 12:	load_high(layout_.start_address);	break;
+				case 13:	load_low(layout_.start_address);	break;
+				case 14:	load_high(layout_.cursor_address);	break;
+				case 15:	load_low(layout_.cursor_address);	break;
 			}
 
 			static constexpr uint8_t masks[] = {
@@ -181,7 +208,7 @@ template <class BusHandlerT, Personality personality, CursorType cursor_type> cl
 				bus_state_.refresh_address = (bus_state_.refresh_address + 1) & RefreshMask;
 
 				bus_state_.cursor = is_cursor_line_ &&
-					bus_state_.refresh_address == (registers_[15] | (registers_[14] << 8));
+					bus_state_.refresh_address == layout_.cursor_address;
 
 				// Check for end-of-line.
 				if(character_counter_ == layout_.horizontal.total) {
@@ -242,7 +269,7 @@ template <class BusHandlerT, Personality personality, CursorType cursor_type> cl
 			if constexpr (cursor_type != CursorType::None) {
 				// Check for cursor disable.
 				// TODO: this is handled differently on the EGA, should I ever implement that.
-				is_cursor_line_ &= bus_state_.row_address != (registers_[11] & 0x1f);
+				is_cursor_line_ &= bus_state_.row_address != layout_.vertical.end_cursor;
 			}
 
 			// Check for end of vertical sync.
@@ -269,7 +296,7 @@ template <class BusHandlerT, Personality personality, CursorType cursor_type> cl
 				}
 			} else {
 				// Advance vertical counter.
-				if(bus_state_.row_address == registers_[9]) {
+				if(bus_state_.row_address == layout_.vertical.end_row) {
 					bus_state_.row_address = 0;
 					line_address_ = end_of_line_address_;
 
@@ -306,7 +333,7 @@ template <class BusHandlerT, Personality personality, CursorType cursor_type> cl
 
 			if constexpr (cursor_type != CursorType::None) {
 				// Check for cursor enable.
-				is_cursor_line_ |= bus_state_.row_address == (registers_[10] & 0x1f);
+				is_cursor_line_ |= bus_state_.row_address == layout_.vertical.start_cursor;
 
 				switch(cursor_type) {
 					// MDA-style blinking.
@@ -328,7 +355,7 @@ template <class BusHandlerT, Personality personality, CursorType cursor_type> cl
 		inline void do_end_of_frame() {
 			line_counter_ = 0;
 			line_is_visible_ = true;
-			line_address_ = uint16_t((registers_[12] << 8) | registers_[13]);
+			line_address_ = layout_.start_address;
 			bus_state_.refresh_address = line_address_;
 			++bus_state_.field_count;
 		}
@@ -336,6 +363,14 @@ template <class BusHandlerT, Personality personality, CursorType cursor_type> cl
 		BusHandlerT &bus_handler_;
 		BusState bus_state_;
 
+		enum class InterlaceMode {
+			Off,
+			InterlaceSync,
+			InterlaceSyncAndVideo,
+		};
+		enum class BlinkMode {
+			// TODO.
+		};
 		struct {
 			struct {
 				uint8_t total;
@@ -350,7 +385,16 @@ template <class BusHandlerT, Personality personality, CursorType cursor_type> cl
 				uint8_t start_sync;
 				uint8_t sync_lines;
 				uint8_t adjust;
+
+				uint8_t end_row;
+				uint8_t start_cursor;
+				uint8_t end_cursor;
 			} vertical;
+
+			InterlaceMode interlace_mode_ = InterlaceMode::Off;
+			uint16_t start_address;
+			uint16_t cursor_address;
+			uint16_t light_pen_address;
 		} layout_;
 
 		uint8_t registers_[18]{};

--- a/Components/6845/CRTC6845.hpp
+++ b/Components/6845/CRTC6845.hpp
@@ -118,20 +118,12 @@ template <class BusHandlerT, Personality personality, CursorType cursor_type> cl
 				case 1: layout_.horizontal.displayed = value;	break;
 				case 2:	layout_.horizontal.start_sync = value;	break;
 				case 3:
-					if constexpr (is_ega) {
-					} else {
-						layout_.horizontal.sync_width = value & 0xf;
-						layout_.vertical.sync_lines = value >> 4;
-						// TODO: vertical sync lines:
-						// "(0 means 16 on some CRTC. Not present on all CRTCs, fixed to 16 lines on these)"
-					}
+					layout_.horizontal.sync_width = value & 0xf;
+					layout_.vertical.sync_lines = value >> 4;
+					// TODO: vertical sync lines:
+					// "(0 means 16 on some CRTC. Not present on all CRTCs, fixed to 16 lines on these)"
 				break;
-				case 4:
-					if constexpr (is_ega) {
-					} else {
-						layout_.vertical.total = value & 0x7f;
-					}
-				break;
+				case 4:	layout_.vertical.total = value & 0x7f;		break;
 				case 5:	layout_.vertical.adjust = value & 0x1f;		break;
 				case 6:	layout_.vertical.displayed = value & 0x7f;	break;
 				case 7:	layout_.vertical.start_sync = value & 0x7f;	break;

--- a/OSBindings/Mac/Clock SignalTests/IIgsMemoryMapTests.mm
+++ b/OSBindings/Mac/Clock SignalTests/IIgsMemoryMapTests.mm
@@ -275,11 +275,10 @@ namespace {
 
 					int physical = physicalStart;
 					for(int logical = logicalStart; logical < logicalEnd; logical++) {
-						const auto &region = self->_memoryMap.regions[self->_memoryMap.region_map[logical]];
+						const auto &region = self->_memoryMap.region(logical);
 
 						// Don't worry about IO pages here; they'll be compared shortly.
 						if(!(region.flags & MemoryMap::Region::IsIO)) {
-							const auto &region = self->_memoryMap.regions[self->_memoryMap.region_map[logical]];
 							applyTest(logical, physical, region);
 
 							if(*stop) {
@@ -367,8 +366,7 @@ namespace {
 		int logical = 0;
 		for(NSNumber *next in test[@"shadowed"]) {
 			while(logical < [next intValue]) {
-				[[maybe_unused]] const auto &region =
-					self->_memoryMap.regions[self->_memoryMap.region_map[logical]];
+				const auto &region = _memoryMap.region(logical);
 				const bool isShadowed = _memoryMap.is_shadowed(region, logical << 8);
 
 				XCTAssertEqual(
@@ -386,8 +384,7 @@ namespace {
 		logical = 0;
 		for(NSNumber *next in test[@"io"]) {
 			while(logical < [next intValue]) {
-				const auto &region =
-					self->_memoryMap.regions[self->_memoryMap.region_map[logical]];
+				const auto &region = self->_memoryMap.region(logical);
 
 				// This emulator marks card pages as IO because it uses IO to mean
 				// "anything that isn't the built-in RAM". Just don't test card pages.


### PR DESCRIPTION
The EGA and VGA change the meaning of some registers, therefore register number isn't a good way to identify programmer-set values while executing.