### PR TITLE
Reduce use of macros.

### DIFF
--- a/Activity/Observer.hpp
+++ b/Activity/Observer.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef ActivityObserver_h
-#define ActivityObserver_h
+#pragma once
 
 #include <cstdint>
 #include <string>
@@ -58,5 +57,3 @@ class Observer {
 };
 
 }
-
-#endif /* ActivityObserver_h */

--- a/Activity/Source.hpp
+++ b/Activity/Source.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef ActivitySource_h
-#define ActivitySource_h
+#pragma once
 
 #include "Observer.hpp"
 
@@ -19,6 +18,3 @@ class Source {
 };
 
 }
-
-
-#endif /* ActivitySource_h */

--- a/Analyser/Dynamic/ConfidenceCounter.hpp
+++ b/Analyser/Dynamic/ConfidenceCounter.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef ConfidenceCounter_hpp
-#define ConfidenceCounter_hpp
+#pragma once
 
 #include "ConfidenceSource.hpp"
 
@@ -41,5 +40,3 @@ class ConfidenceCounter: public ConfidenceSource {
 };
 
 }
-
-#endif /* ConfidenceCounter_hpp */

--- a/Analyser/Dynamic/ConfidenceSource.hpp
+++ b/Analyser/Dynamic/ConfidenceSource.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef ConfidenceSource_hpp
-#define ConfidenceSource_hpp
+#pragma once
 
 namespace Analyser::Dynamic {
 
@@ -22,5 +21,3 @@ struct ConfidenceSource {
 };
 
 }
-
-#endif /* ConfidenceSource_hpp */

--- a/Analyser/Dynamic/ConfidenceSummary.hpp
+++ b/Analyser/Dynamic/ConfidenceSummary.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef ConfidenceSummary_hpp
-#define ConfidenceSummary_hpp
+#pragma once
 
 #include "ConfidenceSource.hpp"
 
@@ -40,5 +39,3 @@ class ConfidenceSummary: public ConfidenceSource {
 };
 
 }
-
-#endif /* ConfidenceSummary_hpp */

--- a/Analyser/Dynamic/MultiMachine/Implementation/MultiConfigurable.hpp
+++ b/Analyser/Dynamic/MultiMachine/Implementation/MultiConfigurable.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef MultiConfigurable_hpp
-#define MultiConfigurable_hpp
+#pragma once
 
 #include "../../../../Machines/DynamicMachine.hpp"
 #include "../../../../Configurable/Configurable.hpp"
@@ -36,5 +35,3 @@ class MultiConfigurable: public Configurable::Device {
 };
 
 }
-
-#endif /* MultiConfigurable_hpp */

--- a/Analyser/Dynamic/MultiMachine/Implementation/MultiJoystickMachine.hpp
+++ b/Analyser/Dynamic/MultiMachine/Implementation/MultiJoystickMachine.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef MultiJoystickMachine_hpp
-#define MultiJoystickMachine_hpp
+#pragma once
 
 #include "../../../../Machines/DynamicMachine.hpp"
 
@@ -34,5 +33,3 @@ class MultiJoystickMachine: public MachineTypes::JoystickMachine {
 };
 
 }
-
-#endif /* MultiJoystickMachine_hpp */

--- a/Analyser/Dynamic/MultiMachine/Implementation/MultiKeyboardMachine.hpp
+++ b/Analyser/Dynamic/MultiMachine/Implementation/MultiKeyboardMachine.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef MultiKeyboardMachine_hpp
-#define MultiKeyboardMachine_hpp
+#pragma once
 
 #include "../../../../Machines/DynamicMachine.hpp"
 #include "../../../../Machines/KeyboardMachine.hpp"
@@ -55,5 +54,3 @@ class MultiKeyboardMachine: public MachineTypes::KeyboardMachine {
 };
 
 }
-
-#endif /* MultiKeyboardMachine_hpp */

--- a/Analyser/Dynamic/MultiMachine/Implementation/MultiMediaTarget.hpp
+++ b/Analyser/Dynamic/MultiMachine/Implementation/MultiMediaTarget.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef MultiMediaTarget_hpp
-#define MultiMediaTarget_hpp
+#pragma once
 
 #include "../../../../Machines/MediaTarget.hpp"
 #include "../../../../Machines/DynamicMachine.hpp"
@@ -35,5 +34,3 @@ struct MultiMediaTarget: public MachineTypes::MediaTarget {
 };
 
 }
-
-#endif /* MultiMediaTarget_hpp */

--- a/Analyser/Dynamic/MultiMachine/Implementation/MultiProducer.hpp
+++ b/Analyser/Dynamic/MultiMachine/Implementation/MultiProducer.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef MultiProducer_hpp
-#define MultiProducer_hpp
+#pragma once
 
 #include "../../../../Concurrency/AsyncTaskQueue.hpp"
 #include "../../../../Machines/MachineTypes.hpp"
@@ -115,5 +114,3 @@ class MultiAudioProducer: public MultiInterface<MachineTypes::AudioProducer>, pu
 */
 
 }
-
-#endif /* MultiProducer_hpp */

--- a/Analyser/Dynamic/MultiMachine/Implementation/MultiSpeaker.hpp
+++ b/Analyser/Dynamic/MultiMachine/Implementation/MultiSpeaker.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef MultiSpeaker_hpp
-#define MultiSpeaker_hpp
+#pragma once
 
 #include "../../../../Machines/DynamicMachine.hpp"
 #include "../../../../Outputs/Speaker/Speaker.hpp"
@@ -55,5 +54,3 @@ class MultiSpeaker: public Outputs::Speaker::Speaker, Outputs::Speaker::Speaker:
 };
 
 }
-
-#endif /* MultiSpeaker_hpp */

--- a/Analyser/Dynamic/MultiMachine/MultiMachine.hpp
+++ b/Analyser/Dynamic/MultiMachine/MultiMachine.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef MultiMachine_hpp
-#define MultiMachine_hpp
+#pragma once
 
 #include "../../../Machines/DynamicMachine.hpp"
 
@@ -80,5 +79,3 @@ class MultiMachine: public ::Machine::DynamicMachine, public MultiTimedMachine::
 };
 
 }
-
-#endif /* MultiMachine_hpp */

--- a/Analyser/Machines.hpp
+++ b/Analyser/Machines.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef Machines_h
-#define Machines_h
+#pragma once
 
 namespace Analyser {
 
@@ -32,5 +31,3 @@ enum class Machine {
 };
 
 }
-
-#endif /* Machines_h */

--- a/Analyser/Static/Acorn/Disk.hpp
+++ b/Analyser/Static/Acorn/Disk.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef StaticAnalyser_Acorn_Disk_hpp
-#define StaticAnalyser_Acorn_Disk_hpp
+#pragma once
 
 #include "File.hpp"
 #include "../../../Storage/Disk/Disk.hpp"
@@ -30,5 +29,3 @@ std::unique_ptr<Catalogue> GetDFSCatalogue(const std::shared_ptr<Storage::Disk::
 std::unique_ptr<Catalogue> GetADFSCatalogue(const std::shared_ptr<Storage::Disk::Disk> &disk);
 
 }
-
-#endif /* Disk_hpp */

--- a/Analyser/Static/Acorn/File.hpp
+++ b/Analyser/Static/Acorn/File.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef StaticAnalyser_Acorn_File_hpp
-#define StaticAnalyser_Acorn_File_hpp
+#pragma once
 
 #include <memory>
 #include <string>
@@ -59,5 +58,3 @@ struct File {
 };
 
 }
-
-#endif /* File_hpp */

--- a/Analyser/Static/Acorn/StaticAnalyser.hpp
+++ b/Analyser/Static/Acorn/StaticAnalyser.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef StaticAnalyser_Acorn_StaticAnalyser_hpp
-#define StaticAnalyser_Acorn_StaticAnalyser_hpp
+#pragma once
 
 #include "../StaticAnalyser.hpp"
 #include "../../../Storage/TargetPlatforms.hpp"
@@ -18,5 +17,3 @@ namespace Analyser::Static::Acorn {
 TargetList GetTargets(const Media &media, const std::string &file_name, TargetPlatform::IntType potential_platforms);
 
 }
-
-#endif /* AcornAnalyser_hpp */

--- a/Analyser/Static/Acorn/Tape.hpp
+++ b/Analyser/Static/Acorn/Tape.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef StaticAnalyser_Acorn_Tape_hpp
-#define StaticAnalyser_Acorn_Tape_hpp
+#pragma once
 
 #include <memory>
 
@@ -19,5 +18,3 @@ namespace Analyser::Static::Acorn {
 std::vector<File> GetFiles(const std::shared_ptr<Storage::Tape::Tape> &tape);
 
 }
-
-#endif /* Tape_hpp */

--- a/Analyser/Static/Acorn/Target.hpp
+++ b/Analyser/Static/Acorn/Target.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef Analyser_Static_Acorn_Target_h
-#define Analyser_Static_Acorn_Target_h
+#pragma once
 
 #include "../../../Reflection/Struct.hpp"
 #include "../StaticAnalyser.hpp"
@@ -36,5 +35,3 @@ struct Target: public ::Analyser::Static::Target, public Reflection::StructImpl<
 };
 
 }
-
-#endif /* Analyser_Static_Acorn_Target_h */

--- a/Analyser/Static/Amiga/StaticAnalyser.hpp
+++ b/Analyser/Static/Amiga/StaticAnalyser.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef Analyser_Static_Amiga_StaticAnalyser_hpp
-#define Analyser_Static_Amiga_StaticAnalyser_hpp
+#pragma once
 
 #include "../StaticAnalyser.hpp"
 #include "../../../Storage/TargetPlatforms.hpp"
@@ -18,5 +17,3 @@ namespace Analyser::Static::Amiga {
 TargetList GetTargets(const Media &media, const std::string &file_name, TargetPlatform::IntType potential_platforms);
 
 }
-
-#endif /* Analyser_Static_Amiga_StaticAnalyser_hpp */

--- a/Analyser/Static/Amiga/Target.hpp
+++ b/Analyser/Static/Amiga/Target.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef Analyser_Static_Amiga_Target_h
-#define Analyser_Static_Amiga_Target_h
+#pragma once
 
 #include "../../../Reflection/Struct.hpp"
 #include "../StaticAnalyser.hpp"
@@ -40,5 +39,3 @@ struct Target: public Analyser::Static::Target, public Reflection::StructImpl<Ta
 };
 
 }
-
-#endif /* Analyser_Static_Amiga_Target_h */

--- a/Analyser/Static/AmstradCPC/StaticAnalyser.hpp
+++ b/Analyser/Static/AmstradCPC/StaticAnalyser.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef Analyser_Static_AmstradCPC_StaticAnalyser_hpp
-#define Analyser_Static_AmstradCPC_StaticAnalyser_hpp
+#pragma once
 
 #include "../StaticAnalyser.hpp"
 #include "../../../Storage/TargetPlatforms.hpp"
@@ -18,5 +17,3 @@ namespace Analyser::Static::AmstradCPC {
 TargetList GetTargets(const Media &media, const std::string &file_name, TargetPlatform::IntType potential_platforms);
 
 }
-
-#endif /* Analyser_Static_AmstradCPC_StaticAnalyser_hpp */

--- a/Analyser/Static/AmstradCPC/Target.hpp
+++ b/Analyser/Static/AmstradCPC/Target.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef Analyser_Static_AmstradCPC_Target_h
-#define Analyser_Static_AmstradCPC_Target_h
+#pragma once
 
 #include "../../../Reflection/Enum.hpp"
 #include "../../../Reflection/Struct.hpp"
@@ -30,5 +29,3 @@ struct Target: public Analyser::Static::Target, public Reflection::StructImpl<Ta
 };
 
 }
-
-#endif /* Analyser_Static_AmstradCPC_Target_h */

--- a/Analyser/Static/AppleII/StaticAnalyser.hpp
+++ b/Analyser/Static/AppleII/StaticAnalyser.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef Analyser_Static_AppleII_StaticAnalyser_hpp
-#define Analyser_Static_AppleII_StaticAnalyser_hpp
+#pragma once
 
 #include "../StaticAnalyser.hpp"
 #include "../../../Storage/TargetPlatforms.hpp"
@@ -18,5 +17,3 @@ namespace Analyser::Static::AppleII {
 TargetList GetTargets(const Media &media, const std::string &file_name, TargetPlatform::IntType potential_platforms);
 
 }
-
-#endif /* Analyser_Static_AppleII_StaticAnalyser_hpp */

--- a/Analyser/Static/AppleII/Target.hpp
+++ b/Analyser/Static/AppleII/Target.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef Analyser_Static_AppleII_Target_h
-#define Analyser_Static_AppleII_Target_h
+#pragma once
 
 #include "../../../Reflection/Enum.hpp"
 #include "../../../Reflection/Struct.hpp"
@@ -50,5 +49,3 @@ struct Target: public Analyser::Static::Target, public Reflection::StructImpl<Ta
 };
 
 }
-
-#endif /* Analyser_Static_AppleII_Target_h */

--- a/Analyser/Static/AppleIIgs/StaticAnalyser.hpp
+++ b/Analyser/Static/AppleIIgs/StaticAnalyser.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef Analyser_Static_AppleIIgs_StaticAnalyser_hpp
-#define Analyser_Static_AppleIIgs_StaticAnalyser_hpp
+#pragma once
 
 #include "../StaticAnalyser.hpp"
 #include "../../../Storage/TargetPlatforms.hpp"
@@ -18,5 +17,3 @@ namespace Analyser::Static::AppleIIgs {
 TargetList GetTargets(const Media &media, const std::string &file_name, TargetPlatform::IntType potential_platforms);
 
 }
-
-#endif /* Analyser_Static_AppleIIgs_StaticAnalyser_hpp */

--- a/Analyser/Static/AppleIIgs/Target.hpp
+++ b/Analyser/Static/AppleIIgs/Target.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef Analyser_Static_AppleIIgs_Target_h
-#define Analyser_Static_AppleIIgs_Target_h
+#pragma once
 
 #include "../../../Reflection/Enum.hpp"
 #include "../../../Reflection/Struct.hpp"
@@ -41,5 +40,3 @@ struct Target: public Analyser::Static::Target, public Reflection::StructImpl<Ta
 };
 
 }
-
-#endif /* Analyser_Static_AppleIIgs_Target_h */

--- a/Analyser/Static/Atari2600/StaticAnalyser.hpp
+++ b/Analyser/Static/Atari2600/StaticAnalyser.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef StaticAnalyser_Atari_StaticAnalyser_hpp
-#define StaticAnalyser_Atari_StaticAnalyser_hpp
+#pragma once
 
 #include "../StaticAnalyser.hpp"
 #include "../../../Storage/TargetPlatforms.hpp"
@@ -18,5 +17,3 @@ namespace Analyser::Static::Atari2600 {
 TargetList GetTargets(const Media &media, const std::string &file_name, TargetPlatform::IntType potential_platforms);
 
 }
-
-#endif /* StaticAnalyser_hpp */

--- a/Analyser/Static/Atari2600/Target.hpp
+++ b/Analyser/Static/Atari2600/Target.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef Analyser_Static_Atari2600_Target_h
-#define Analyser_Static_Atari2600_Target_h
+#pragma once
 
 #include "../StaticAnalyser.hpp"
 
@@ -37,5 +36,3 @@ struct Target: public ::Analyser::Static::Target {
 };
 
 }
-
-#endif /* Analyser_Static_Atari_Target_h */

--- a/Analyser/Static/AtariST/StaticAnalyser.hpp
+++ b/Analyser/Static/AtariST/StaticAnalyser.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
-#ifndef Analyser_Static_AtariST_StaticAnalyser_hpp
-#define Analyser_Static_AtariST_StaticAnalyser_hpp
+#pragma once
 
 #include "../StaticAnalyser.hpp"
 #include "../../../Storage/TargetPlatforms.hpp"
@@ -18,5 +17,3 @@ namespace Analyser::Static::AtariST {
 TargetList GetTargets(const Media &media, const std::string &file_name, TargetPlatform::IntType potential_platforms);
 
 }
-
-#endif /* Analyser_Static_AtariST_StaticAnalyser_hpp */

--- a/Analyser/Static/AtariST/Target.hpp
+++ b/Analyser/Static/AtariST/Target.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
-#ifndef Analyser_Static_AtariST_Target_h
-#define Analyser_Static_AtariST_Target_h
+#pragma once
 
 #include "../../../Reflection/Struct.hpp"
 #include "../StaticAnalyser.hpp"
@@ -30,5 +29,3 @@ struct Target: public Analyser::Static::Target, public Reflection::StructImpl<Ta
 };
 
 }
-
-#endif /* Analyser_Static_AtariST_Target_h */

--- a/Analyser/Static/Coleco/StaticAnalyser.hpp
+++ b/Analyser/Static/Coleco/StaticAnalyser.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef StaticAnalyser_Coleco_StaticAnalyser_hpp
-#define StaticAnalyser_Coleco_StaticAnalyser_hpp
+#pragma once
 
 #include "../StaticAnalyser.hpp"
 #include "../../../Storage/TargetPlatforms.hpp"
@@ -18,5 +17,3 @@ namespace Analyser::Static::Coleco {
 TargetList GetTargets(const Media &media, const std::string &file_name, TargetPlatform::IntType potential_platforms);
 
 }
-
-#endif /* StaticAnalyser_hpp */

--- a/Analyser/Static/Commodore/Disk.hpp
+++ b/Analyser/Static/Commodore/Disk.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef StaticAnalyser_Commodore_Disk_hpp
-#define StaticAnalyser_Commodore_Disk_hpp
+#pragma once
 
 #include "../../../Storage/Disk/Disk.hpp"
 #include "File.hpp"
@@ -19,5 +18,3 @@ namespace Analyser::Static::Commodore {
 std::vector<File> GetFiles(const std::shared_ptr<Storage::Disk::Disk> &disk);
 
 }
-
-#endif /* Disk_hpp */

--- a/Analyser/Static/Commodore/File.hpp
+++ b/Analyser/Static/Commodore/File.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef File_hpp
-#define File_hpp
+#pragma once
 
 #include <cstdint>
 #include <string>
@@ -35,5 +34,3 @@ struct File {
 };
 
 }
-
-#endif /* File_hpp */

--- a/Analyser/Static/Commodore/StaticAnalyser.hpp
+++ b/Analyser/Static/Commodore/StaticAnalyser.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef StaticAnalyser_Commodore_StaticAnalyser_hpp
-#define StaticAnalyser_Commodore_StaticAnalyser_hpp
+#pragma once
 
 #include "../StaticAnalyser.hpp"
 #include "../../../Storage/TargetPlatforms.hpp"
@@ -18,5 +17,3 @@ namespace Analyser::Static::Commodore {
 TargetList GetTargets(const Media &media, const std::string &file_name, TargetPlatform::IntType potential_platforms);
 
 }
-
-#endif /* CommodoreAnalyser_hpp */

--- a/Analyser/Static/Commodore/Tape.hpp
+++ b/Analyser/Static/Commodore/Tape.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef StaticAnalyser_Commodore_Tape_hpp
-#define StaticAnalyser_Commodore_Tape_hpp
+#pragma once
 
 #include "../../../Storage/Tape/Tape.hpp"
 #include "File.hpp"
@@ -17,5 +16,3 @@ namespace Analyser::Static::Commodore {
 std::vector<File> GetFiles(const std::shared_ptr<Storage::Tape::Tape> &tape);
 
 }
-
-#endif /* Tape_hpp */

--- a/Analyser/Static/Commodore/Target.hpp
+++ b/Analyser/Static/Commodore/Target.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef Analyser_Static_Commodore_Target_h
-#define Analyser_Static_Commodore_Target_h
+#pragma once
 
 #include "../../../Reflection/Enum.hpp"
 #include "../../../Reflection/Struct.hpp"
@@ -70,5 +69,3 @@ struct Target: public Analyser::Static::Target, public Reflection::StructImpl<Ta
 };
 
 }
-
-#endif /* Analyser_Static_Commodore_Target_h */

--- a/Analyser/Static/Disassembler/6502.hpp
+++ b/Analyser/Static/Disassembler/6502.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef StaticAnalyser_Disassembler_6502_hpp
-#define StaticAnalyser_Disassembler_6502_hpp
+#pragma once
 
 #include <cstdint>
 #include <functional>
@@ -93,5 +92,3 @@ Disassembly Disassemble(
 	std::vector<uint16_t> entry_points);
 
 }
-
-#endif /* Disassembler6502_hpp */

--- a/Analyser/Static/Disassembler/AddressMapper.hpp
+++ b/Analyser/Static/Disassembler/AddressMapper.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef AddressMapper_hpp
-#define AddressMapper_hpp
+#pragma once
 
 #include <functional>
 
@@ -24,5 +23,3 @@ template <typename T> std::function<std::size_t(T)> OffsetMapper(T start_address
 }
 
 }
-
-#endif /* AddressMapper_hpp */

--- a/Analyser/Static/Disassembler/Kernel.hpp
+++ b/Analyser/Static/Disassembler/Kernel.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef Kernel_hpp
-#define Kernel_hpp
+#pragma once
 
 namespace Analyser::Static::Disassembly {
 
@@ -65,5 +64,3 @@ template <typename D, typename S, typename Disassembler> D Disassemble(
 }
 
 }
-
-#endif /* Kernel_hpp */

--- a/Analyser/Static/Disassembler/Z80.hpp
+++ b/Analyser/Static/Disassembler/Z80.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef StaticAnalyser_Disassembler_Z80_hpp
-#define StaticAnalyser_Disassembler_Z80_hpp
+#pragma once
 
 #include <cstdint>
 #include <functional>
@@ -91,5 +90,3 @@ Disassembly Disassemble(
 	Approach approach);
 
 }
-
-#endif /* StaticAnalyser_Disassembler_Z80_hpp */

--- a/Analyser/Static/DiskII/StaticAnalyser.hpp
+++ b/Analyser/Static/DiskII/StaticAnalyser.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef Analyser_Static_DiskII_StaticAnalyser_hpp
-#define Analyser_Static_DiskII_StaticAnalyser_hpp
+#pragma once
 
 #include "../StaticAnalyser.hpp"
 #include "../../../Storage/TargetPlatforms.hpp"
@@ -18,5 +17,3 @@ namespace Analyser::Static::DiskII {
 TargetList GetTargets(const Media &media, const std::string &file_name, TargetPlatform::IntType potential_platforms);
 
 }
-
-#endif /* Analyser_Static_DiskII_StaticAnalyser_hpp */

--- a/Analyser/Static/Enterprise/StaticAnalyser.hpp
+++ b/Analyser/Static/Enterprise/StaticAnalyser.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef Analyser_Static_Enterprise_StaticAnalyser_hpp
-#define Analyser_Static_Enterprise_StaticAnalyser_hpp
+#pragma once
 
 #include "../StaticAnalyser.hpp"
 #include "../../../Storage/TargetPlatforms.hpp"
@@ -18,5 +17,3 @@ namespace Analyser::Static::Enterprise {
 TargetList GetTargets(const Media &media, const std::string &file_name, TargetPlatform::IntType potential_platforms);
 
 }
-
-#endif /* Analyser_Static_Enterprise_StaticAnalyser_hpp */

--- a/Analyser/Static/Enterprise/Target.hpp
+++ b/Analyser/Static/Enterprise/Target.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef Analyser_Static_Enterprise_Target_h
-#define Analyser_Static_Enterprise_Target_h
+#pragma once
 
 #include "../../../Reflection/Enum.hpp"
 #include "../../../Reflection/Struct.hpp"
@@ -49,5 +48,3 @@ struct Target: public Analyser::Static::Target, public Reflection::StructImpl<Ta
 };
 
 }
-
-#endif /* Analyser_Static_Enterprise_Target_h */

--- a/Analyser/Static/FAT12/StaticAnalyser.hpp
+++ b/Analyser/Static/FAT12/StaticAnalyser.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef Analyser_Static_FAT12_StaticAnalyser_hpp
-#define Analyser_Static_FAT12_StaticAnalyser_hpp
+#pragma once
 
 #include "../StaticAnalyser.hpp"
 #include "../../../Storage/TargetPlatforms.hpp"
@@ -18,5 +17,3 @@ namespace Analyser::Static::FAT12 {
 TargetList GetTargets(const Media &media, const std::string &file_name, TargetPlatform::IntType potential_platforms);
 
 }
-
-#endif /* Analyser_Static_FAT12_StaticAnalyser_hpp */

--- a/Analyser/Static/MSX/Cartridge.hpp
+++ b/Analyser/Static/MSX/Cartridge.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef Cartridge_hpp
-#define Cartridge_hpp
+#pragma once
 
 #include "../../../Storage/Cartridge/Cartridge.hpp"
 
@@ -32,5 +31,3 @@ struct Cartridge: public ::Storage::Cartridge::Cartridge {
 };
 
 }
-
-#endif /* Cartridge_hpp */

--- a/Analyser/Static/MSX/StaticAnalyser.hpp
+++ b/Analyser/Static/MSX/StaticAnalyser.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef StaticAnalyser_MSX_StaticAnalyser_hpp
-#define StaticAnalyser_MSX_StaticAnalyser_hpp
+#pragma once
 
 #include "../StaticAnalyser.hpp"
 #include "../../../Storage/TargetPlatforms.hpp"
@@ -18,5 +17,3 @@ namespace Analyser::Static::MSX {
 TargetList GetTargets(const Media &media, const std::string &file_name, TargetPlatform::IntType potential_platforms);
 
 }
-
-#endif /* StaticAnalyser_MSX_StaticAnalyser_hpp */

--- a/Analyser/Static/MSX/Tape.hpp
+++ b/Analyser/Static/MSX/Tape.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef StaticAnalyser_MSX_Tape_hpp
-#define StaticAnalyser_MSX_Tape_hpp
+#pragma once
 
 #include "../../../Storage/Tape/Tape.hpp"
 
@@ -36,5 +35,3 @@ struct File {
 std::vector<File> GetFiles(const std::shared_ptr<Storage::Tape::Tape> &tape);
 
 }
-
-#endif /* StaticAnalyser_MSX_Tape_hpp */

--- a/Analyser/Static/MSX/Target.hpp
+++ b/Analyser/Static/MSX/Target.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef Analyser_Static_MSX_Target_h
-#define Analyser_Static_MSX_Target_h
+#pragma once
 
 #include "../../../Reflection/Enum.hpp"
 #include "../../../Reflection/Struct.hpp"
@@ -47,5 +46,3 @@ struct Target: public ::Analyser::Static::Target, public Reflection::StructImpl<
 };
 
 }
-
-#endif /* Analyser_Static_MSX_Target_h */

--- a/Analyser/Static/Macintosh/StaticAnalyser.hpp
+++ b/Analyser/Static/Macintosh/StaticAnalyser.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
-#ifndef Analyser_Static_Macintosh_StaticAnalyser_hpp
-#define Analyser_Static_Macintosh_StaticAnalyser_hpp
+#pragma once
 
 #include "../StaticAnalyser.hpp"
 #include "../../../Storage/TargetPlatforms.hpp"
@@ -18,5 +17,3 @@ namespace Analyser::Static::Macintosh {
 TargetList GetTargets(const Media &media, const std::string &file_name, TargetPlatform::IntType potential_platforms);
 
 }
-
-#endif /* Analyser_Static_Macintosh_StaticAnalyser_hpp */

--- a/Analyser/Static/Macintosh/Target.hpp
+++ b/Analyser/Static/Macintosh/Target.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
-#ifndef Analyser_Static_Macintosh_Target_h
-#define Analyser_Static_Macintosh_Target_h
+#pragma once
 
 #include "../../../Reflection/Enum.hpp"
 #include "../../../Reflection/Struct.hpp"
@@ -29,5 +28,3 @@ struct Target: public Analyser::Static::Target, public Reflection::StructImpl<Ta
 };
 
 }
-
-#endif /* Analyser_Static_Macintosh_Target_h */

--- a/Analyser/Static/Oric/StaticAnalyser.hpp
+++ b/Analyser/Static/Oric/StaticAnalyser.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef StaticAnalyser_Oric_StaticAnalyser_hpp
-#define StaticAnalyser_Oric_StaticAnalyser_hpp
+#pragma once
 
 #include "../StaticAnalyser.hpp"
 #include "../../../Storage/TargetPlatforms.hpp"
@@ -18,5 +17,3 @@ namespace Analyser::Static::Oric {
 TargetList GetTargets(const Media &media, const std::string &file_name, TargetPlatform::IntType potential_platforms);
 
 }
-
-#endif /* StaticAnalyser_hpp */

--- a/Analyser/Static/Oric/Tape.hpp
+++ b/Analyser/Static/Oric/Tape.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef StaticAnalyser_Oric_Tape_hpp
-#define StaticAnalyser_Oric_Tape_hpp
+#pragma once
 
 #include "../../../Storage/Tape/Tape.hpp"
 
@@ -32,5 +31,3 @@ struct File {
 std::vector<File> GetFiles(const std::shared_ptr<Storage::Tape::Tape> &tape);
 
 }
-
-#endif /* Tape_hpp */

--- a/Analyser/Static/Oric/Target.hpp
+++ b/Analyser/Static/Oric/Target.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef Analyser_Static_Oric_Target_h
-#define Analyser_Static_Oric_Target_h
+#pragma once
 
 #include "../../../Reflection/Enum.hpp"
 #include "../../../Reflection/Struct.hpp"
@@ -55,5 +54,3 @@ struct Target: public Analyser::Static::Target, public Reflection::StructImpl<Ta
 };
 
 }
-
-#endif /* Analyser_Static_Oric_Target_h */

--- a/Analyser/Static/PCCompatible/StaticAnalyser.hpp
+++ b/Analyser/Static/PCCompatible/StaticAnalyser.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef Analyser_Static_PCCompatible_StaticAnalyser_hpp
-#define Analyser_Static_PCCompatible_StaticAnalyser_hpp
+#pragma once
 
 #include "../StaticAnalyser.hpp"
 #include "../../../Storage/TargetPlatforms.hpp"
@@ -18,5 +17,3 @@ namespace Analyser::Static::PCCompatible {
 TargetList GetTargets(const Media &media, const std::string &file_name, TargetPlatform::IntType potential_platforms);
 
 }
-
-#endif /* Analyser_Static_PCCompatible_StaticAnalyser_hpp */

--- a/Analyser/Static/PCCompatible/Target.hpp
+++ b/Analyser/Static/PCCompatible/Target.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef Analyser_Static_PCCompatible_Target_h
-#define Analyser_Static_PCCompatible_Target_h
+#pragma once
 
 #include "../../../Reflection/Struct.hpp"
 #include "../StaticAnalyser.hpp"
@@ -36,5 +35,3 @@ struct Target: public Analyser::Static::Target, public Reflection::StructImpl<Ta
 };
 
 }
-
-#endif /* Analyser_Static_PCCompatible_Target_h */

--- a/Analyser/Static/Sega/StaticAnalyser.hpp
+++ b/Analyser/Static/Sega/StaticAnalyser.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef StaticAnalyser_Sega_StaticAnalyser_hpp
-#define StaticAnalyser_Sega_StaticAnalyser_hpp
+#pragma once
 
 #include "../StaticAnalyser.hpp"
 #include "../../../Storage/TargetPlatforms.hpp"
@@ -18,5 +17,3 @@ namespace Analyser::Static::Sega {
 TargetList GetTargets(const Media &media, const std::string &file_name, TargetPlatform::IntType potential_platforms);
 
 }
-
-#endif /* StaticAnalyser_hpp */

--- a/Analyser/Static/Sega/Target.hpp
+++ b/Analyser/Static/Sega/Target.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef Analyser_Static_Sega_Target_h
-#define Analyser_Static_Sega_Target_h
+#pragma once
 
 #include "../../../Reflection/Enum.hpp"
 #include "../../../Reflection/Struct.hpp"
@@ -51,5 +50,3 @@ constexpr bool is_master_system(Analyser::Static::Sega::Target::Model model) {
 }
 
 }
-
-#endif /* Analyser_Static_Sega_Target_h */

--- a/Analyser/Static/StaticAnalyser.cpp
+++ b/Analyser/Static/StaticAnalyser.cpp
@@ -88,6 +88,7 @@
 template<class> inline constexpr bool always_false_v = false;
 
 using namespace Analyser::Static;
+using namespace Storage;
 
 namespace {
 
@@ -101,46 +102,59 @@ std::string get_extension(const std::string &name) {
 	return extension;
 }
 
+/// Adds @c instance to @c list and adds @c platforms to the set of @c potential_platforms.
+/// If @c instance is an @c TargetPlatform::TypeDistinguisher then it is given an opportunity to restrict the set of @c potential_platforms.
+template <typename ContainerT, typename InstanceT>
+void insert_instance(ContainerT &list, InstanceT instance, TargetPlatform::IntType &potential_platforms, TargetPlatform::IntType platforms) {
+	list.emplace_back(instance);
+	potential_platforms |= platforms;
+
+	TargetPlatform::TypeDistinguisher *const distinguisher =
+		dynamic_cast<TargetPlatform::TypeDistinguisher *>(list.back().get());
+	if(distinguisher) potential_platforms &= distinguisher->target_platform_type();
+}
+
+/// Concstructs a new instance of @c InstanceT supplying @c args and adds it to the back of @c list using @c insert_instance.
+template <typename InstanceT, typename ContainerT, typename... Args>
+void insert(ContainerT &list, TargetPlatform::IntType &potential_platforms, TargetPlatform::IntType platforms, Args &&... args) {
+	insert_instance(list, new InstanceT(std::forward<Args>(args)...), potential_platforms, platforms);
+}
+
+/// Calls @c insert with the specified parameters, ignoring any exceptions thrown.
+template <typename InstanceT, typename ContainerT, typename... Args>
+void try_insert(ContainerT &list, TargetPlatform::IntType &potential_platforms, TargetPlatform::IntType platforms, Args &&... args) {
+	try {
+		insert<InstanceT>(list, potential_platforms, platforms, std::forward<Args>(args)...);
+	} catch(...) {}
+}
+
 }
 
 static Media GetMediaAndPlatforms(const std::string &file_name, TargetPlatform::IntType &potential_platforms) {
-	Media result;
 	const std::string extension = get_extension(file_name);
 
-#define InsertInstance(list, instance, platforms) \
-	list.emplace_back(instance);\
-	potential_platforms |= platforms;\
-	TargetPlatform::TypeDistinguisher *const distinguisher = dynamic_cast<TargetPlatform::TypeDistinguisher *>(list.back().get());\
-	if(distinguisher) potential_platforms &= distinguisher->target_platform_type();
-
-#define Insert(list, class, platforms, ...) \
-	InsertInstance(list, new Storage::class(__VA_ARGS__), platforms);
-
-#define TryInsert(list, class, platforms, ...) \
-	try {\
-		Insert(list, class, platforms, __VA_ARGS__) \
-	} catch(...) {}
+	Media result;
 
 #define Format(ext, list, class, platforms) \
 	if(extension == ext)	{		\
-		TryInsert(list, class, platforms, file_name)	\
+		try_insert<class>(list, potential_platforms, platforms, file_name);	\
 	}
 
 	// 2MG
 	if(extension == "2mg") {
 		// 2MG uses a factory method; defer to it.
 		try {
-			const auto media = Storage::Disk::Disk2MG::open(file_name);
-			std::visit([&result, &potential_platforms](auto &&arg) {
+			const auto media = Disk::Disk2MG::open(file_name);
+			std::visit([&](auto &&arg) {
 				using Type = typename std::decay<decltype(arg)>::type;
 
 				if constexpr (std::is_same<Type, nullptr_t>::value) {
 					// It's valid for no media to be returned.
-				} else if constexpr (std::is_same<Type, Storage::Disk::DiskImageHolderBase *>::value) {
-					InsertInstance(result.disks, arg, TargetPlatform::DiskII);
-				} else if constexpr (std::is_same<Type, Storage::MassStorage::MassStorageDevice *>::value) {
+				} else if constexpr (std::is_same<Type, Disk::DiskImageHolderBase *>::value) {
+					insert_instance(result.disks, arg, potential_platforms, TargetPlatform::DiskII);
+				} else if constexpr (std::is_same<Type, MassStorage::MassStorageDevice *>::value) {
 					// TODO: or is it Apple IIgs?
-					InsertInstance(result.mass_storage_devices, arg, TargetPlatform::AppleII);
+					insert_instance(result.mass_storage_devices, arg, potential_platforms, TargetPlatform::AppleII);
 				} else {
 					static_assert(always_false_v<Type>, "Unexpected type encountered.");
 				}
@@ -151,64 +165,67 @@ static Media GetMediaAndPlatforms(const std::string &file_name, TargetPlatform::
 	Format("80", result.tapes, Tape::ZX80O81P, TargetPlatform::ZX8081)											// 80
 	Format("81", result.tapes, Tape::ZX80O81P, TargetPlatform::ZX8081)											// 81
 	Format("a26", result.cartridges, Cartridge::BinaryDump, TargetPlatform::Atari2600)							// A26
-	Format("adf", result.disks, Disk::DiskImageHolder<Storage::Disk::AcornADF>, TargetPlatform::Acorn)			// ADF (Acorn)
-	Format("adf", result.disks, Disk::DiskImageHolder<Storage::Disk::AmigaADF>, TargetPlatform::Amiga)			// ADF (Amiga)
-	Format("adl", result.disks, Disk::DiskImageHolder<Storage::Disk::AcornADF>, TargetPlatform::Acorn)			// ADL
+	Format("adf", result.disks, Disk::DiskImageHolder<Disk::AcornADF>, TargetPlatform::Acorn)			// ADF (Acorn)
+	Format("adf", result.disks, Disk::DiskImageHolder<Disk::AmigaADF>, TargetPlatform::Amiga)			// ADF (Amiga)
+	Format("adl", result.disks, Disk::DiskImageHolder<Disk::AcornADF>, TargetPlatform::Acorn)			// ADL
 	Format("bin", result.cartridges, Cartridge::BinaryDump, TargetPlatform::AllCartridge)						// BIN (cartridge dump)
 	Format("cas", result.tapes, Tape::CAS, TargetPlatform::MSX)													// CAS
 	Format("cdt", result.tapes, Tape::TZX, TargetPlatform::AmstradCPC)											// CDT
 	Format("col", result.cartridges, Cartridge::BinaryDump, TargetPlatform::Coleco)								// COL
 	Format("csw", result.tapes, Tape::CSW, TargetPlatform::AllTape)												// CSW
-	Format("d64", result.disks, Disk::DiskImageHolder<Storage::Disk::D64>, TargetPlatform::Commodore)			// D64
+	Format("d64", result.disks, Disk::DiskImageHolder<Disk::D64>, TargetPlatform::Commodore)			// D64
 	Format("dat", result.mass_storage_devices, MassStorage::DAT, TargetPlatform::Acorn)							// DAT
-	Format("dmk", result.disks, Disk::DiskImageHolder<Storage::Disk::DMK>, TargetPlatform::MSX)					// DMK
-	Format("do", result.disks, Disk::DiskImageHolder<Storage::Disk::AppleDSK>, TargetPlatform::DiskII)			// DO
-	Format("dsd", result.disks, Disk::DiskImageHolder<Storage::Disk::SSD>, TargetPlatform::Acorn)				// DSD
+	Format("dmk", result.disks, Disk::DiskImageHolder<Disk::DMK>, TargetPlatform::MSX)					// DMK
+	Format("do", result.disks, Disk::DiskImageHolder<Disk::AppleDSK>, TargetPlatform::DiskII)			// DO
+	Format("dsd", result.disks, Disk::DiskImageHolder<Disk::SSD>, TargetPlatform::Acorn)				// DSD
 	Format(	"dsk",
 			result.disks,
-			Disk::DiskImageHolder<Storage::Disk::CPCDSK>,
+			Disk::DiskImageHolder<Disk::CPCDSK>,
 			TargetPlatform::AmstradCPC | TargetPlatform::Oric | TargetPlatform::ZXSpectrum)						// DSK (Amstrad CPC, etc)
-	Format("dsk", result.disks, Disk::DiskImageHolder<Storage::Disk::AppleDSK>, TargetPlatform::DiskII)			// DSK (Apple II)
-	Format("dsk", result.disks, Disk::DiskImageHolder<Storage::Disk::MacintoshIMG>, TargetPlatform::Macintosh)	// DSK (Macintosh, floppy disk)
+	Format("dsk", result.disks, Disk::DiskImageHolder<Disk::AppleDSK>, TargetPlatform::DiskII)			// DSK (Apple II)
+	Format("dsk", result.disks, Disk::DiskImageHolder<Disk::MacintoshIMG>, TargetPlatform::Macintosh)	// DSK (Macintosh, floppy disk)
 	Format("dsk", result.mass_storage_devices, MassStorage::HFV, TargetPlatform::Macintosh)						// DSK (Macintosh, hard disk, single volume image)
 	Format("dsk", result.mass_storage_devices, MassStorage::DSK, TargetPlatform::Macintosh)						// DSK (Macintosh, hard disk, full device image)
-	Format("dsk", result.disks, Disk::DiskImageHolder<Storage::Disk::FAT12>, TargetPlatform::MSX)				// DSK (MSX)
-	Format("dsk", result.disks, Disk::DiskImageHolder<Storage::Disk::OricMFMDSK>, TargetPlatform::Oric)			// DSK (Oric)
-	Format("g64", result.disks, Disk::DiskImageHolder<Storage::Disk::G64>, TargetPlatform::Commodore)			// G64
+	Format("dsk", result.disks, Disk::DiskImageHolder<Disk::FAT12>, TargetPlatform::MSX)				// DSK (MSX)
+	Format("dsk", result.disks, Disk::DiskImageHolder<Disk::OricMFMDSK>, TargetPlatform::Oric)			// DSK (Oric)
+	Format("g64", result.disks, Disk::DiskImageHolder<Disk::G64>, TargetPlatform::Commodore)			// G64
 	Format("hdv", result.mass_storage_devices, MassStorage::HDV, TargetPlatform::AppleII)						// HDV (Apple II, hard disk, single volume image)
 	Format(	"hfe",
 			result.disks,
-			Disk::DiskImageHolder<Storage::Disk::HFE>,
+			Disk::DiskImageHolder<Disk::HFE>,
 			TargetPlatform::Acorn | TargetPlatform::AmstradCPC | TargetPlatform::Commodore | TargetPlatform::Oric | TargetPlatform::ZXSpectrum)
 			// HFE (TODO: switch to AllDisk once the MSX stops being so greedy)
-	Format("ima", result.disks, Disk::DiskImageHolder<Storage::Disk::FAT12>, TargetPlatform::PCCompatible)			// IMG (MS-DOS style)
-	Format("image", result.disks, Disk::DiskImageHolder<Storage::Disk::MacintoshIMG>, TargetPlatform::Macintosh)	// IMG (DiskCopy 4.2)
-	Format("imd", result.disks, Disk::DiskImageHolder<Storage::Disk::IMD>, TargetPlatform::PCCompatible)			// IMD
-	Format("img", result.disks, Disk::DiskImageHolder<Storage::Disk::MacintoshIMG>, TargetPlatform::Macintosh)		// IMG (DiskCopy 4.2)
+	Format("ima", result.disks, Disk::DiskImageHolder<Disk::FAT12>, TargetPlatform::PCCompatible)			// IMG (MS-DOS style)
+	Format("image", result.disks, Disk::DiskImageHolder<Disk::MacintoshIMG>, TargetPlatform::Macintosh)	// IMG (DiskCopy 4.2)
+	Format("imd", result.disks, Disk::DiskImageHolder<Disk::IMD>, TargetPlatform::PCCompatible)			// IMD
+	Format("img", result.disks, Disk::DiskImageHolder<Disk::MacintoshIMG>, TargetPlatform::Macintosh)		// IMG (DiskCopy 4.2)
 
 	// Treat PC booter as a potential backup only if this doesn't parse as a FAT12.
 	if(extension == "img") {
 		try {
-			Insert(result.disks, Disk::DiskImageHolder<Storage::Disk::FAT12>, TargetPlatform::FAT12, file_name)				// IMG (Enterprise or MS-DOS style)
+			insert<Disk::DiskImageHolder<Disk::FAT12>>(result.disks, potential_platforms, TargetPlatform::FAT12, file_name);				// IMG (Enterprise or MS-DOS style)
 		} catch(...) {
-			Format("img", result.disks, Disk::DiskImageHolder<Storage::Disk::PCBooter>, TargetPlatform::PCCompatible)		// IMG (PC raw booter)
+			Format("img", result.disks, Disk::DiskImageHolder<Disk::PCBooter>, TargetPlatform::PCCompatible)		// IMG (PC raw booter)
 		}
 	}
 
 	Format(	"ipf",
 			result.disks,
-			Disk::DiskImageHolder<Storage::Disk::IPF>,
+			Disk::DiskImageHolder<Disk::IPF>,
 			TargetPlatform::Amiga | TargetPlatform::AtariST | TargetPlatform::AmstradCPC | TargetPlatform::ZXSpectrum)		// IPF
-	Format("msa", result.disks, Disk::DiskImageHolder<Storage::Disk::MSA>, TargetPlatform::AtariST)				// MSA
+	Format("msa", result.disks, Disk::DiskImageHolder<Disk::MSA>, TargetPlatform::AtariST)				// MSA
 	Format("mx2", result.cartridges, Cartridge::BinaryDump, TargetPlatform::MSX)								// MX2
-	Format("nib", result.disks, Disk::DiskImageHolder<Storage::Disk::NIB>, TargetPlatform::DiskII)				// NIB
+	Format("nib", result.disks, Disk::DiskImageHolder<Disk::NIB>, TargetPlatform::DiskII)				// NIB
 	Format("o", result.tapes, Tape::ZX80O81P, TargetPlatform::ZX8081)											// O
 	Format("p", result.tapes, Tape::ZX80O81P, TargetPlatform::ZX8081)											// P
-	Format("po", result.disks, Disk::DiskImageHolder<Storage::Disk::AppleDSK>, TargetPlatform::DiskII)			// PO (original Apple II kind)
+	Format("po", result.disks, Disk::DiskImageHolder<Disk::AppleDSK>, TargetPlatform::DiskII)			// PO (original Apple II kind)
 
 	// PO (Apple IIgs kind)
 	if(extension == "po")	{
-		TryInsert(result.disks, Disk::DiskImageHolder<Storage::Disk::MacintoshIMG>, TargetPlatform::AppleIIgs, file_name, Storage::Disk::MacintoshIMG::FixedType::GCR)
+		try_insert<Disk::DiskImageHolder<Disk::MacintoshIMG>>(
+			result.disks,
+			potential_platforms, TargetPlatform::AppleIIgs,
+			file_name, Disk::MacintoshIMG::FixedType::GCR);
 	}
 
 	Format("p81", result.tapes, Tape::ZX80O81P, TargetPlatform::ZX8081)											// P81
@@ -217,10 +234,10 @@ static Media GetMediaAndPlatforms(const std::string &file_name, TargetPlatform::
 	if(extension == "prg") {
 		// try instantiating as a ROM; failing that accept as a tape
 		try {
-			Insert(result.cartridges, Cartridge::PRG, TargetPlatform::Commodore, file_name)
+			insert<Cartridge::PRG>(result.cartridges, potential_platforms, TargetPlatform::Commodore, file_name);
 		} catch(...) {
 			try {
-				Insert(result.tapes, Tape::PRG, TargetPlatform::Commodore, file_name)
+				insert<Tape::PRG>(result.tapes, potential_platforms, TargetPlatform::Commodore, file_name);
 			} catch(...) {}
 		}
 	}
@@ -231,21 +248,18 @@ static Media GetMediaAndPlatforms(const std::string &file_name, TargetPlatform::
 			TargetPlatform::AcornElectron | TargetPlatform::Coleco | TargetPlatform::MSX)						// ROM
 	Format("sg", result.cartridges, Cartridge::BinaryDump, TargetPlatform::Sega)								// SG
 	Format("sms", result.cartridges, Cartridge::BinaryDump, TargetPlatform::Sega)								// SMS
-	Format("ssd", result.disks, Disk::DiskImageHolder<Storage::Disk::SSD>, TargetPlatform::Acorn)				// SSD
-	Format("st", result.disks, Disk::DiskImageHolder<Storage::Disk::FAT12>, TargetPlatform::AtariST)			// ST
-	Format("stx", result.disks, Disk::DiskImageHolder<Storage::Disk::STX>, TargetPlatform::AtariST)				// STX
+	Format("ssd", result.disks, Disk::DiskImageHolder<Disk::SSD>, TargetPlatform::Acorn)				// SSD
+	Format("st", result.disks, Disk::DiskImageHolder<Disk::FAT12>, TargetPlatform::AtariST)			// ST
+	Format("stx", result.disks, Disk::DiskImageHolder<Disk::STX>, TargetPlatform::AtariST)				// STX
 	Format("tap", result.tapes, Tape::CommodoreTAP, TargetPlatform::Commodore)									// TAP (Commodore)
 	Format("tap", result.tapes, Tape::OricTAP, TargetPlatform::Oric)											// TAP (Oric)
 	Format("tap", result.tapes, Tape::ZXSpectrumTAP, TargetPlatform::ZXSpectrum)								// TAP (ZX Spectrum)
 	Format("tsx", result.tapes, Tape::TZX, TargetPlatform::MSX)													// TSX
 	Format("tzx", result.tapes, Tape::TZX, TargetPlatform::ZX8081 | TargetPlatform::ZXSpectrum)					// TZX
 	Format("uef", result.tapes, Tape::UEF, TargetPlatform::Acorn)												// UEF (tape)
-	Format("woz", result.disks, Disk::DiskImageHolder<Storage::Disk::WOZ>, TargetPlatform::DiskII)				// WOZ
+	Format("woz", result.disks, Disk::DiskImageHolder<Disk::WOZ>, TargetPlatform::DiskII)				// WOZ
 
 #undef Format
-#undef Insert
-#undef TryInsert
-#undef InsertInstance
 
 	return result;
 }

--- a/Analyser/Static/StaticAnalyser.cpp
+++ b/Analyser/Static/StaticAnalyser.cpp
@@ -102,46 +102,77 @@ std::string get_extension(const std::string &name) {
 	return extension;
 }
 
-/// Adds @c instance to @c list and adds @c platforms to the set of @c potential_platforms.
-/// If @c instance is an @c TargetPlatform::TypeDistinguisher then it is given an opportunity to restrict the set of @c potential_platforms.
-template <typename ContainerT, typename InstanceT>
-void insert_instance(ContainerT &list, InstanceT instance, TargetPlatform::IntType &potential_platforms, TargetPlatform::IntType platforms) {
-	list.emplace_back(instance);
-	potential_platforms |= platforms;
+class MediaAccumulator {
+	public:
+	MediaAccumulator(const std::string &file_name, TargetPlatform::IntType &potential_platforms) :
+		file_name_(file_name), potential_platforms_(potential_platforms), extension_(get_extension(file_name)) {}
 
-	TargetPlatform::TypeDistinguisher *const distinguisher =
-		dynamic_cast<TargetPlatform::TypeDistinguisher *>(list.back().get());
-	if(distinguisher) potential_platforms &= distinguisher->target_platform_type();
-}
+	/// Adds @c instance to the media collection and adds @c platforms to the set of potentials.
+	/// If @c instance is an @c TargetPlatform::TypeDistinguisher then it is given an opportunity to restrict the set of potentials.
+	template <typename InstanceT>
+	void insert(TargetPlatform::IntType platforms, InstanceT *instance) {
+		if constexpr (std::is_base_of_v<Storage::Disk::Disk, InstanceT>) {
+			media.disks.emplace_back(instance);
+		} else if constexpr (std::is_base_of_v<Storage::Tape::Tape, InstanceT>) {
+			media.tapes.emplace_back(instance);
+		} else if constexpr (std::is_base_of_v<Storage::Cartridge::Cartridge, InstanceT>) {
+			media.cartridges.emplace_back(instance);
+		} else if constexpr (std::is_base_of_v<Storage::MassStorage::MassStorageDevice, InstanceT>) {
+			media.mass_storage_devices.emplace_back(instance);
+		} else {
+			static_assert(always_false_v<InstanceT>, "Unexpected type encountered.");
+		}
 
-/// Concstructs a new instance of @c InstanceT supplying @c args and adds it to the back of @c list using @c insert_instance.
-template <typename InstanceT, typename ContainerT, typename... Args>
-void insert(ContainerT &list, TargetPlatform::IntType &potential_platforms, TargetPlatform::IntType platforms, Args &&... args) {
-	insert_instance(list, new InstanceT(std::forward<Args>(args)...), potential_platforms, platforms);
-}
+		potential_platforms_ |= platforms;
 
-/// Calls @c insert with the specified parameters, ignoring any exceptions thrown.
-template <typename InstanceT, typename ContainerT, typename... Args>
-void try_insert(ContainerT &list, TargetPlatform::IntType &potential_platforms, TargetPlatform::IntType platforms, Args &&... args) {
-	try {
-		insert<InstanceT>(list, potential_platforms, platforms, std::forward<Args>(args)...);
-	} catch(...) {}
-}
+		// Check whether the instance itself has any input on target platforms.
+		TargetPlatform::TypeDistinguisher *const distinguisher =
+			dynamic_cast<TargetPlatform::TypeDistinguisher *>(instance);
+		if(distinguisher) potential_platforms_ &= distinguisher->target_platform_type();
+	}
+
+	/// Concstructs a new instance of @c InstanceT supplying @c args and adds it to the back of @c list using @c insert_instance.
+	template <typename InstanceT, typename... Args>
+	void insert(TargetPlatform::IntType platforms, Args &&... args) {
+		insert(platforms, new InstanceT(std::forward<Args>(args)...));
+	}
+
+	/// Calls @c insert with the specified parameters, ignoring any exceptions thrown.
+	template <typename InstanceT, typename... Args>
+	void try_insert(TargetPlatform::IntType platforms, Args &&... args) {
+		try {
+			insert<InstanceT>(platforms, std::forward<Args>(args)...);
+		} catch(...) {}
+	}
+
+	/// Performs a @c try_insert for an object of @c InstanceT if @c extension matches that of the file name,
+	/// providing the file name as the only construction argument.
+	template <typename InstanceT>
+	void try_standard(TargetPlatform::IntType platforms, const char *extension) {
+		if(name_matches(extension))	{
+			try_insert<InstanceT>(platforms, file_name_);
+		}
+	}
+
+	bool name_matches(const char *extension) {
+		return extension_ == extension;
+	}
+
+	Media media;
+
+	private:
+		const std::string &file_name_;
+		TargetPlatform::IntType &potential_platforms_;
+		const std::string extension_;
+};
 
 }
 
 static Media GetMediaAndPlatforms(const std::string &file_name, TargetPlatform::IntType &potential_platforms) {
-	const std::string extension = get_extension(file_name);
-
-	Media result;
-
-#define Format(ext, list, class, platforms) \
-	if(extension == ext)	{		\
-		try_insert<class>(list, potential_platforms, platforms, file_name);	\
-	}
+	MediaAccumulator accumulator(file_name, potential_platforms);
 
 	// 2MG
-	if(extension == "2mg") {
+	if(accumulator.name_matches("2mg")) {
 		// 2MG uses a factory method; defer to it.
 		try {
 			const auto media = Disk::Disk2MG::open(file_name);
@@ -151,10 +182,10 @@ static Media GetMediaAndPlatforms(const std::string &file_name, TargetPlatform::
 				if constexpr (std::is_same<Type, nullptr_t>::value) {
 					// It's valid for no media to be returned.
 				} else if constexpr (std::is_same<Type, Disk::DiskImageHolderBase *>::value) {
-					insert_instance(result.disks, arg, potential_platforms, TargetPlatform::DiskII);
+					accumulator.insert(TargetPlatform::DiskII, arg);
 				} else if constexpr (std::is_same<Type, MassStorage::MassStorageDevice *>::value) {
 					// TODO: or is it Apple IIgs?
-					insert_instance(result.mass_storage_devices, arg, potential_platforms, TargetPlatform::AppleII);
+					accumulator.insert(TargetPlatform::AppleII, arg);
 				} else {
 					static_assert(always_false_v<Type>, "Unexpected type encountered.");
 				}
@@ -162,106 +193,108 @@ static Media GetMediaAndPlatforms(const std::string &file_name, TargetPlatform::
 		} catch(...) {}
 	}
 
-	Format("80", result.tapes, Tape::ZX80O81P, TargetPlatform::ZX8081)											// 80
-	Format("81", result.tapes, Tape::ZX80O81P, TargetPlatform::ZX8081)											// 81
-	Format("a26", result.cartridges, Cartridge::BinaryDump, TargetPlatform::Atari2600)							// A26
-	Format("adf", result.disks, Disk::DiskImageHolder<Disk::AcornADF>, TargetPlatform::Acorn)			// ADF (Acorn)
-	Format("adf", result.disks, Disk::DiskImageHolder<Disk::AmigaADF>, TargetPlatform::Amiga)			// ADF (Amiga)
-	Format("adl", result.disks, Disk::DiskImageHolder<Disk::AcornADF>, TargetPlatform::Acorn)			// ADL
-	Format("bin", result.cartridges, Cartridge::BinaryDump, TargetPlatform::AllCartridge)						// BIN (cartridge dump)
-	Format("cas", result.tapes, Tape::CAS, TargetPlatform::MSX)													// CAS
-	Format("cdt", result.tapes, Tape::TZX, TargetPlatform::AmstradCPC)											// CDT
-	Format("col", result.cartridges, Cartridge::BinaryDump, TargetPlatform::Coleco)								// COL
-	Format("csw", result.tapes, Tape::CSW, TargetPlatform::AllTape)												// CSW
-	Format("d64", result.disks, Disk::DiskImageHolder<Disk::D64>, TargetPlatform::Commodore)			// D64
-	Format("dat", result.mass_storage_devices, MassStorage::DAT, TargetPlatform::Acorn)							// DAT
-	Format("dmk", result.disks, Disk::DiskImageHolder<Disk::DMK>, TargetPlatform::MSX)					// DMK
-	Format("do", result.disks, Disk::DiskImageHolder<Disk::AppleDSK>, TargetPlatform::DiskII)			// DO
-	Format("dsd", result.disks, Disk::DiskImageHolder<Disk::SSD>, TargetPlatform::Acorn)				// DSD
-	Format(	"dsk",
-			result.disks,
-			Disk::DiskImageHolder<Disk::CPCDSK>,
-			TargetPlatform::AmstradCPC | TargetPlatform::Oric | TargetPlatform::ZXSpectrum)						// DSK (Amstrad CPC, etc)
-	Format("dsk", result.disks, Disk::DiskImageHolder<Disk::AppleDSK>, TargetPlatform::DiskII)			// DSK (Apple II)
-	Format("dsk", result.disks, Disk::DiskImageHolder<Disk::MacintoshIMG>, TargetPlatform::Macintosh)	// DSK (Macintosh, floppy disk)
-	Format("dsk", result.mass_storage_devices, MassStorage::HFV, TargetPlatform::Macintosh)						// DSK (Macintosh, hard disk, single volume image)
-	Format("dsk", result.mass_storage_devices, MassStorage::DSK, TargetPlatform::Macintosh)						// DSK (Macintosh, hard disk, full device image)
-	Format("dsk", result.disks, Disk::DiskImageHolder<Disk::FAT12>, TargetPlatform::MSX)				// DSK (MSX)
-	Format("dsk", result.disks, Disk::DiskImageHolder<Disk::OricMFMDSK>, TargetPlatform::Oric)			// DSK (Oric)
-	Format("g64", result.disks, Disk::DiskImageHolder<Disk::G64>, TargetPlatform::Commodore)			// G64
-	Format("hdv", result.mass_storage_devices, MassStorage::HDV, TargetPlatform::AppleII)						// HDV (Apple II, hard disk, single volume image)
-	Format(	"hfe",
-			result.disks,
-			Disk::DiskImageHolder<Disk::HFE>,
-			TargetPlatform::Acorn | TargetPlatform::AmstradCPC | TargetPlatform::Commodore | TargetPlatform::Oric | TargetPlatform::ZXSpectrum)
-			// HFE (TODO: switch to AllDisk once the MSX stops being so greedy)
-	Format("ima", result.disks, Disk::DiskImageHolder<Disk::FAT12>, TargetPlatform::PCCompatible)			// IMG (MS-DOS style)
-	Format("image", result.disks, Disk::DiskImageHolder<Disk::MacintoshIMG>, TargetPlatform::Macintosh)	// IMG (DiskCopy 4.2)
-	Format("imd", result.disks, Disk::DiskImageHolder<Disk::IMD>, TargetPlatform::PCCompatible)			// IMD
-	Format("img", result.disks, Disk::DiskImageHolder<Disk::MacintoshIMG>, TargetPlatform::Macintosh)		// IMG (DiskCopy 4.2)
+	accumulator.try_standard<Tape::ZX80O81P>(TargetPlatform::ZX8081, "80");
+	accumulator.try_standard<Tape::ZX80O81P>(TargetPlatform::ZX8081, "81");
+
+	accumulator.try_standard<Cartridge::BinaryDump>(TargetPlatform::Atari2600, "a26");
+	accumulator.try_standard<Disk::DiskImageHolder<Disk::AcornADF>>(TargetPlatform::Acorn, "adf");
+	accumulator.try_standard<Disk::DiskImageHolder<Disk::AmigaADF>>(TargetPlatform::Amiga, "adf");
+	accumulator.try_standard<Disk::DiskImageHolder<Disk::AcornADF>>(TargetPlatform::Acorn, "adl");
+
+	accumulator.try_standard<Cartridge::BinaryDump>(TargetPlatform::AllCartridge, "bin");
+
+	accumulator.try_standard<Tape::CAS>(TargetPlatform::MSX, "cas");
+	accumulator.try_standard<Tape::TZX>(TargetPlatform::AmstradCPC, "cdt");
+	accumulator.try_standard<Cartridge::BinaryDump>(TargetPlatform::Coleco, "col");
+	accumulator.try_standard<Tape::CSW>(TargetPlatform::AllTape, "csw");
+
+	accumulator.try_standard<Disk::DiskImageHolder<Disk::D64>>(TargetPlatform::Commodore, "d64");
+	accumulator.try_standard<MassStorage::DAT>(TargetPlatform::Acorn, "dat");
+	accumulator.try_standard<Disk::DiskImageHolder<Disk::DMK>>(TargetPlatform::MSX, "dmk");
+	accumulator.try_standard<Disk::DiskImageHolder<Disk::AppleDSK>>(TargetPlatform::DiskII, "do");
+	accumulator.try_standard<Disk::DiskImageHolder<Disk::SSD>>(TargetPlatform::Acorn, "dsd");
+	accumulator.try_standard<Disk::DiskImageHolder<Disk::CPCDSK>>(
+		TargetPlatform::AmstradCPC | TargetPlatform::Oric | TargetPlatform::ZXSpectrum, "dsk");
+	accumulator.try_standard<Disk::DiskImageHolder<Disk::AppleDSK>>(TargetPlatform::DiskII, "dsk");
+	accumulator.try_standard<Disk::DiskImageHolder<Disk::MacintoshIMG>>(TargetPlatform::Macintosh, "dsk");
+	accumulator.try_standard<MassStorage::HFV>(TargetPlatform::Macintosh, "dsk");
+	accumulator.try_standard<MassStorage::DSK>(TargetPlatform::Macintosh, "dsk");
+	accumulator.try_standard<Disk::DiskImageHolder<Disk::FAT12>>(TargetPlatform::MSX, "dsk");
+	accumulator.try_standard<Disk::DiskImageHolder<Disk::OricMFMDSK>>(TargetPlatform::Oric, "dsk");
+
+	accumulator.try_standard<Disk::DiskImageHolder<Disk::G64>>(TargetPlatform::Commodore, "g64");
+
+	accumulator.try_standard<MassStorage::HDV>(TargetPlatform::AppleII, "hdv");
+	accumulator.try_standard<Disk::DiskImageHolder<Disk::HFE>>(
+		TargetPlatform::Acorn | TargetPlatform::AmstradCPC | TargetPlatform::Commodore | TargetPlatform::Oric | TargetPlatform::ZXSpectrum,
+		"hfe");	// TODO: switch to AllDisk once the MSX stops being so greedy.
+
+	accumulator.try_standard<Disk::DiskImageHolder<Disk::FAT12>>(TargetPlatform::PCCompatible, "ima");
+	accumulator.try_standard<Disk::DiskImageHolder<Disk::MacintoshIMG>>(TargetPlatform::Macintosh, "image");
+	accumulator.try_standard<Disk::DiskImageHolder<Disk::IMD>>(TargetPlatform::PCCompatible, "imd");
+	accumulator.try_standard<Disk::DiskImageHolder<Disk::MacintoshIMG>>(TargetPlatform::Macintosh, "img");
 
 	// Treat PC booter as a potential backup only if this doesn't parse as a FAT12.
-	if(extension == "img") {
+	if(accumulator.name_matches("img")) {
 		try {
-			insert<Disk::DiskImageHolder<Disk::FAT12>>(result.disks, potential_platforms, TargetPlatform::FAT12, file_name);				// IMG (Enterprise or MS-DOS style)
+			accumulator.insert<Disk::DiskImageHolder<Disk::FAT12>>(TargetPlatform::FAT12, file_name);
 		} catch(...) {
-			Format("img", result.disks, Disk::DiskImageHolder<Disk::PCBooter>, TargetPlatform::PCCompatible)		// IMG (PC raw booter)
+			accumulator.try_standard<Disk::DiskImageHolder<Disk::PCBooter>>(TargetPlatform::PCCompatible, "img");
 		}
 	}
 
-	Format(	"ipf",
-			result.disks,
-			Disk::DiskImageHolder<Disk::IPF>,
-			TargetPlatform::Amiga | TargetPlatform::AtariST | TargetPlatform::AmstradCPC | TargetPlatform::ZXSpectrum)		// IPF
-	Format("msa", result.disks, Disk::DiskImageHolder<Disk::MSA>, TargetPlatform::AtariST)				// MSA
-	Format("mx2", result.cartridges, Cartridge::BinaryDump, TargetPlatform::MSX)								// MX2
-	Format("nib", result.disks, Disk::DiskImageHolder<Disk::NIB>, TargetPlatform::DiskII)				// NIB
-	Format("o", result.tapes, Tape::ZX80O81P, TargetPlatform::ZX8081)											// O
-	Format("p", result.tapes, Tape::ZX80O81P, TargetPlatform::ZX8081)											// P
-	Format("po", result.disks, Disk::DiskImageHolder<Disk::AppleDSK>, TargetPlatform::DiskII)			// PO (original Apple II kind)
+	accumulator.try_standard<Disk::DiskImageHolder<Disk::IPF>>(
+		TargetPlatform::Amiga | TargetPlatform::AtariST | TargetPlatform::AmstradCPC | TargetPlatform::ZXSpectrum,
+		"ipf");
 
-	// PO (Apple IIgs kind)
-	if(extension == "po")	{
-		try_insert<Disk::DiskImageHolder<Disk::MacintoshIMG>>(
-			result.disks,
-			potential_platforms, TargetPlatform::AppleIIgs,
+	accumulator.try_standard<Disk::DiskImageHolder<Disk::MSA>>(TargetPlatform::AtariST, "msa");
+	accumulator.try_standard<Cartridge::BinaryDump>(TargetPlatform::MSX, "mx2");
+	accumulator.try_standard<Disk::DiskImageHolder<Disk::NIB>>(TargetPlatform::DiskII, "nib");
+
+	accumulator.try_standard<Tape::ZX80O81P>(TargetPlatform::ZX8081, "o");
+	accumulator.try_standard<Tape::ZX80O81P>(TargetPlatform::ZX8081, "p");
+	accumulator.try_standard<Disk::DiskImageHolder<Disk::AppleDSK>>(TargetPlatform::DiskII, "po");
+
+	if(accumulator.name_matches("po"))	{
+		accumulator.try_insert<Disk::DiskImageHolder<Disk::MacintoshIMG>>(
+			TargetPlatform::AppleIIgs,
 			file_name, Disk::MacintoshIMG::FixedType::GCR);
 	}
 
-	Format("p81", result.tapes, Tape::ZX80O81P, TargetPlatform::ZX8081)											// P81
+	accumulator.try_standard<Tape::ZX80O81P>(TargetPlatform::ZX8081, "p81");
 
-	// PRG
-	if(extension == "prg") {
-		// try instantiating as a ROM; failing that accept as a tape
+	if(accumulator.name_matches("prg")) {
+		// Try instantiating as a ROM; failing that accept as a tape.
 		try {
-			insert<Cartridge::PRG>(result.cartridges, potential_platforms, TargetPlatform::Commodore, file_name);
+			accumulator.insert<Cartridge::PRG>(TargetPlatform::Commodore, file_name);
 		} catch(...) {
 			try {
-				insert<Tape::PRG>(result.tapes, potential_platforms, TargetPlatform::Commodore, file_name);
+				accumulator.insert<Tape::PRG>(TargetPlatform::Commodore, file_name);
 			} catch(...) {}
 		}
 	}
 
-	Format(	"rom",
-			result.cartridges,
-			Cartridge::BinaryDump,
-			TargetPlatform::AcornElectron | TargetPlatform::Coleco | TargetPlatform::MSX)						// ROM
-	Format("sg", result.cartridges, Cartridge::BinaryDump, TargetPlatform::Sega)								// SG
-	Format("sms", result.cartridges, Cartridge::BinaryDump, TargetPlatform::Sega)								// SMS
-	Format("ssd", result.disks, Disk::DiskImageHolder<Disk::SSD>, TargetPlatform::Acorn)				// SSD
-	Format("st", result.disks, Disk::DiskImageHolder<Disk::FAT12>, TargetPlatform::AtariST)			// ST
-	Format("stx", result.disks, Disk::DiskImageHolder<Disk::STX>, TargetPlatform::AtariST)				// STX
-	Format("tap", result.tapes, Tape::CommodoreTAP, TargetPlatform::Commodore)									// TAP (Commodore)
-	Format("tap", result.tapes, Tape::OricTAP, TargetPlatform::Oric)											// TAP (Oric)
-	Format("tap", result.tapes, Tape::ZXSpectrumTAP, TargetPlatform::ZXSpectrum)								// TAP (ZX Spectrum)
-	Format("tsx", result.tapes, Tape::TZX, TargetPlatform::MSX)													// TSX
-	Format("tzx", result.tapes, Tape::TZX, TargetPlatform::ZX8081 | TargetPlatform::ZXSpectrum)					// TZX
-	Format("uef", result.tapes, Tape::UEF, TargetPlatform::Acorn)												// UEF (tape)
-	Format("woz", result.disks, Disk::DiskImageHolder<Disk::WOZ>, TargetPlatform::DiskII)				// WOZ
+	accumulator.try_standard<Cartridge::BinaryDump>(
+		TargetPlatform::AcornElectron | TargetPlatform::Coleco | TargetPlatform::MSX,
+		"rom");
 
-#undef Format
+	accumulator.try_standard<Cartridge::BinaryDump>(TargetPlatform::Sega, "sg");
+	accumulator.try_standard<Cartridge::BinaryDump>(TargetPlatform::Sega, "sms");
+	accumulator.try_standard<Disk::DiskImageHolder<Disk::SSD>>(TargetPlatform::Acorn, "ssd");
+	accumulator.try_standard<Disk::DiskImageHolder<Disk::FAT12>>(TargetPlatform::AtariST, "st");
+	accumulator.try_standard<Disk::DiskImageHolder<Disk::STX>>(TargetPlatform::AtariST, "stx");
 
-	return result;
+	accumulator.try_standard<Tape::CommodoreTAP>(TargetPlatform::Commodore, "tap");
+	accumulator.try_standard<Tape::OricTAP>(TargetPlatform::Oric, "tap");
+	accumulator.try_standard<Tape::ZXSpectrumTAP>(TargetPlatform::ZXSpectrum, "tap");
+	accumulator.try_standard<Tape::TZX>(TargetPlatform::MSX, "tsx");
+	accumulator.try_standard<Tape::TZX>(TargetPlatform::ZX8081 | TargetPlatform::ZXSpectrum, "tzx");
+
+	accumulator.try_standard<Tape::UEF>(TargetPlatform::Acorn, "uef");
+
+	accumulator.try_standard<Disk::DiskImageHolder<Disk::WOZ>>(TargetPlatform::DiskII, "woz");
+
+	return accumulator.media;
 }
 
 Media Analyser::Static::GetMedia(const std::string &file_name) {

--- a/Analyser/Static/StaticAnalyser.hpp
+++ b/Analyser/Static/StaticAnalyser.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef StaticAnalyser_hpp
-#define StaticAnalyser_hpp
+#pragma once
 
 #include "../Machines.hpp"
 
@@ -79,5 +78,3 @@ TargetList GetTargets(const std::string &file_name);
 Media GetMedia(const std::string &file_name);
 
 }
-
-#endif /* StaticAnalyser_hpp */

--- a/Analyser/Static/ZX8081/StaticAnalyser.hpp
+++ b/Analyser/Static/ZX8081/StaticAnalyser.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef Analyser_Static_ZX8081_StaticAnalyser_hpp
-#define Analyser_Static_ZX8081_StaticAnalyser_hpp
+#pragma once
 
 #include "../StaticAnalyser.hpp"
 #include "../../../Storage/TargetPlatforms.hpp"
@@ -18,5 +17,3 @@ namespace Analyser::Static::ZX8081 {
 TargetList GetTargets(const Media &media, const std::string &file_name, TargetPlatform::IntType potential_platforms);
 
 }
-
-#endif /* StaticAnalyser_hpp */

--- a/Analyser/Static/ZX8081/Target.hpp
+++ b/Analyser/Static/ZX8081/Target.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef Analyser_Static_ZX8081_Target_h
-#define Analyser_Static_ZX8081_Target_h
+#pragma once
 
 #include "../../../Reflection/Enum.hpp"
 #include "../../../Reflection/Struct.hpp"
@@ -39,5 +38,3 @@ struct Target: public ::Analyser::Static::Target, public Reflection::StructImpl<
 };
 
 }
-
-#endif /* Analyser_Static_ZX8081_Target_h */

--- a/Analyser/Static/ZXSpectrum/StaticAnalyser.hpp
+++ b/Analyser/Static/ZXSpectrum/StaticAnalyser.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef Analyser_Static_ZXSpectrum_StaticAnalyser_hpp
-#define Analyser_Static_ZXSpectrum_StaticAnalyser_hpp
+#pragma once
 
 #include "../StaticAnalyser.hpp"
 #include "../../../Storage/TargetPlatforms.hpp"
@@ -18,5 +17,3 @@ namespace Analyser::Static::ZXSpectrum {
 TargetList GetTargets(const Media &media, const std::string &file_name, TargetPlatform::IntType potential_platforms);
 
 }
-
-#endif /* StaticAnalyser_hpp */

--- a/Analyser/Static/ZXSpectrum/Target.hpp
+++ b/Analyser/Static/ZXSpectrum/Target.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef Analyser_Static_ZXSpectrum_Target_h
-#define Analyser_Static_ZXSpectrum_Target_h
+#pragma once
 
 #include "../../../Reflection/Enum.hpp"
 #include "../../../Reflection/Struct.hpp"
@@ -37,5 +36,3 @@ struct Target: public ::Analyser::Static::Target, public Reflection::StructImpl<
 };
 
 }
-
-#endif /* Target_h */

--- a/ClockReceiver/ClockReceiver.hpp
+++ b/ClockReceiver/ClockReceiver.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef ClockReceiver_hpp
-#define ClockReceiver_hpp
+#pragma once
 
 #include "ForceInline.hpp"
 
@@ -277,5 +276,3 @@ template <class T> class HalfClockReceiver: public T {
 	private:
 		HalfCycles half_cycles_;
 };
-
-#endif /* ClockReceiver_hpp */

--- a/ClockReceiver/ClockingHintSource.hpp
+++ b/ClockReceiver/ClockingHintSource.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef ClockingHintSource_hpp
-#define ClockingHintSource_hpp
+#pragma once
 
 namespace ClockingHint {
 
@@ -84,5 +83,3 @@ class Source {
 };
 
 }
-
-#endif /* ClockingHintSource_h */

--- a/ClockReceiver/DeferredQueue.hpp
+++ b/ClockReceiver/DeferredQueue.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef DeferredQueue_h
-#define DeferredQueue_h
+#pragma once
 
 #include <functional>
 #include <vector>
@@ -120,5 +119,3 @@ template <typename TimeUnit> class DeferredQueuePerformer: public DeferredQueue<
 	private:
 		std::function<void(TimeUnit)> target_;
 };
-
-#endif /* DeferredQueue_h */

--- a/ClockReceiver/DeferredValue.hpp
+++ b/ClockReceiver/DeferredValue.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef DeferredValue_h
-#define DeferredValue_h
+#pragma once
 
 /*!
 	Provides storage for a single deferred value: one with a current value and a certain number
@@ -44,5 +43,3 @@ template <int DeferredDepth, typename ValueT> class DeferredValue {
 				(backlog[DeferredDepth / elements_per_uint32] & insert_mask) | (value << insert_shift);
 		}
 };
-
-#endif /* DeferredValue_h */

--- a/ClockReceiver/ForceInline.hpp
+++ b/ClockReceiver/ForceInline.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef ForceInline_hpp
-#define ForceInline_hpp
+#pragma once
 
 #ifndef NDEBUG
 
@@ -22,5 +21,3 @@
 #endif
 
 #endif
-
-#endif /* ForceInline_h */

--- a/ClockReceiver/JustInTime.hpp
+++ b/ClockReceiver/JustInTime.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
-#ifndef JustInTime_h
-#define JustInTime_h
+#pragma once
 
 #include "ClockReceiver.hpp"
 #include "../Concurrency/AsyncTaskQueue.hpp"
@@ -335,5 +334,3 @@ template <class T, class LocalTimeScale = HalfCycles, class TargetTimeScale = Lo
 		bool is_flushed_ = true;
 		Concurrency::AsyncTaskQueue<true> task_queue_;
 };
-
-#endif /* JustInTime_h */

--- a/ClockReceiver/ScanSynchroniser.hpp
+++ b/ClockReceiver/ScanSynchroniser.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2020 Thomas Harte. All rights reserved.
 //
 
-#ifndef ScanSynchroniser_h
-#define ScanSynchroniser_h
+#pragma once
 
 #include "../Outputs/ScanTarget.hpp"
 
@@ -84,5 +83,3 @@ class ScanSynchroniser {
 };
 
 }
-
-#endif /* ScanSynchroniser_h */

--- a/ClockReceiver/TimeTypes.hpp
+++ b/ClockReceiver/TimeTypes.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef TimeTypes_h
-#define TimeTypes_h
+#pragma once
 
 #include <chrono>
 
@@ -25,6 +24,3 @@ inline Seconds seconds(Nanos nanos) {
 }
 
 }
-
-#endif /* TimeTypes_h */
-

--- a/ClockReceiver/VSyncPredictor.hpp
+++ b/ClockReceiver/VSyncPredictor.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2020 Thomas Harte. All rights reserved.
 //
 
-#ifndef VSyncPredictor_hpp
-#define VSyncPredictor_hpp
+#pragma once
 
 #include "TimeTypes.hpp"
 #include <cassert>
@@ -151,5 +150,3 @@ class VSyncPredictor {
 };
 
 }
-
-#endif /* VSyncPredictor_hpp */

--- a/Components/1770/1770.hpp
+++ b/Components/1770/1770.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef _770_hpp
-#define _770_hpp
+#pragma once
 
 #include "../../Storage/Disk/Controller/MFMDiskController.hpp"
 
@@ -141,5 +140,3 @@ class WD1770: public Storage::Disk::MFMController {
 };
 
 }
-
-#endif /* _770_hpp */

--- a/Components/5380/ncr5380.hpp
+++ b/Components/5380/ncr5380.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
-#ifndef ncr5380_hpp
-#define ncr5380_hpp
+#pragma once
 
 #include <cstdint>
 
@@ -86,5 +85,3 @@ class NCR5380 final: public SCSI::Bus::Observer {
 };
 
 }
-
-#endif /* ncr5380_hpp */

--- a/Components/6522/6522.hpp
+++ b/Components/6522/6522.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef _522_hpp
-#define _522_hpp
+#pragma once
 
 #include <cstdint>
 
@@ -140,5 +139,3 @@ template <class BusHandlerT> class MOS6522: public MOS6522Storage {
 }
 
 #include "Implementation/6522Implementation.hpp"
-
-#endif /* _522_hpp */

--- a/Components/6522/Implementation/6522Storage.hpp
+++ b/Components/6522/Implementation/6522Storage.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef _522Storage_hpp
-#define _522Storage_hpp
+#pragma once
 
 #include <cstdint>
 
@@ -107,5 +106,3 @@ class MOS6522Storage {
 };
 
 }
-
-#endif /* _522Storage_hpp */

--- a/Components/6526/6526.hpp
+++ b/Components/6526/6526.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef _526_h
-#define _526_h
+#pragma once
 
 #include <cstdint>
 
@@ -88,5 +87,3 @@ template <typename PortHandlerT, Personality personality> class MOS6526:
 }
 
 #include "Implementation/6526Implementation.hpp"
-
-#endif /* _526_h */

--- a/Components/6526/Implementation/6526Implementation.hpp
+++ b/Components/6526/Implementation/6526Implementation.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef _526Implementation_h
-#define _526Implementation_h
+#pragma once
 
 #include <cassert>
 #include <cstdio>
@@ -238,5 +237,3 @@ bool MOS6526<BusHandlerT, personality>::serial_line_did_produce_bit(Serial::Line
 }
 
 }
-
-#endif /* _526Implementation_h */

--- a/Components/6526/Implementation/6526Storage.hpp
+++ b/Components/6526/Implementation/6526Storage.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef _526Storage_h
-#define _526Storage_h
+#pragma once
 
 #include <array>
 
@@ -331,5 +330,3 @@ struct MOS6526Storage {
 };
 
 }
-
-#endif /* _526Storage_h */

--- a/Components/6532/6532.hpp
+++ b/Components/6532/6532.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef _532_hpp
-#define _532_hpp
+#pragma once
 
 #include <cstdint>
 #include <cstdio>
@@ -188,5 +187,3 @@ template <class T> class MOS6532 {
 };
 
 }
-
-#endif /* _532_hpp */

--- a/Components/6560/6560.hpp
+++ b/Components/6560/6560.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef _560_hpp
-#define _560_hpp
+#pragma once
 
 #include "../../ClockReceiver/ClockReceiver.hpp"
 #include "../../Concurrency/AsyncTaskQueue.hpp"
@@ -515,5 +514,3 @@ template <class BusHandler> class MOS6560 {
 };
 
 }
-
-#endif /* _560_hpp */

--- a/Components/6845/CRTC6845.hpp
+++ b/Components/6845/CRTC6845.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef CRTC6845_hpp
-#define CRTC6845_hpp
+#pragma once
 
 #include "../../ClockReceiver/ClockReceiver.hpp"
 
@@ -414,5 +413,3 @@ template <class BusHandlerT, Personality personality, CursorType cursor_type> cl
 };
 
 }
-
-#endif /* CRTC6845_hpp */

--- a/Components/6850/6850.hpp
+++ b/Components/6850/6850.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
-#ifndef Motorola_ACIA_6850_hpp
-#define Motorola_ACIA_6850_hpp
+#pragma once
 
 #include <cstdint>
 #include "../../ClockReceiver/ClockReceiver.hpp"
@@ -126,5 +125,3 @@ class ACIA: public ClockingHint::Source, private Serial::Line<false>::ReadDelega
 };
 
 }
-
-#endif /* Motorola_ACIA_6850_hpp */

--- a/Components/68901/MFP68901.hpp
+++ b/Components/68901/MFP68901.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
-#ifndef MFP68901_hpp
-#define MFP68901_hpp
+#pragma once
 
 #include "../../ClockReceiver/ClockReceiver.hpp"
 #include "../../ClockReceiver/ClockingHintSource.hpp"
@@ -184,5 +183,3 @@ class MFP68901: public ClockingHint::Source {
 };
 
 }
-
-#endif /* MFP68901_hpp */

--- a/Components/8255/i8255.hpp
+++ b/Components/8255/i8255.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef i8255_hpp
-#define i8255_hpp
+#pragma once
 
 #include <cstdint>
 
@@ -88,5 +87,3 @@ template <class T> class i8255 {
 };
 
 }
-
-#endif /* i8255_hpp */

--- a/Components/8272/CommandDecoder.hpp
+++ b/Components/8272/CommandDecoder.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef CommandDecoder_hpp
-#define CommandDecoder_hpp
+#pragma once
 
 #include <cstdint>
 #include <cstddef>
@@ -217,5 +216,3 @@ class CommandDecoder {
 };
 
 }
-
-#endif /* CommandDecoder_hpp */

--- a/Components/8272/Results.hpp
+++ b/Components/8272/Results.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef Results_hpp
-#define Results_hpp
+#pragma once
 
 #include "CommandDecoder.hpp"
 #include "Status.hpp"
@@ -61,5 +60,3 @@ class Results {
 };
 
 }
-
-#endif /* Results_hpp */

--- a/Components/8272/Status.hpp
+++ b/Components/8272/Status.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef Status_hpp
-#define Status_hpp
+#pragma once
 
 namespace Intel::i8272 {
 
@@ -130,5 +129,3 @@ class Status {
 };
 
 }
-
-#endif /* Status_hpp */

--- a/Components/8272/i8272.hpp
+++ b/Components/8272/i8272.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef i8272_hpp
-#define i8272_hpp
+#pragma once
 
 #include "CommandDecoder.hpp"
 #include "Status.hpp"
@@ -134,5 +133,3 @@ class i8272 : public Storage::Disk::MFMController {
 };
 
 }
-
-#endif /* i8272_hpp */

--- a/Components/8530/z8530.hpp
+++ b/Components/8530/z8530.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
-#ifndef z8530_hpp
-#define z8530_hpp
+#pragma once
 
 #include <cstdint>
 
@@ -109,5 +108,3 @@ class z8530 {
 };
 
 }
-
-#endif /* z8530_hpp */

--- a/Components/9918/9918.hpp
+++ b/Components/9918/9918.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef TMS9918_hpp
-#define TMS9918_hpp
+#pragma once
 
 #include "../../Outputs/CRT/CRT.hpp"
 #include "../../ClockReceiver/ClockReceiver.hpp"
@@ -127,5 +126,3 @@ template <Personality personality> class TMS9918: private Base<personality> {
 };
 
 }
-
-#endif /* TMS9918_hpp */

--- a/Components/9918/Implementation/9918Base.hpp
+++ b/Components/9918/Implementation/9918Base.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef TMS9918Base_hpp
-#define TMS9918Base_hpp
+#pragma once
 
 #include "ClockConverter.hpp"
 
@@ -624,5 +623,3 @@ template <Personality personality> struct Base: public Storage<personality> {
 
 #include "Fetch.hpp"
 #include "Draw.hpp"
-
-#endif /* TMS9918Base_hpp */

--- a/Components/9918/Implementation/AccessEnums.hpp
+++ b/Components/9918/Implementation/AccessEnums.hpp
@@ -6,9 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef AccessEnums_hpp
-#define AccessEnums_hpp
-
+#pragma once
 
 namespace TI::TMS {
 
@@ -111,5 +109,3 @@ enum class SpriteMode {
 };
 
 }
-
-#endif /* AccessEnums_hpp */

--- a/Components/9918/Implementation/ClockConverter.hpp
+++ b/Components/9918/Implementation/ClockConverter.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef ClockConverter_hpp
-#define ClockConverter_hpp
+#pragma once
 
 #include "../9918.hpp"
 #include "PersonalityTraits.hpp"
@@ -164,5 +163,3 @@ template <Personality personality> class ClockConverter {
 };
 
 }
-
-#endif /* ClockConverter_hpp */

--- a/Components/9918/Implementation/Draw.hpp
+++ b/Components/9918/Implementation/Draw.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef Draw_hpp
-#define Draw_hpp
+#pragma once
 
 namespace TI::TMS {
 
@@ -568,5 +567,3 @@ void Base<personality>::draw_yamaha(uint8_t y, int start, int end) {
 // TODO.
 
 }
-
-#endif /* Draw_hpp */

--- a/Components/9918/Implementation/Fetch.hpp
+++ b/Components/9918/Implementation/Fetch.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef Fetch_hpp
-#define Fetch_hpp
+#pragma once
 
 namespace TI::TMS {
 
@@ -792,5 +791,3 @@ template<bool use_end> void Base<personality>::fetch_yamaha(uint8_t y, int, int 
 // TODO.
 
 }
-
-#endif /* Fetch_hpp */

--- a/Components/9918/Implementation/LineBuffer.hpp
+++ b/Components/9918/Implementation/LineBuffer.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef LineBuffer_hpp
-#define LineBuffer_hpp
+#pragma once
 
 #include "AccessEnums.hpp"
 
@@ -128,5 +127,3 @@ struct LineBufferPointer {
 };
 
 }
-
-#endif /* LineBuffer_hpp */

--- a/Components/9918/Implementation/LineLayout.hpp
+++ b/Components/9918/Implementation/LineLayout.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef LineLayout_h
-#define LineLayout_h
+#pragma once
 
 namespace TI::TMS {
 
@@ -76,5 +75,3 @@ template <Personality personality> struct LineLayout<personality, std::enable_if
 };
 
 }
-
-#endif /* LineLayout_h */

--- a/Components/9918/Implementation/PersonalityTraits.hpp
+++ b/Components/9918/Implementation/PersonalityTraits.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef PersonalityTraits_hpp
-#define PersonalityTraits_hpp
+#pragma once
 
 namespace TI::TMS {
 
@@ -46,5 +45,3 @@ constexpr size_t memory_mask(Personality p) {
 }
 
 }
-
-#endif /* PersonalityTraits_hpp */

--- a/Components/9918/Implementation/Storage.hpp
+++ b/Components/9918/Implementation/Storage.hpp
@@ -7,8 +7,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef Storage_h
-#define Storage_h
+#pragma once
 
 #include "LineBuffer.hpp"
 #include "YamahaCommands.hpp"
@@ -486,5 +485,3 @@ template <Personality personality> struct Storage<personality, std::enable_if_t<
 };
 
 }
-
-#endif /* Storage_h */

--- a/Components/9918/Implementation/YamahaCommands.hpp
+++ b/Components/9918/Implementation/YamahaCommands.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef YamahaCommands_hpp
-#define YamahaCommands_hpp
+#pragma once
 
 #include "AccessEnums.hpp"
 
@@ -380,5 +379,3 @@ template <bool logical> struct Fill: public Rectangle<logical, false> {
 
 }
 }
-
-#endif /* YamahaCommands_hpp */

--- a/Components/AY38910/AY38910.hpp
+++ b/Components/AY38910/AY38910.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef AY_3_8910_hpp
-#define AY_3_8910_hpp
+#pragma once
 
 #include "../../Outputs/Speaker/Implementation/SampleSource.hpp"
 #include "../../Concurrency/AsyncTaskQueue.hpp"
@@ -219,5 +218,3 @@ struct State: public Reflection::StructImpl<State> {
 };
 
 }
-
-#endif /* AY_3_8910_hpp */

--- a/Components/AppleClock/AppleClock.hpp
+++ b/Components/AppleClock/AppleClock.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
-#ifndef Apple_RealTimeClock_hpp
-#define Apple_RealTimeClock_hpp
+#pragma once
 
 #include <array>
 
@@ -293,5 +292,3 @@ class ParallelClock: public ClockStorage {
 };
 
 }
-
-#endif /* Apple_RealTimeClock_hpp */

--- a/Components/AudioToggle/AudioToggle.hpp
+++ b/Components/AudioToggle/AudioToggle.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef AudioToggle_hpp
-#define AudioToggle_hpp
+#pragma once
 
 #include "../../Outputs/Speaker/Implementation/SampleSource.hpp"
 #include "../../Concurrency/AsyncTaskQueue.hpp"
@@ -38,5 +37,3 @@ class Toggle: public Outputs::Speaker::SampleSource {
 };
 
 }
-
-#endif /* AudioToggle_hpp */

--- a/Components/DiskII/DiskII.hpp
+++ b/Components/DiskII/DiskII.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef DiskII_hpp
-#define DiskII_hpp
+#pragma once
 
 #include "../../ClockReceiver/ClockReceiver.hpp"
 #include "../../ClockReceiver/ClockingHintSource.hpp"
@@ -126,5 +125,3 @@ class DiskII :
 };
 
 }
-
-#endif /* DiskII_hpp */

--- a/Components/DiskII/DiskIIDrive.hpp
+++ b/Components/DiskII/DiskIIDrive.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2020 Thomas Harte. All rights reserved.
 //
 
-#ifndef DiskIIDrive_hpp
-#define DiskIIDrive_hpp
+#pragma once
 
 #include "IWM.hpp"
 
@@ -27,5 +26,3 @@ class DiskIIDrive: public IWMDrive {
 };
 
 }
-
-#endif /* DiskIIDrive_hpp */

--- a/Components/DiskII/IWM.hpp
+++ b/Components/DiskII/IWM.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
-#ifndef IWM_hpp
-#define IWM_hpp
+#pragma once
 
 #include "../../Activity/Observer.hpp"
 
@@ -119,7 +118,4 @@ class IWM:
 		void select_shift_mode();
 };
 
-
 }
-
-#endif /* IWM_hpp */

--- a/Components/DiskII/MacintoshDoubleDensityDrive.hpp
+++ b/Components/DiskII/MacintoshDoubleDensityDrive.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
-#ifndef MacintoshDoubleDensityDrive_hpp
-#define MacintoshDoubleDensityDrive_hpp
+#pragma once
 
 #include "IWM.hpp"
 
@@ -47,5 +46,3 @@ class DoubleDensityDrive: public IWMDrive {
 };
 
 }
-
-#endif /* MacintoshDoubleDensityDrive_hpp */

--- a/Components/KonamiSCC/KonamiSCC.hpp
+++ b/Components/KonamiSCC/KonamiSCC.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef KonamiSCC_hpp
-#define KonamiSCC_hpp
+#pragma once
 
 #include "../../Outputs/Speaker/Implementation/SampleSource.hpp"
 #include "../../Concurrency/AsyncTaskQueue.hpp"
@@ -70,5 +69,3 @@ class SCC: public ::Outputs::Speaker::SampleSource {
 };
 
 }
-
-#endif /* KonamiSCC_hpp */

--- a/Components/OPx/Implementation/EnvelopeGenerator.hpp
+++ b/Components/OPx/Implementation/EnvelopeGenerator.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2020 Thomas Harte. All rights reserved.
 //
 
-#ifndef EnvelopeGenerator_h
-#define EnvelopeGenerator_h
+#pragma once
 
 #include <optional>
 #include <functional>
@@ -258,5 +257,3 @@ template <int envelope_precision, int period_precision> class EnvelopeGenerator 
 };
 
 }
-
-#endif /* EnvelopeGenerator_h */

--- a/Components/OPx/Implementation/KeyLevelScaler.hpp
+++ b/Components/OPx/Implementation/KeyLevelScaler.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2020 Thomas Harte. All rights reserved.
 //
 
-#ifndef KeyLevelScaler_h
-#define KeyLevelScaler_h
+#pragma once
 
 namespace Yamaha::OPL {
 
@@ -51,5 +50,3 @@ template <int frequency_precision> class KeyLevelScaler {
 };
 
 }
-
-#endif /* KeyLevelScaler_h */

--- a/Components/OPx/Implementation/LowFrequencyOscillator.hpp
+++ b/Components/OPx/Implementation/LowFrequencyOscillator.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2020 Thomas Harte. All rights reserved.
 //
 
-#ifndef LowFrequencyOscillator_hpp
-#define LowFrequencyOscillator_hpp
+#pragma once
 
 #include "../../../Numeric/LFSR.hpp"
 
@@ -62,5 +61,3 @@ class LowFrequencyOscillator {
 };
 
 }
-
-#endif /* LowFrequencyOscillator_hpp */

--- a/Components/OPx/Implementation/OPLBase.hpp
+++ b/Components/OPx/Implementation/OPLBase.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2020 Thomas Harte. All rights reserved.
 //
 
-#ifndef OPLBase_h
-#define OPLBase_h
+#pragma once
 
 #include "../../../Outputs/Speaker/Implementation/SampleSource.hpp"
 #include "../../../Concurrency/AsyncTaskQueue.hpp"
@@ -34,5 +33,3 @@ template <typename Child> class OPLBase: public ::Outputs::Speaker::SampleSource
 };
 
 }
-
-#endif /* OPLBase_h */

--- a/Components/OPx/Implementation/PhaseGenerator.hpp
+++ b/Components/OPx/Implementation/PhaseGenerator.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2020 Thomas Harte. All rights reserved.
 //
 
-#ifndef PhaseGenerator_h
-#define PhaseGenerator_h
+#pragma once
 
 #include <cassert>
 #include "LowFrequencyOscillator.hpp"
@@ -119,5 +118,3 @@ template <int precision> class PhaseGenerator {
 };
 
 }
-
-#endif /* PhaseGenerator_h */

--- a/Components/OPx/Implementation/Tables.hpp
+++ b/Components/OPx/Implementation/Tables.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2020 Thomas Harte. All rights reserved.
 //
 
-#ifndef Tables_hpp
-#define Tables_hpp
+#pragma once
 
 namespace Yamaha::OPL {
 
@@ -221,5 +220,3 @@ inline int LogSign::level(int fractional) const {
 }
 
 }
-
-#endif /* Tables_hpp */

--- a/Components/OPx/Implementation/WaveformGenerator.hpp
+++ b/Components/OPx/Implementation/WaveformGenerator.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2020 Thomas Harte. All rights reserved.
 //
 
-#ifndef WaveformGenerator_h
-#define WaveformGenerator_h
+#pragma once
 
 #include "Tables.hpp"
 #include "LowFrequencyOscillator.hpp"
@@ -86,5 +85,3 @@ template <int phase_precision> class WaveformGenerator {
 };
 
 }
-
-#endif /* WaveformGenerator_h */

--- a/Components/OPx/OPLL.hpp
+++ b/Components/OPx/OPLL.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2020 Thomas Harte. All rights reserved.
 //
 
-#ifndef OPLL_hpp
-#define OPLL_hpp
+#pragma once
 
 #include "Implementation/OPLBase.hpp"
 #include "Implementation/EnvelopeGenerator.hpp"
@@ -125,5 +124,3 @@ class OPLL: public OPLBase<OPLL> {
 };
 
 }
-
-#endif /* OPLL_hpp */

--- a/Components/RP5C01/RP5C01.hpp
+++ b/Components/RP5C01/RP5C01.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef RP5C01_hpp
-#define RP5C01_hpp
+#pragma once
 
 #include "../../ClockReceiver/ClockReceiver.hpp"
 
@@ -55,5 +54,3 @@ class RP5C01 {
 };
 
 }
-
-#endif /* RP5C01_hpp */

--- a/Components/SN76489/SN76489.hpp
+++ b/Components/SN76489/SN76489.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef SN76489_hpp
-#define SN76489_hpp
+#pragma once
 
 #include "../../Outputs/Speaker/Implementation/SampleSource.hpp"
 #include "../../Concurrency/AsyncTaskQueue.hpp"
@@ -65,5 +64,3 @@ class SN76489: public Outputs::Speaker::SampleSource {
 };
 
 }
-
-#endif /* SN76489_hpp */

--- a/Components/Serial/Line.hpp
+++ b/Components/Serial/Line.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
-#ifndef SerialPort_hpp
-#define SerialPort_hpp
+#pragma once
 
 #include <vector>
 #include "../../Storage/Storage.hpp"
@@ -143,5 +142,3 @@ class Port {
 };
 
 }
-
-#endif /* SerialPort_hpp */

--- a/Concurrency/AsyncTaskQueue.hpp
+++ b/Concurrency/AsyncTaskQueue.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef AsyncTaskQueue_hpp
-#define AsyncTaskQueue_hpp
+#pragma once
 
 #include <atomic>
 #include <condition_variable>
@@ -189,5 +188,3 @@ template <bool perform_automatically, bool start_immediately = true, typename Pe
 };
 
 }
-
-#endif /* AsyncTaskQueue_hpp */

--- a/Configurable/Configurable.hpp
+++ b/Configurable/Configurable.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef Configurable_h
-#define Configurable_h
+#pragma once
 
 #include "../Reflection/Struct.hpp"
 
@@ -42,5 +41,3 @@ enum class OptionsType {
 };
 
 }
-
-#endif /* Configurable_h */

--- a/Configurable/StandardOptions.hpp
+++ b/Configurable/StandardOptions.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef StandardOptions_hpp
-#define StandardOptions_hpp
+#pragma once
 
 #include "../Reflection/Enum.hpp"
 
@@ -61,5 +60,3 @@ template <typename Owner> class QuickbootOption {
 };
 
 }
-
-#endif /* StandardOptions_hpp */

--- a/Inputs/Joystick.hpp
+++ b/Inputs/Joystick.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef Joystick_hpp
-#define Joystick_hpp
+#pragma once
 
 #include <cstddef>
 #include <vector>
@@ -234,5 +233,3 @@ class ConcreteJoystick: public Joystick {
 };
 
 }
-
-#endif /* Joystick_hpp */

--- a/Inputs/Keyboard.hpp
+++ b/Inputs/Keyboard.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef Inputs_Keyboard_hpp
-#define Inputs_Keyboard_hpp
+#pragma once
 
 #include <vector>
 #include <set>
@@ -90,5 +89,3 @@ class Keyboard {
 };
 
 }
-
-#endif /* Inputs_Keyboard_hpp */

--- a/Inputs/Mouse.hpp
+++ b/Inputs/Mouse.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
-#ifndef Mouse_h
-#define Mouse_h
+#pragma once
 
 namespace Inputs {
 
@@ -43,5 +42,3 @@ class Mouse {
 };
 
 }
-
-#endif /* Mouse_h */

--- a/Inputs/QuadratureMouse/QuadratureMouse.hpp
+++ b/Inputs/QuadratureMouse/QuadratureMouse.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
-#ifndef QuadratureMouse_hpp
-#define QuadratureMouse_hpp
+#pragma once
 
 #include "../Mouse.hpp"
 #include <atomic>
@@ -119,5 +118,3 @@ class QuadratureMouse: public Mouse {
 };
 
 }
-
-#endif /* QuadratureMouse_hpp */

--- a/InstructionSets/6809/OperationMapper.hpp
+++ b/InstructionSets/6809/OperationMapper.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef InstructionSets_M6809_OperationMapper_hpp
-#define InstructionSets_M6809_OperationMapper_hpp
+#pragma once
 
 // Cf. https://techheap.packetizer.com/processors/6809/6809Instructions.html
 //
@@ -239,5 +238,3 @@ template <int i, typename SchedulerT> void OperationMapper<Page::Page2>::dispatc
 }
 
 }
-
-#endif /* InstructionSets_M6809_OperationMapper_hpp */

--- a/InstructionSets/AccessType.hpp
+++ b/InstructionSets/AccessType.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef AccessType_h
-#define AccessType_h
+#pragma once
 
 namespace InstructionSet {
 
@@ -19,5 +18,3 @@ enum class AccessType {
 };
 
 }
-
-#endif /* AccessType_h */

--- a/InstructionSets/CachingExecutor.hpp
+++ b/InstructionSets/CachingExecutor.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef CachingExecutor_hpp
-#define CachingExecutor_hpp
+#pragma once
 
 #include "../Numeric/Sizes.hpp"
 
@@ -196,5 +195,3 @@ template <
 };
 
 }
-
-#endif /* CachingExecutor_hpp */

--- a/InstructionSets/Disassembler.hpp
+++ b/InstructionSets/Disassembler.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef Disassembler_hpp
-#define Disassembler_hpp
+#pragma once
 
 #include "../Numeric/Sizes.hpp"
 
@@ -85,5 +84,3 @@ template <
 };
 
 }
-
-#endif /* Disassembler_h */

--- a/InstructionSets/M50740/Decoder.hpp
+++ b/InstructionSets/M50740/Decoder.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef InstructionSets_M50740_Decoder_hpp
-#define InstructionSets_M50740_Decoder_hpp
+#pragma once
 
 #include "Instruction.hpp"
 
@@ -33,5 +32,3 @@ class Decoder {
 };
 
 }
-
-#endif /* InstructionSets_M50740_Decoder_hpp */

--- a/InstructionSets/M50740/Executor.hpp
+++ b/InstructionSets/M50740/Executor.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef Executor_h
-#define Executor_h
+#pragma once
 
 #include "Instruction.hpp"
 #include "Parser.hpp"
@@ -176,5 +175,3 @@ class Executor: public CachingExecutor {
 };
 
 }
-
-#endif /* Executor_h */

--- a/InstructionSets/M50740/Instruction.hpp
+++ b/InstructionSets/M50740/Instruction.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef InstructionSets_M50740_Instruction_h
-#define InstructionSets_M50740_Instruction_h
+#pragma once
 
 #include <cstdint>
 #include <iomanip>
@@ -235,5 +234,3 @@ inline std::ostream &operator <<(std::ostream &stream, const Instruction &instru
 }
 
 }
-
-#endif /* InstructionSets_M50740_Instruction_h */

--- a/InstructionSets/M50740/Parser.hpp
+++ b/InstructionSets/M50740/Parser.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef InstructionSets_M50740_Parser_hpp
-#define InstructionSets_M50740_Parser_hpp
+#pragma once
 
 #include <cstdint>
 #include "Decoder.hpp"
@@ -119,5 +118,3 @@ template<typename Target, bool include_entries_and_accesses> struct Parser {
 };
 
 }
-
-#endif /* InstructionSets_M50740_Parser_hpp */

--- a/InstructionSets/M68k/Decoder.hpp
+++ b/InstructionSets/M68k/Decoder.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2022 Thomas Harte. All rights reserved.
 //
 
-#ifndef InstructionSets_M68k_Decoder_hpp
-#define InstructionSets_M68k_Decoder_hpp
+#pragma once
 
 #include "Instruction.hpp"
 #include "Model.hpp"
@@ -115,5 +114,3 @@ template <Model model> class Predecoder {
 };
 
 }
-
-#endif /* InstructionSets_M68k_Decoder_hpp */

--- a/InstructionSets/M68k/ExceptionVectors.hpp
+++ b/InstructionSets/M68k/ExceptionVectors.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2022 Thomas Harte. All rights reserved.
 //
 
-#ifndef InstructionSets_M68k_ExceptionVectors_hpp
-#define InstructionSets_M68k_ExceptionVectors_hpp
+#pragma once
 
 namespace InstructionSet::M68k {
 
@@ -44,5 +43,3 @@ enum Exception {
 };
 
 }
-
-#endif /* InstructionSets_M68k_ExceptionVectors_hpp */

--- a/InstructionSets/M68k/Executor.hpp
+++ b/InstructionSets/M68k/Executor.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2022 Thomas Harte. All rights reserved.
 //
 
-#ifndef InstructionSets_M68k_Executor_hpp
-#define InstructionSets_M68k_Executor_hpp
+#pragma once
 
 #include "Decoder.hpp"
 #include "Instruction.hpp"
@@ -165,5 +164,3 @@ template <Model model, typename BusHandler> class Executor {
 }
 
 #include "Implementation/ExecutorImplementation.hpp"
-
-#endif /* InstructionSets_M68k_Executor_hpp */

--- a/InstructionSets/M68k/Implementation/ExecutorImplementation.hpp
+++ b/InstructionSets/M68k/Implementation/ExecutorImplementation.hpp
@@ -7,8 +7,7 @@
 //  Copyright © 2022 Thomas Harte. All rights reserved.
 //
 
-#ifndef InstructionSets_M68k_ExecutorImplementation_hpp
-#define InstructionSets_M68k_ExecutorImplementation_hpp
+#pragma once
 
 #include "../Perform.hpp"
 #include "../ExceptionVectors.hpp"
@@ -749,5 +748,3 @@ void Executor<model, BusHandler>::State::movem_toR(Preinstruction instruction, u
 #undef AccessException
 
 }
-
-#endif /* InstructionSets_M68k_ExecutorImplementation_hpp */

--- a/InstructionSets/M68k/Implementation/InstructionOperandFlags.hpp
+++ b/InstructionSets/M68k/Implementation/InstructionOperandFlags.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2022 Thomas Harte. All rights reserved.
 //
 
-#ifndef InstructionSets_68k_InstructionOperandFlags_hpp
-#define InstructionSets_68k_InstructionOperandFlags_hpp
+#pragma once
 
 namespace InstructionSet::M68k {
 
@@ -168,5 +167,3 @@ template <Model model, Operation t_operation> constexpr uint8_t operand_flags(Op
 }
 
 }
-
-#endif /* InstructionSets_68k_InstructionOperandFlags_hpp */

--- a/InstructionSets/M68k/Implementation/InstructionOperandSize.hpp
+++ b/InstructionSets/M68k/Implementation/InstructionOperandSize.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2022 Thomas Harte. All rights reserved.
 //
 
-#ifndef InstructionSets_68k_InstructionOperandSize_hpp
-#define InstructionSets_68k_InstructionOperandSize_hpp
+#pragma once
 
 namespace InstructionSet::M68k {
 
@@ -128,5 +127,3 @@ constexpr DataSize operand_size(Operation r_operation) {
 }
 
 }
-
-#endif /* InstructionSets_68k_InstructionOperandSize_hpp */

--- a/InstructionSets/M68k/Implementation/PerformImplementation.hpp
+++ b/InstructionSets/M68k/Implementation/PerformImplementation.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2022 Thomas Harte. All rights reserved.
 //
 
-#ifndef InstructionSets_M68k_PerformImplementation_h
-#define InstructionSets_M68k_PerformImplementation_h
+#pragma once
 
 #include "../../../Numeric/Carry.hpp"
 #include "../ExceptionVectors.hpp"
@@ -1004,5 +1003,3 @@ template <
 }
 
 }
-
-#endif /* InstructionSets_M68k_PerformImplementation_h */

--- a/InstructionSets/M68k/Instruction.hpp
+++ b/InstructionSets/M68k/Instruction.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2022 Thomas Harte. All rights reserved.
 //
 
-#ifndef InstructionSets_68k_Instruction_hpp
-#define InstructionSets_68k_Instruction_hpp
+#pragma once
 
 #include "Model.hpp"
 
@@ -497,5 +496,3 @@ class Preinstruction {
 
 #include "Implementation/InstructionOperandSize.hpp"
 #include "Implementation/InstructionOperandFlags.hpp"
-
-#endif /* InstructionSets_68k_Instruction_hpp */

--- a/InstructionSets/M68k/Model.hpp
+++ b/InstructionSets/M68k/Model.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2022 Thomas Harte. All rights reserved.
 //
 
-#ifndef InstructionSets_M68k_Model_hpp
-#define InstructionSets_M68k_Model_hpp
+#pragma once
 
 namespace InstructionSet::M68k {
 
@@ -20,5 +19,3 @@ enum class Model {
 };
 
 }
-
-#endif /* InstructionSets_M68k_Model_hpp */

--- a/InstructionSets/M68k/Perform.hpp
+++ b/InstructionSets/M68k/Perform.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2022 Thomas Harte. All rights reserved.
 //
 
-#ifndef InstructionSets_M68k_Perform_h
-#define InstructionSets_M68k_Perform_h
+#pragma once
 
 #include "Model.hpp"
 #include "Instruction.hpp"
@@ -169,5 +168,3 @@ template <
 }
 
 #include "Implementation/PerformImplementation.hpp"
-
-#endif /* InstructionSets_M68k_Perform_h */

--- a/InstructionSets/M68k/RegisterSet.hpp
+++ b/InstructionSets/M68k/RegisterSet.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2022 Thomas Harte. All rights reserved.
 //
 
-#ifndef InstructionSets_M68k_RegisterSet_h
-#define InstructionSets_M68k_RegisterSet_h
+#pragma once
 
 namespace InstructionSet::M68k {
 
@@ -25,5 +24,3 @@ struct RegisterSet {
 };
 
 }
-
-#endif /* InstructionSets_M68k_RegisterSet_h */

--- a/InstructionSets/M68k/Status.hpp
+++ b/InstructionSets/M68k/Status.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2022 Thomas Harte. All rights reserved.
 //
 
-#ifndef InstructionSets_M68k_Status_h
-#define InstructionSets_M68k_Status_h
+#pragma once
 
 #include "Instruction.hpp"
 
@@ -159,5 +158,3 @@ struct Status {
 };
 
 }
-
-#endif /* InstructionSets_M68k_Status_h */

--- a/InstructionSets/PowerPC/Decoder.hpp
+++ b/InstructionSets/PowerPC/Decoder.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2020 Thomas Harte. All rights reserved.
 //
 
-#ifndef InstructionSets_PowerPC_Decoder_hpp
-#define InstructionSets_PowerPC_Decoder_hpp
+#pragma once
 
 #include "Instruction.hpp"
 
@@ -50,5 +49,3 @@ template <Model model, bool validate_reserved_bits = false> struct Decoder {
 };
 
 }
-
-#endif /* InstructionSets_PowerPC_Decoder_hpp */

--- a/InstructionSets/PowerPC/Instruction.hpp
+++ b/InstructionSets/PowerPC/Instruction.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef InstructionSets_PowerPC_Instruction_h
-#define InstructionSets_PowerPC_Instruction_h
+#pragma once
 
 #include <cstdint>
 
@@ -1530,5 +1529,3 @@ struct Instruction {
 static_assert(sizeof(Instruction) <= 8);
 
 }
-
-#endif /* InstructionSets_PowerPC_Instruction_h */

--- a/InstructionSets/x86/AccessType.hpp
+++ b/InstructionSets/x86/AccessType.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef AccessType_h
-#define AccessType_h
+#pragma once
 
 namespace InstructionSet::x86 {
 
@@ -62,5 +61,3 @@ template<typename IntT> using modify_t = typename Accessor<IntT, AccessType::Rea
 template<typename IntT, AccessType type> using access_t = typename Accessor<IntT, type>::type;
 
 }
-
-#endif /* AccessType_h */

--- a/InstructionSets/x86/Decoder.hpp
+++ b/InstructionSets/x86/Decoder.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef InstructionSets_x86_Decoder_hpp
-#define InstructionSets_x86_Decoder_hpp
+#pragma once
 
 #include "Instruction.hpp"
 #include "Model.hpp"
@@ -242,5 +241,3 @@ class Decoder8086 {
 };
 
 }
-
-#endif /* InstructionSets_x86_Decoder_hpp */

--- a/InstructionSets/x86/Flags.hpp
+++ b/InstructionSets/x86/Flags.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef InstructionSets_x86_Flags_hpp
-#define InstructionSets_x86_Flags_hpp
+#pragma once
 
 #include "../../Numeric/Carry.hpp"
 
@@ -229,5 +228,3 @@ class Flags {
 };
 
 }
-
-#endif /* InstructionSets_x86_Flags_hpp */

--- a/InstructionSets/x86/Implementation/Arithmetic.hpp
+++ b/InstructionSets/x86/Implementation/Arithmetic.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef Arithmetic_hpp
-#define Arithmetic_hpp
+#pragma once
 
 #include "../AccessType.hpp"
 #include "../Interrupts.hpp"
@@ -361,5 +360,3 @@ void neg(
 }
 
 }
-
-#endif /* Arithmetic_hpp */

--- a/InstructionSets/x86/Implementation/BCD.hpp
+++ b/InstructionSets/x86/Implementation/BCD.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef BCD_h
-#define BCD_h
+#pragma once
 
 #include "../AccessType.hpp"
 
@@ -112,5 +111,3 @@ void daas(
 }
 
 }
-
-#endif /* BCD_h */

--- a/InstructionSets/x86/Implementation/FlowControl.hpp
+++ b/InstructionSets/x86/Implementation/FlowControl.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef FlowControl_hpp
-#define FlowControl_hpp
+#pragma once
 
 #include "Resolver.hpp"
 #include "Stack.hpp"
@@ -244,5 +243,3 @@ void bound(
 }
 
 }
-
-#endif /* FlowControl_hpp */

--- a/InstructionSets/x86/Implementation/InOut.hpp
+++ b/InstructionSets/x86/Implementation/InOut.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef InOut_h
-#define InOut_h
+#pragma once
 
 #include "../AccessType.hpp"
 
@@ -32,5 +31,3 @@ void in(
 }
 
 }
-
-#endif /* InOut_h */

--- a/InstructionSets/x86/Implementation/LoadStore.hpp
+++ b/InstructionSets/x86/Implementation/LoadStore.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef LoadStore_h
-#define LoadStore_h
+#pragma once
 
 #include "../AccessType.hpp"
 
@@ -79,5 +78,3 @@ void mov(
 }
 
 }
-
-#endif /* LoadStore_h */

--- a/InstructionSets/x86/Implementation/Logical.hpp
+++ b/InstructionSets/x86/Implementation/Logical.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef Logical_h
-#define Logical_h
+#pragma once
 
 #include "../AccessType.hpp"
 
@@ -142,5 +141,3 @@ void setmo(
 }
 
 }
-
-#endif /* Logical_h */

--- a/InstructionSets/x86/Implementation/PerformImplementation.hpp
+++ b/InstructionSets/x86/Implementation/PerformImplementation.hpp
@@ -7,8 +7,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef PerformImplementation_h
-#define PerformImplementation_h
+#pragma once
 
 #include "Arithmetic.hpp"
 #include "BCD.hpp"
@@ -532,5 +531,3 @@ template <
 }
 
 }
-
-#endif /* PerformImplementation_h */

--- a/InstructionSets/x86/Implementation/Repetition.hpp
+++ b/InstructionSets/x86/Implementation/Repetition.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef Repetition_h
-#define Repetition_h
+#pragma once
 
 #include "../AccessType.hpp"
 
@@ -176,5 +175,3 @@ void ins(
 }
 
 }
-
-#endif /* Repetition_h */

--- a/InstructionSets/x86/Implementation/Resolver.hpp
+++ b/InstructionSets/x86/Implementation/Resolver.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef Resolver_h
-#define Resolver_h
+#pragma once
 
 #include "../AccessType.hpp"
 
@@ -205,5 +204,3 @@ typename Accessor<IntT, access>::type resolve(
 }
 
 }
-
-#endif /* Resolver_h */

--- a/InstructionSets/x86/Implementation/ShiftRoll.hpp
+++ b/InstructionSets/x86/Implementation/ShiftRoll.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef ShiftRoll_hpp
-#define ShiftRoll_hpp
+#pragma once
 
 #include "../AccessType.hpp"
 
@@ -361,5 +360,3 @@ void shr(
 }
 
 }
-
-#endif /* ShiftRoll_hpp */

--- a/InstructionSets/x86/Implementation/Stack.hpp
+++ b/InstructionSets/x86/Implementation/Stack.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef Stack_hpp
-#define Stack_hpp
+#pragma once
 
 #include "../AccessType.hpp"
 
@@ -197,5 +196,3 @@ void leave(
 }
 
 }
-
-#endif /* Stack_hpp */

--- a/InstructionSets/x86/Instruction.hpp
+++ b/InstructionSets/x86/Instruction.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef InstructionSets_x86_Instruction_h
-#define InstructionSets_x86_Instruction_h
+#pragma once
 
 #include "Model.hpp"
 
@@ -965,5 +964,3 @@ std::string to_string(
 	int immediate_length = 0);
 
 }
-
-#endif /* InstructionSets_x86_Instruction_h */

--- a/InstructionSets/x86/Interrupts.hpp
+++ b/InstructionSets/x86/Interrupts.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef InstructionSets_x86_Interrupts_h
-#define InstructionSets_x86_Interrupts_h
+#pragma once
 
 namespace InstructionSet::x86 {
 
@@ -35,5 +34,3 @@ enum Interrupt {
 };
 
 }
-
-#endif /* InstructionSets_x86_Interrupts_h */

--- a/InstructionSets/x86/Model.hpp
+++ b/InstructionSets/x86/Model.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2022 Thomas Harte. All rights reserved.
 //
 
-#ifndef Model_h
-#define Model_h
+#pragma once
 
 #include <cstdint>
 
@@ -26,5 +25,3 @@ template <bool is_32bit> struct AddressT { using type = uint16_t; };
 template <> struct AddressT<true> { using type = uint32_t; };
 
 }
-
-#endif /* Model_h */

--- a/InstructionSets/x86/Perform.hpp
+++ b/InstructionSets/x86/Perform.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef Perform_h
-#define Perform_h
+#pragma once
 
 #include "Instruction.hpp"
 #include "Model.hpp"
@@ -52,5 +51,3 @@ template <
 }
 
 #include "Implementation/PerformImplementation.hpp"
-
-#endif /* Perform_h */

--- a/Machines/Amiga/Amiga.hpp
+++ b/Machines/Amiga/Amiga.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef Amiga_hpp
-#define Amiga_hpp
+#pragma once
 
 #include "../../Analyser/Static/StaticAnalyser.hpp"
 #include "../ROMMachine.hpp"
@@ -25,5 +24,3 @@ class Machine {
 };
 
 }
-
-#endif /* Amiga_hpp */

--- a/Machines/Amiga/Audio.hpp
+++ b/Machines/Amiga/Audio.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef Audio_hpp
-#define Audio_hpp
+#pragma once
 
 #include <atomic>
 #include <cstdint>
@@ -159,5 +158,3 @@ class Audio: public DMADevice<4> {
 };
 
 }
-
-#endif /* Audio_hpp */

--- a/Machines/Amiga/Bitplanes.hpp
+++ b/Machines/Amiga/Bitplanes.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef Bitplanes_hpp
-#define Bitplanes_hpp
+#pragma once
 
 #include <cstdint>
 
@@ -98,5 +97,3 @@ class BitplaneShifter {
 };
 
 }
-
-#endif /* Bitplanes_hpp */

--- a/Machines/Amiga/Blitter.hpp
+++ b/Machines/Amiga/Blitter.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef Blitter_hpp
-#define Blitter_hpp
+#pragma once
 
 #include <cstddef>
 #include <cstdint>
@@ -129,6 +128,3 @@ template <bool record_bus = false> class Blitter: public DMADevice<4, 4> {
 };
 
 }
-
-
-#endif /* Blitter_hpp */

--- a/Machines/Amiga/BlitterSequencer.hpp
+++ b/Machines/Amiga/BlitterSequencer.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2022 Thomas Harte. All rights reserved.
 //
 
-#ifndef BlitterSequencer_hpp
-#define BlitterSequencer_hpp
+#pragma once
 
 #include <array>
 
@@ -163,5 +162,3 @@ class BlitterSequencer {
 };
 
 }
-
-#endif /* BlitterSequencer_hpp */

--- a/Machines/Amiga/Chipset.hpp
+++ b/Machines/Amiga/Chipset.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef Chipset_hpp
-#define Chipset_hpp
+#pragma once
 
 #include <algorithm>
 #include <array>
@@ -376,5 +375,3 @@ class Chipset: private ClockingHint::Observer {
 };
 
 }
-
-#endif /* Chipset_hpp */

--- a/Machines/Amiga/Copper.hpp
+++ b/Machines/Amiga/Copper.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef Copper_h
-#define Copper_h
+#pragma once
 
 #include "DMADevice.hpp"
 
@@ -50,5 +49,3 @@ class Copper: public DMADevice<2> {
 };
 
 }
-
-#endif /* Copper_h */

--- a/Machines/Amiga/DMADevice.hpp
+++ b/Machines/Amiga/DMADevice.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef DMADevice_hpp
-#define DMADevice_hpp
+#pragma once
 
 #include <array>
 #include <cstddef>
@@ -70,5 +69,3 @@ template <size_t num_addresses, size_t num_modulos = 0> class DMADevice: public 
 };
 
 }
-
-#endif /* DMADevice_hpp */

--- a/Machines/Amiga/Flags.hpp
+++ b/Machines/Amiga/Flags.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef Flags_hpp
-#define Flags_hpp
+#pragma once
 
 namespace Amiga {
 
@@ -49,5 +48,3 @@ namespace DMAFlag {
 }
 
 }
-
-#endif /* Flags_hpp */

--- a/Machines/Amiga/Keyboard.hpp
+++ b/Machines/Amiga/Keyboard.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef Machines_Amiga_Keyboard_hpp
-#define Machines_Amiga_Keyboard_hpp
+#pragma once
 
 #include <array>
 #include <cstdint>
@@ -117,5 +116,3 @@ class Keyboard {
 };
 
 }
-
-#endif /* Machines_Amiga_Keyboard_hpp */

--- a/Machines/Amiga/MemoryMap.hpp
+++ b/Machines/Amiga/MemoryMap.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef MemoryMap_hpp
-#define MemoryMap_hpp
+#pragma once
 
 #include "../../Analyser/Static/Amiga/Target.hpp"
 
@@ -193,4 +192,3 @@ class MemoryMap {
 };
 
 }
-#endif /* MemoryMap_hpp */

--- a/Machines/Amiga/Minterms.hpp
+++ b/Machines/Amiga/Minterms.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef Minterms_hpp
-#define Minterms_hpp
+#pragma once
 
 namespace Amiga {
 
@@ -383,5 +382,3 @@ template <typename IntT> IntT apply_minterm(IntT a, IntT b, IntT c, int minterm)
 }
 
 }
-
-#endif /* Minterms_hpp */

--- a/Machines/Amiga/MouseJoystick.hpp
+++ b/Machines/Amiga/MouseJoystick.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef MouseJoystick_hpp
-#define MouseJoystick_hpp
+#pragma once
 
 #include <array>
 #include <atomic>
@@ -53,5 +52,3 @@ class Joystick: public Inputs::ConcreteJoystick, public MouseJoystickInput {
 };
 
 }
-
-#endif /* MouseJoystick_hpp */

--- a/Machines/Amiga/Sprites.hpp
+++ b/Machines/Amiga/Sprites.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef Sprites_hpp
-#define Sprites_hpp
+#pragma once
 
 #include <cstdint>
 
@@ -64,7 +63,4 @@ class TwoSpriteShifter {
 		uint8_t overflow_;
 };
 
-
 }
-
-#endif /* Sprites_hpp */

--- a/Machines/AmstradCPC/AmstradCPC.hpp
+++ b/Machines/AmstradCPC/AmstradCPC.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef AmstradCPC_hpp
-#define AmstradCPC_hpp
+#pragma once
 
 #include "../../Configurable/Configurable.hpp"
 #include "../../Configurable/StandardOptions.hpp"
@@ -51,5 +50,3 @@ class Machine {
 };
 
 }
-
-#endif /* AmstradCPC_hpp */

--- a/Machines/AmstradCPC/FDC.hpp
+++ b/Machines/AmstradCPC/FDC.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef FDC_h
-#define FDC_h
+#pragma once
 
 #include "../../Components/8272/i8272.hpp"
 
@@ -47,5 +46,3 @@ class FDC: public Intel::i8272::i8272 {
 };
 
 }
-
-#endif /* FDC_h */

--- a/Machines/AmstradCPC/Keyboard.hpp
+++ b/Machines/AmstradCPC/Keyboard.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef Machines_AmstradCPC_Keyboard_hpp
-#define Machines_AmstradCPC_Keyboard_hpp
+#pragma once
 
 #include "../KeyboardMachine.hpp"
 #include "../Utility/Typer.hpp"
@@ -44,6 +43,4 @@ struct CharacterMapper: public ::Utility::CharacterMapper {
 	bool needs_pause_after_key(uint16_t key) const override;
 };
 
-};
-
-#endif /* KeyboardMapper_hpp */
+}

--- a/Machines/Apple/ADB/Bus.hpp
+++ b/Machines/Apple/ADB/Bus.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef Bus_hpp
-#define Bus_hpp
+#pragma once
 
 #include "../../../ClockReceiver/ClockReceiver.hpp"
 
@@ -166,5 +165,3 @@ class Bus {
 };
 
 }
-
-#endif /* Bus_hpp */

--- a/Machines/Apple/ADB/Keyboard.hpp
+++ b/Machines/Apple/ADB/Keyboard.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef Keyboard_hpp
-#define Keyboard_hpp
+#pragma once
 
 #include "ReactiveDevice.hpp"
 #include "../../../Inputs/Keyboard.hpp"
@@ -119,5 +118,3 @@ class KeyboardMapper: public MachineTypes::MappedKeyboardMachine::KeyboardMapper
 };
 
 }
-
-#endif /* Keyboard_hpp */

--- a/Machines/Apple/ADB/Mouse.hpp
+++ b/Machines/Apple/ADB/Mouse.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef Mouse_hpp
-#define Mouse_hpp
+#pragma once
 
 #include "ReactiveDevice.hpp"
 #include "../../../Inputs/Mouse.hpp"
@@ -32,5 +31,3 @@ class Mouse: public ReactiveDevice, public Inputs::Mouse {
 };
 
 }
-
-#endif /* Mouse_hpp */

--- a/Machines/Apple/ADB/ReactiveDevice.hpp
+++ b/Machines/Apple/ADB/ReactiveDevice.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef ReactiveDevice_hpp
-#define ReactiveDevice_hpp
+#pragma once
 
 #include "Bus.hpp"
 
@@ -60,5 +59,3 @@ class ReactiveDevice: public Bus::Device {
 };
 
 }
-
-#endif /* ReactiveDevice_hpp */

--- a/Machines/Apple/AppleII/AppleII.hpp
+++ b/Machines/Apple/AppleII/AppleII.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef AppleII_hpp
-#define AppleII_hpp
+#pragma once
 
 #include "../../../Configurable/Configurable.hpp"
 #include "../../../Configurable/StandardOptions.hpp"
@@ -42,5 +41,3 @@ class Machine {
 };
 
 }
-
-#endif /* AppleII_hpp */

--- a/Machines/Apple/AppleII/AuxiliaryMemorySwitches.hpp
+++ b/Machines/Apple/AppleII/AuxiliaryMemorySwitches.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2020 Thomas Harte. All rights reserved.
 //
 
-#ifndef AuxiliaryMemorySwitches_h
-#define AuxiliaryMemorySwitches_h
+#pragma once
 
 #include "MemorySwitches.hpp"
 
@@ -271,5 +270,3 @@ template <typename Machine> class AuxiliaryMemorySwitches {
 };
 
 }
-
-#endif /* AuxiliaryMemorySwitches_h */

--- a/Machines/Apple/AppleII/Card.hpp
+++ b/Machines/Apple/AppleII/Card.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef Card_h
-#define Card_h
+#pragma once
 
 #include "../../../Processors/6502/6502.hpp"
 #include "../../../ClockReceiver/ClockReceiver.hpp"
@@ -112,5 +111,3 @@ class Card {
 };
 
 }
-
-#endif /* Card_h */

--- a/Machines/Apple/AppleII/DiskIICard.hpp
+++ b/Machines/Apple/AppleII/DiskIICard.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef DiskIICard_hpp
-#define DiskIICard_hpp
+#pragma once
 
 #include "Card.hpp"
 #include "../../ROMMachine.hpp"
@@ -43,5 +42,3 @@ class DiskIICard: public Card, public ClockingHint::Observer {
 };
 
 }
-
-#endif /* DiskIICard_hpp */

--- a/Machines/Apple/AppleII/Joystick.hpp
+++ b/Machines/Apple/AppleII/Joystick.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef AppleII_Joystick_hpp
-#define AppleII_Joystick_hpp
+#pragma once
 
 #include "../../../Inputs/Joystick.hpp"
 
@@ -106,5 +105,3 @@ class JoystickPair {
 };
 
 }
-
-#endif /* AppleII_Joystick_hpp */

--- a/Machines/Apple/AppleII/LanguageCardSwitches.hpp
+++ b/Machines/Apple/AppleII/LanguageCardSwitches.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2020 Thomas Harte. All rights reserved.
 //
 
-#ifndef LanguageCardSwitches_h
-#define LanguageCardSwitches_h
+#pragma once
 
 #include "MemorySwitches.hpp"
 
@@ -112,5 +111,3 @@ template <typename Machine> class LanguageCardSwitches {
 };
 
 }
-
-#endif /* LanguageCard_h */

--- a/Machines/Apple/AppleII/MemorySwitches.hpp
+++ b/Machines/Apple/AppleII/MemorySwitches.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2022 Thomas Harte. All rights reserved.
 //
 
-#ifndef MemorySwitches_h
-#define MemorySwitches_h
+#pragma once
 
 namespace Apple::II {
 
@@ -19,5 +18,3 @@ enum PagingType: int {
 };
 
 }
-
-#endif /* MemorySwitches_h */

--- a/Machines/Apple/AppleII/SCSICard.hpp
+++ b/Machines/Apple/AppleII/SCSICard.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2022 Thomas Harte. All rights reserved.
 //
 
-#ifndef SCSICard_hpp
-#define SCSICard_hpp
+#pragma once
 
 #include "Card.hpp"
 #include "../../ROMMachine.hpp"
@@ -51,5 +50,3 @@ class SCSICard: public Card {
 };
 
 }
-
-#endif /* SCSICard_hpp */

--- a/Machines/Apple/AppleII/Video.hpp
+++ b/Machines/Apple/AppleII/Video.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef Apple_II_Video_hpp
-#define Apple_II_Video_hpp
+#pragma once
 
 #include "../../../Outputs/CRT/CRT.hpp"
 #include "../../../ClockReceiver/ClockReceiver.hpp"
@@ -512,5 +511,3 @@ template <class BusHandler, bool is_iie> class Video: public VideoBase {
 };
 
 }
-
-#endif /* Apple_II_Video_hpp */

--- a/Machines/Apple/AppleII/VideoSwitches.hpp
+++ b/Machines/Apple/AppleII/VideoSwitches.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2020 Thomas Harte. All rights reserved.
 //
 
-#ifndef VideoSwitches_h
-#define VideoSwitches_h
+#pragma once
 
 #include "../../../ClockReceiver/ClockReceiver.hpp"
 #include "../../../ClockReceiver/DeferredQueue.hpp"
@@ -343,5 +342,3 @@ template <typename TimeUnit> class VideoSwitches {
 };
 
 }
-
-#endif /* VideoSwitches_h */

--- a/Machines/Apple/AppleIIgs/ADB.hpp
+++ b/Machines/Apple/AppleIIgs/ADB.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2020 Thomas Harte. All rights reserved.
 //
 
-#ifndef Apple_IIgs_ADB_hpp
-#define Apple_IIgs_ADB_hpp
+#pragma once
 
 #include <cstdint>
 #include <vector>
@@ -84,5 +83,3 @@ class GLU: public InstructionSet::M50740::PortHandler {
 };
 
 }
-
-#endif /* Apple_IIgs_ADB_hpp */

--- a/Machines/Apple/AppleIIgs/AppleIIgs.hpp
+++ b/Machines/Apple/AppleIIgs/AppleIIgs.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2020 Thomas Harte. All rights reserved.
 //
 
-#ifndef Machines_Apple_AppleIIgs_hpp
-#define Machines_Apple_AppleIIgs_hpp
+#pragma once
 
 #include "../../../Configurable/Configurable.hpp"
 #include "../../../Configurable/StandardOptions.hpp"
@@ -27,5 +26,3 @@ class Machine {
 };
 
 }
-
-#endif /* Machines_Apple_AppleIIgs_hpp */

--- a/Machines/Apple/AppleIIgs/MemoryMap.hpp
+++ b/Machines/Apple/AppleIIgs/MemoryMap.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2020 Thomas Harte. All rights reserved.
 //
 
-#ifndef Machines_Apple_AppleIIgs_MemoryMap_hpp
-#define Machines_Apple_AppleIIgs_MemoryMap_hpp
+#pragma once
 
 #include <array>
 #include <bitset>
@@ -161,5 +160,3 @@ class MemoryMap {
 };
 
 }
-
-#endif /* MemoryMap_h */

--- a/Machines/Apple/AppleIIgs/Sound.hpp
+++ b/Machines/Apple/AppleIIgs/Sound.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2020 Thomas Harte. All rights reserved.
 //
 
-#ifndef Apple_IIgs_Sound_hpp
-#define Apple_IIgs_Sound_hpp
+#pragma once
 
 #include <atomic>
 
@@ -103,5 +102,3 @@ class GLU: public Outputs::Speaker::SampleSource {
 };
 
 }
-
-#endif /* SoundGLU_hpp */

--- a/Machines/Apple/AppleIIgs/Video.cpp
+++ b/Machines/Apple/AppleIIgs/Video.cpp
@@ -22,31 +22,31 @@ constexpr auto FinalColumn = CyclesPerLine / CyclesPerTick;
 
 // Converts from Apple's RGB ordering to this emulator's.
 #if TARGET_RT_BIG_ENDIAN
-#define PaletteConvulve(x)	uint16_t(x)
+constexpr uint16_t convulve(uint16_t x) { return x; }
 #else
-#define PaletteConvulve(x)	uint16_t(((x&0xf00) >> 8) | ((x&0x0ff) << 8))
+constexpr uint16_t convulve(uint16_t x) { return uint16_t(((x&0xf00) >> 8) | ((x&0x0ff) << 8)); }
 #endif
 
 // The 12-bit values used by the Apple IIgs to approximate Apple II colours,
 // as implied by tech note #63's use of them as border colours.
 // http://www.1000bit.it/support/manuali/apple/technotes/iigs/tn.iigs.063.html
 constexpr uint16_t appleii_palette[16] = {
-	PaletteConvulve(0x0000),	// Black.
-	PaletteConvulve(0x0d03),	// Deep Red.
-	PaletteConvulve(0x0009),	// Dark Blue.
-	PaletteConvulve(0x0d2d),	// Purple.
-	PaletteConvulve(0x0072),	// Dark Green.
-	PaletteConvulve(0x0555),	// Dark Gray.
-	PaletteConvulve(0x022f),	// Medium Blue.
-	PaletteConvulve(0x06af),	// Light Blue.
-	PaletteConvulve(0x0850),	// Brown.
-	PaletteConvulve(0x0f60),	// Orange.
-	PaletteConvulve(0x0aaa),	// Light Grey.
-	PaletteConvulve(0x0f98),	// Pink.
-	PaletteConvulve(0x01d0),	// Light Green.
-	PaletteConvulve(0x0ff0),	// Yellow.
-	PaletteConvulve(0x04f9),	// Aquamarine.
-	PaletteConvulve(0x0fff),	// White.
+	convulve(0x0000),	// Black.
+	convulve(0x0d03),	// Deep Red.
+	convulve(0x0009),	// Dark Blue.
+	convulve(0x0d2d),	// Purple.
+	convulve(0x0072),	// Dark Green.
+	convulve(0x0555),	// Dark Gray.
+	convulve(0x022f),	// Medium Blue.
+	convulve(0x06af),	// Light Blue.
+	convulve(0x0850),	// Brown.
+	convulve(0x0f60),	// Orange.
+	convulve(0x0aaa),	// Light Grey.
+	convulve(0x0f98),	// Pink.
+	convulve(0x01d0),	// Light Green.
+	convulve(0x0ff0),	// Yellow.
+	convulve(0x04f9),	// Aquamarine.
+	convulve(0x0fff),	// White.
 };
 
 // Reasoned guesswork ahoy!
@@ -280,7 +280,7 @@ void Video::output_row(int row, int start, int end) {
 				const int palette_base = (line_control_ & 15) * 32 + 0x19e00;
 				for(int c = 0; c < 16; c++) {
 					const int entry = ram_[palette_base + (c << 1)] | (ram_[palette_base + (c << 1) + 1] << 8);
-					palette_[c] = PaletteConvulve(entry);
+					palette_[c] = convulve(entry);
 				}
 
 				// Post an interrupt if requested.

--- a/Machines/Apple/AppleIIgs/Video.hpp
+++ b/Machines/Apple/AppleIIgs/Video.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2020 Thomas Harte. All rights reserved.
 //
 
-#ifndef Apple_IIgs_Video_hpp
-#define Apple_IIgs_Video_hpp
+#pragma once
 
 #include "../AppleII/VideoSwitches.hpp"
 #include "../../../Outputs/CRT/CRT.hpp"
@@ -252,6 +251,3 @@ class Video: public Apple::II::VideoSwitches<Cycles> {
 };
 
 }
-
-#endif /* Video_hpp */
-

--- a/Machines/Apple/Macintosh/Audio.hpp
+++ b/Machines/Apple/Macintosh/Audio.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
-#ifndef Audio_hpp
-#define Audio_hpp
+#pragma once
 
 #include "../../../Concurrency/AsyncTaskQueue.hpp"
 #include "../../../ClockReceiver/ClockReceiver.hpp"
@@ -83,5 +82,3 @@ class Audio: public ::Outputs::Speaker::SampleSource {
 };
 
 }
-
-#endif /* Audio_hpp */

--- a/Machines/Apple/Macintosh/DeferredAudio.hpp
+++ b/Machines/Apple/Macintosh/DeferredAudio.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
-#ifndef DeferredAudio_h
-#define DeferredAudio_h
+#pragma once
 
 #include "Audio.hpp"
 #include "../../../Outputs/Speaker/Implementation/LowpassSpeaker.hpp"
@@ -28,5 +27,3 @@ struct DeferredAudio {
 };
 
 }
-
-#endif /* DeferredAudio_h */

--- a/Machines/Apple/Macintosh/DriveSpeedAccumulator.hpp
+++ b/Machines/Apple/Macintosh/DriveSpeedAccumulator.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
-#ifndef DriveSpeedAccumulator_hpp
-#define DriveSpeedAccumulator_hpp
+#pragma once
 
 #include <array>
 #include <cstddef>
@@ -40,5 +39,3 @@ class DriveSpeedAccumulator {
 };
 
 }
-
-#endif /* DriveSpeedAccumulator_hpp */

--- a/Machines/Apple/Macintosh/Keyboard.hpp
+++ b/Machines/Apple/Macintosh/Keyboard.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
-#ifndef Apple_Macintosh_Keyboard_hpp
-#define Apple_Macintosh_Keyboard_hpp
+#pragma once
 
 #include "../../KeyboardMachine.hpp"
 #include "../../../ClockReceiver/ClockReceiver.hpp"
@@ -294,5 +293,3 @@ class KeyboardMapper: public MachineTypes::MappedKeyboardMachine::KeyboardMapper
 };
 
 }
-
-#endif /* Apple_Macintosh_Keyboard_hpp */

--- a/Machines/Apple/Macintosh/Macintosh.hpp
+++ b/Machines/Apple/Macintosh/Macintosh.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
-#ifndef Macintosh_hpp
-#define Macintosh_hpp
+#pragma once
 
 #include "../../../Configurable/Configurable.hpp"
 #include "../../../Configurable/StandardOptions.hpp"
@@ -36,5 +35,3 @@ class Machine {
 };
 
 }
-
-#endif /* Macintosh_hpp */

--- a/Machines/Apple/Macintosh/Video.hpp
+++ b/Machines/Apple/Macintosh/Video.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
-#ifndef Video_hpp
-#define Video_hpp
+#pragma once
 
 #include "../../../Outputs/CRT/CRT.hpp"
 #include "../../../ClockReceiver/ClockReceiver.hpp"
@@ -102,5 +101,3 @@ class Video {
 };
 
 }
-
-#endif /* Video_hpp */

--- a/Machines/Atari/2600/Atari2600.hpp
+++ b/Machines/Atari/2600/Atari2600.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2015 Thomas Harte. All rights reserved.
 //
 
-#ifndef Atari2600_cpp
-#define Atari2600_cpp
+#pragma once
 
 #include "../../../Configurable/Configurable.hpp"
 #include "../../../Analyser/Static/StaticAnalyser.hpp"
@@ -40,5 +39,3 @@ class Machine {
 };
 
 }
-
-#endif /* Atari2600_cpp */

--- a/Machines/Atari/2600/Atari2600Inputs.h
+++ b/Machines/Atari/2600/Atari2600Inputs.h
@@ -6,8 +6,7 @@
 //  Copyright 2015 Thomas Harte. All rights reserved.
 //
 
-#ifndef Atari2600Inputs_h
-#define Atari2600Inputs_h
+#pragma once
 
 #ifdef __cplusplus
 extern "C" {
@@ -38,5 +37,3 @@ typedef enum {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* Atari2600Inputs_h */

--- a/Machines/Atari/2600/Bus.hpp
+++ b/Machines/Atari/2600/Bus.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef Atari2600_Bus_hpp
-#define Atari2600_Bus_hpp
+#pragma once
 
 #include "Atari2600.hpp"
 #include "PIA.hpp"
@@ -67,5 +66,3 @@ class Bus {
 };
 
 }
-
-#endif /* Atari2600_Bus_hpp */

--- a/Machines/Atari/2600/Cartridges/ActivisionStack.hpp
+++ b/Machines/Atari/2600/Cartridges/ActivisionStack.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef Atari2600_ActivisionStack_hpp
-#define Atari2600_ActivisionStack_hpp
+#pragma once
 
 namespace Atari2600::Cartridge {
 
@@ -45,5 +44,3 @@ class ActivisionStack: public BusExtender {
 };
 
 }
-
-#endif /* Atari2600_CartridgeActivisionStack_hpp */

--- a/Machines/Atari/2600/Cartridges/Atari16k.hpp
+++ b/Machines/Atari/2600/Cartridges/Atari16k.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef Atari2600_CartridgeAtari16k_hpp
-#define Atari2600_CartridgeAtari16k_hpp
+#pragma once
 
 #include "Cartridge.hpp"
 
@@ -60,5 +59,3 @@ class Atari16kSuperChip: public BusExtender {
 };
 
 }
-
-#endif /* Atari2600_CartridgeAtari16k_hpp */

--- a/Machines/Atari/2600/Cartridges/Atari32k.hpp
+++ b/Machines/Atari/2600/Cartridges/Atari32k.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef Atari2600_CartridgeAtari32k_hpp
-#define Atari2600_CartridgeAtari32k_hpp
+#pragma once
 
 #include "Cartridge.hpp"
 
@@ -56,5 +55,3 @@ class Atari32kSuperChip: public BusExtender {
 };
 
 }
-
-#endif /* Atari2600_CartridgeAtari32k_hpp */

--- a/Machines/Atari/2600/Cartridges/Atari8k.hpp
+++ b/Machines/Atari/2600/Cartridges/Atari8k.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef Atari2600_CartridgeAtari8k_hpp
-#define Atari2600_CartridgeAtari8k_hpp
+#pragma once
 
 #include "Cartridge.hpp"
 
@@ -58,5 +57,3 @@ class Atari8kSuperChip: public BusExtender {
 };
 
 }
-
-#endif /* Atari2600_CartridgeAtari8k_hpp */

--- a/Machines/Atari/2600/Cartridges/CBSRAMPlus.hpp
+++ b/Machines/Atari/2600/Cartridges/CBSRAMPlus.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef Atari2600_CartridgeCBSRAMPlus_hpp
-#define Atari2600_CartridgeCBSRAMPlus_hpp
+#pragma once
 
 #include "Cartridge.hpp"
 
@@ -37,5 +36,3 @@ class CBSRAMPlus: public BusExtender {
 };
 
 }
-
-#endif /* Atari2600_CartridgeCBSRAMPlus_hpp */

--- a/Machines/Atari/2600/Cartridges/Cartridge.hpp
+++ b/Machines/Atari/2600/Cartridges/Cartridge.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef Atari2600_Cartridge_hpp
-#define Atari2600_Cartridge_hpp
+#pragma once
 
 #include "../../../../Processors/6502/6502.hpp"
 #include "../Bus.hpp"
@@ -214,5 +213,3 @@ template<class T> class Cartridge:
 };
 
 }
-
-#endif /* Atari2600_Cartridge_hpp */

--- a/Machines/Atari/2600/Cartridges/CommaVid.hpp
+++ b/Machines/Atari/2600/Cartridges/CommaVid.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef Atari2600_CartridgeCommaVid_hpp
-#define Atari2600_CartridgeCommaVid_hpp
+#pragma once
 
 #include "Cartridge.hpp"
 
@@ -39,5 +38,3 @@ class CommaVid: public BusExtender {
 };
 
 }
-
-#endif /* Atari2600_CartridgeCommaVid_hpp */

--- a/Machines/Atari/2600/Cartridges/MNetwork.hpp
+++ b/Machines/Atari/2600/Cartridges/MNetwork.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef Atari2600_CartridgeMNetwork_hpp
-#define Atari2600_CartridgeMNetwork_hpp
+#pragma once
 
 #include "Cartridge.hpp"
 
@@ -63,5 +62,3 @@ class MNetwork: public BusExtender {
 };
 
 }
-
-#endif /* Atari2600_CartridgeMNetwork_hpp */

--- a/Machines/Atari/2600/Cartridges/MegaBoy.hpp
+++ b/Machines/Atari/2600/Cartridges/MegaBoy.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef Atari2600_CartridgeMegaBoy_hpp
-#define Atari2600_CartridgeMegaBoy_hpp
+#pragma once
 
 #include "Cartridge.hpp"
 
@@ -41,5 +40,3 @@ class MegaBoy: public BusExtender {
 };
 
 }
-
-#endif /* CartridgeMegaBoy_h */

--- a/Machines/Atari/2600/Cartridges/ParkerBros.hpp
+++ b/Machines/Atari/2600/Cartridges/ParkerBros.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef Atari2600_CartridgeParkerBros_hpp
-#define Atari2600_CartridgeParkerBros_hpp
+#pragma once
 
 #include "Cartridge.hpp"
 
@@ -42,5 +41,3 @@ class ParkerBros: public BusExtender {
 };
 
 }
-
-#endif /* Atari2600_CartridgeParkerBros_hpp */

--- a/Machines/Atari/2600/Cartridges/Pitfall2.hpp
+++ b/Machines/Atari/2600/Cartridges/Pitfall2.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef Atari2600_CartridgePitfall2_hpp
-#define Atari2600_CartridgePitfall2_hpp
+#pragma once
 
 namespace Atari2600::Cartridge {
 
@@ -123,5 +122,3 @@ class Pitfall2: public BusExtender {
 };
 
 }
-
-#endif /* Atari2600_CartridgePitfall2_hpp */

--- a/Machines/Atari/2600/Cartridges/Tigervision.hpp
+++ b/Machines/Atari/2600/Cartridges/Tigervision.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef Atari2600_CartridgeTigervision_hpp
-#define Atari2600_CartridgeTigervision_hpp
+#pragma once
 
 #include "Cartridge.hpp"
 
@@ -36,5 +35,3 @@ class Tigervision: public BusExtender {
 };
 
 }
-
-#endif /* Atari2600_CartridgeTigervision_hpp */

--- a/Machines/Atari/2600/Cartridges/Unpaged.hpp
+++ b/Machines/Atari/2600/Cartridges/Unpaged.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef Atari2600_CartridgeUnpaged_hpp
-#define Atari2600_CartridgeUnpaged_hpp
+#pragma once
 
 #include "Cartridge.hpp"
 
@@ -25,5 +24,3 @@ class Unpaged: public BusExtender {
 };
 
 }
-
-#endif /* Atari2600_CartridgeUnpaged_hpp */

--- a/Machines/Atari/2600/PIA.hpp
+++ b/Machines/Atari/2600/PIA.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef Atari2600_PIA_h
-#define Atari2600_PIA_h
+#pragma once
 
 #include <cstdint>
 
@@ -36,5 +35,3 @@ class PIA: public MOS::MOS6532<PIA> {
 };
 
 }
-
-#endif /* PIA_h */

--- a/Machines/Atari/2600/TIA.hpp
+++ b/Machines/Atari/2600/TIA.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef TIA_hpp
-#define TIA_hpp
+#pragma once
 
 #include <algorithm>
 #include <array>
@@ -313,5 +312,3 @@ class TIA {
 };
 
 }
-
-#endif /* TIA_hpp */

--- a/Machines/Atari/2600/TIASound.hpp
+++ b/Machines/Atari/2600/TIASound.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef Atari2600_TIASound_hpp
-#define Atari2600_TIASound_hpp
+#pragma once
 
 #include "../../../Outputs/Speaker/Implementation/SampleSource.hpp"
 #include "../../../Concurrency/AsyncTaskQueue.hpp"
@@ -48,5 +47,3 @@ class TIASound: public Outputs::Speaker::SampleSource {
 };
 
 }
-
-#endif /* Speaker_hpp */

--- a/Machines/Atari/ST/AtariST.hpp
+++ b/Machines/Atari/ST/AtariST.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
-#ifndef AtariST_hpp
-#define AtariST_hpp
+#pragma once
 
 #include "../../../Configurable/Configurable.hpp"
 #include "../../../Configurable/StandardOptions.hpp"
@@ -38,5 +37,3 @@ class Machine {
 };
 
 }
-
-#endif /* AtariST_hpp */

--- a/Machines/Atari/ST/DMAController.cpp
+++ b/Machines/Atari/ST/DMAController.cpp
@@ -191,10 +191,10 @@ int DMAController::bus_grant(uint16_t *ram, size_t size) {
 		// Check that the older buffer is full; stop if not.
 		if(!buffer_[active_buffer_ ^ 1].is_full) return 0;
 
-#define b(i, n) " " << PADHEX(2) << int(buffer_[i].contents[n])
-#define b2(i, n) b(i, n) << b(i, n+1)
-#define b4(i, n) b2(i, n) << b2(i, n+2)
-#define b16(i) b4(i, 0) << b4(i, 4) << b4(i, 8) << b4(i, 12)
+//#define b(i, n) " " << PADHEX(2) << int(buffer_[i].contents[n])
+//#define b2(i, n) b(i, n) << b(i, n+1)
+//#define b4(i, n) b2(i, n) << b2(i, n+2)
+//#define b16(i) b4(i, 0) << b4(i, 4) << b4(i, 8) << b4(i, 12)
 //		LOG("[1] to " << PADHEX(6) << address_ << b16(active_buffer_ ^ 1));
 
 		for(int c = 0; c < 8; ++c) {
@@ -212,10 +212,10 @@ int DMAController::bus_grant(uint16_t *ram, size_t size) {
 		if(!buffer_[active_buffer_ ].is_full) return 8;
 
 //		LOG("[2] to " << PADHEX(6) << address_ << b16(active_buffer_));
-#undef b16
-#undef b4
-#undef b2
-#undef b
+//#undef b16
+//#undef b4
+//#undef b2
+//#undef b
 
 		for(int c = 0; c < 8; ++c) {
 			if(size_t(address_) < size) {

--- a/Machines/Atari/ST/DMAController.hpp
+++ b/Machines/Atari/ST/DMAController.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
-#ifndef DMAController_hpp
-#define DMAController_hpp
+#pragma once
 
 #include <cstdint>
 #include <vector>
@@ -110,5 +109,3 @@ class DMAController: public WD::WD1770::Delegate, public ClockingHint::Source, p
 };
 
 }
-
-#endif /* DMAController_hpp */

--- a/Machines/Atari/ST/IntelligentKeyboard.hpp
+++ b/Machines/Atari/ST/IntelligentKeyboard.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
-#ifndef IntelligentKeyboard_hpp
-#define IntelligentKeyboard_hpp
+#pragma once
 
 #include "../../../ClockReceiver/ClockingHintSource.hpp"
 #include "../../../Components/Serial/Line.hpp"
@@ -196,5 +195,3 @@ class IntelligentKeyboard:
 };
 
 }
-
-#endif /* IntelligentKeyboard_hpp */

--- a/Machines/Atari/ST/Video.hpp
+++ b/Machines/Atari/ST/Video.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
-#ifndef Atari_ST_Video_hpp
-#define Atari_ST_Video_hpp
+#pragma once
 
 #include "../../../Outputs/CRT/CRT.hpp"
 #include "../../../ClockReceiver/ClockReceiver.hpp"
@@ -249,5 +248,3 @@ class Video {
 };
 
 }
-
-#endif /* Atari_ST_Video_hpp */

--- a/Machines/AudioProducer.hpp
+++ b/Machines/AudioProducer.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2020 Thomas Harte. All rights reserved.
 //
 
-#ifndef AudioProducer_h
-#define AudioProducer_h
+#pragma once
 
 #include "../Outputs/Speaker/Speaker.hpp"
 
@@ -23,5 +22,3 @@ class AudioProducer {
 };
 
 }
-
-#endif /* AudioProducer_h */

--- a/Machines/ColecoVision/ColecoVision.hpp
+++ b/Machines/ColecoVision/ColecoVision.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef ColecoVision_hpp
-#define ColecoVision_hpp
+#pragma once
 
 #include "../../Configurable/Configurable.hpp"
 #include "../../Configurable/StandardOptions.hpp"
@@ -37,5 +36,3 @@ class Machine {
 };
 
 }
-
-#endif /* ColecoVision_hpp */

--- a/Machines/Commodore/1540/C1540.hpp
+++ b/Machines/Commodore/1540/C1540.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef Commodore1540_hpp
-#define Commodore1540_hpp
+#pragma once
 
 namespace Commodore::C1540 {
 
@@ -54,5 +53,3 @@ class Machine final: public MachineBase {
 };
 
 }
-
-#endif /* Commodore1540_hpp */

--- a/Machines/Commodore/1540/Implementation/C1540Base.hpp
+++ b/Machines/Commodore/1540/Implementation/C1540Base.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef C1540Base_hpp
-#define C1540Base_hpp
+#pragma once
 
 #include "../../../../Processors/6502/6502.hpp"
 #include "../../../../Components/6522/6522.hpp"
@@ -160,5 +159,3 @@ class MachineBase:
 };
 
 }
-
-#endif /* C1540Base_hpp */

--- a/Machines/Commodore/SerialBus.hpp
+++ b/Machines/Commodore/SerialBus.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef SerialBus_hpp
-#define SerialBus_hpp
+#pragma once
 
 #include <cstdint>
 #include <memory>
@@ -127,5 +126,3 @@ namespace Commodore::Serial {
 	};
 
 }
-
-#endif /* SerialPort_hpp */

--- a/Machines/Commodore/Vic-20/Keyboard.hpp
+++ b/Machines/Commodore/Vic-20/Keyboard.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef Machines_Commodore_Vic20_Keyboard_hpp
-#define Machines_Commodore_Vic20_Keyboard_hpp
+#pragma once
 
 #include "../../KeyboardMachine.hpp"
 #include "../../Utility/Typer.hpp"
@@ -55,5 +54,3 @@ struct CharacterMapper: public ::Utility::CharacterMapper {
 };
 
 }
-
-#endif /* Keyboard_hpp */

--- a/Machines/Commodore/Vic-20/Vic20.hpp
+++ b/Machines/Commodore/Vic-20/Vic20.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef Vic20_hpp
-#define Vic20_hpp
+#pragma once
 
 #include "../../../Configurable/Configurable.hpp"
 #include "../../../Configurable/StandardOptions.hpp"
@@ -45,5 +44,3 @@ class Machine {
 };
 
 }
-
-#endif /* Vic20_hpp */

--- a/Machines/DynamicMachine.hpp
+++ b/Machines/DynamicMachine.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef DynamicMachine_h
-#define DynamicMachine_h
+#pragma once
 
 #include "../Configurable/Configurable.hpp"
 #include "../Activity/Source.hpp"
@@ -70,5 +69,3 @@ SpecialisedGet(MachineTypes::MediaTarget, media_target)
 #undef SpecialisedGet
 
 }
-
-#endif /* DynamicMachine_h */

--- a/Machines/Electron/Electron.hpp
+++ b/Machines/Electron/Electron.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef Electron_hpp
-#define Electron_hpp
+#pragma once
 
 #include "../../Configurable/Configurable.hpp"
 #include "../../Configurable/StandardOptions.hpp"
@@ -49,5 +48,3 @@ class Machine {
 };
 
 }
-
-#endif /* Electron_hpp */

--- a/Machines/Electron/Interrupts.hpp
+++ b/Machines/Electron/Interrupts.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef Interrupts_h
-#define Interrupts_h
+#pragma once
 
 #include <cstdint>
 
@@ -23,5 +22,3 @@ enum Interrupt: uint8_t {
 };
 
 }
-
-#endif /* Interrupts_h */

--- a/Machines/Electron/Keyboard.hpp
+++ b/Machines/Electron/Keyboard.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef Machines_Electron_Keyboard_hpp
-#define Machines_Electron_Keyboard_hpp
+#pragma once
 
 #include "../KeyboardMachine.hpp"
 #include "../Utility/Typer.hpp"
@@ -52,5 +51,3 @@ struct CharacterMapper: public ::Utility::CharacterMapper {
 };
 
 };
-
-#endif /* KeyboardMapper_hpp */

--- a/Machines/Electron/Plus3.hpp
+++ b/Machines/Electron/Plus3.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef Plus3_hpp
-#define Plus3_hpp
+#pragma once
 
 #include "../../Components/1770/1770.hpp"
 #include "../../Activity/Observer.hpp"
@@ -31,6 +30,3 @@ class Plus3 final : public WD::WD1770 {
 };
 
 }
-
-#endif /* Plus3_hpp */
-

--- a/Machines/Electron/SoundGenerator.hpp
+++ b/Machines/Electron/SoundGenerator.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef Electron_SoundGenerator_hpp
-#define Electron_SoundGenerator_hpp
+#pragma once
 
 #include "../../Outputs/Speaker/Implementation/SampleSource.hpp"
 #include "../../Concurrency/AsyncTaskQueue.hpp"
@@ -39,5 +38,3 @@ class SoundGenerator: public ::Outputs::Speaker::SampleSource {
 };
 
 }
-
-#endif /* Speaker_hpp */

--- a/Machines/Electron/Tape.hpp
+++ b/Machines/Electron/Tape.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef Electron_Tape_h
-#define Electron_Tape_h
+#pragma once
 
 #include <cstdint>
 
@@ -74,5 +73,3 @@ class Tape:
 };
 
 }
-
-#endif /* Electron_Tape_h */

--- a/Machines/Electron/Video.hpp
+++ b/Machines/Electron/Video.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef Machines_Electron_Video_hpp
-#define Machines_Electron_Video_hpp
+#pragma once
 
 #include "../../Outputs/CRT/CRT.hpp"
 #include "../../ClockReceiver/ClockReceiver.hpp"
@@ -137,5 +136,3 @@ class VideoOutput {
 };
 
 }
-
-#endif /* Video_hpp */

--- a/Machines/Enterprise/Dave.hpp
+++ b/Machines/Enterprise/Dave.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef Dave_hpp
-#define Dave_hpp
+#pragma once
 
 #include <cstdint>
 
@@ -182,5 +181,3 @@ class TimedInterruptSource {
 };
 
 }
-
-#endif /* Dave_hpp */

--- a/Machines/Enterprise/EXDos.hpp
+++ b/Machines/Enterprise/EXDos.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef EXDos_hpp
-#define EXDos_hpp
+#pragma once
 
 #include "../../Components/1770/1770.hpp"
 #include "../../Activity/Observer.hpp"
@@ -32,5 +31,3 @@ class EXDos final : public WD::WD1770 {
 };
 
 }
-
-#endif /* EXDos_hpp */

--- a/Machines/Enterprise/Enterprise.hpp
+++ b/Machines/Enterprise/Enterprise.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef Enterprise_hpp
-#define Enterprise_hpp
+#pragma once
 
 #include "../../Analyser/Static/StaticAnalyser.hpp"
 #include "../../Configurable/Configurable.hpp"
@@ -44,5 +43,3 @@ class Machine {
 };
 
 };
-
-#endif /* Enterprise_hpp */

--- a/Machines/Enterprise/Keyboard.hpp
+++ b/Machines/Enterprise/Keyboard.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef Machines_Enterprise_Keyboard_hpp
-#define Machines_Enterprise_Keyboard_hpp
+#pragma once
 
 #include "../KeyboardMachine.hpp"
 #include "../Utility/Typer.hpp"
@@ -62,5 +61,3 @@ struct CharacterMapper: public ::Utility::CharacterMapper {
 };
 
 }
-
-#endif /* Keyboard_hpp */

--- a/Machines/Enterprise/Nick.hpp
+++ b/Machines/Enterprise/Nick.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef Nick_hpp
-#define Nick_hpp
+#pragma once
 
 #include <cstdint>
 #include "../../ClockReceiver/ClockReceiver.hpp"
@@ -120,7 +119,4 @@ class Nick {
 		template <int bpp> void output_attributed(uint16_t *target, int columns) const;
 };
 
-
 }
-
-#endif /* Nick_hpp */

--- a/Machines/JoystickMachine.hpp
+++ b/Machines/JoystickMachine.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef JoystickMachine_hpp
-#define JoystickMachine_hpp
+#pragma once
 
 #include "../Inputs/Joystick.hpp"
 #include <vector>
@@ -20,5 +19,3 @@ class JoystickMachine {
 };
 
 }
-
-#endif /* JoystickMachine_hpp */

--- a/Machines/KeyboardMachine.hpp
+++ b/Machines/KeyboardMachine.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef KeyboardMachine_h
-#define KeyboardMachine_h
+#pragma once
 
 #include <bitset>
 #include <cstdint>
@@ -153,5 +152,3 @@ class MappedKeyboardMachine: public Inputs::Keyboard::Delegate, public KeyboardM
 };
 
 }
-
-#endif /* KeyboardMachine_h */

--- a/Machines/MSX/Cartridges/ASCII16kb.hpp
+++ b/Machines/MSX/Cartridges/ASCII16kb.hpp
@@ -6,13 +6,11 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef ASCII16kb_hpp
-#define ASCII16kb_hpp
+#pragma once
 
 #include "../MemorySlotHandler.hpp"
 
-namespace MSX {
-namespace Cartridge {
+namespace MSX::Cartridge {
 
 class ASCII16kbROMSlotHandler: public MemorySlotHandler {
 	public:
@@ -47,6 +45,3 @@ class ASCII16kbROMSlotHandler: public MemorySlotHandler {
 };
 
 }
-}
-
-#endif /* ASCII16kb_hpp */

--- a/Machines/MSX/Cartridges/ASCII8kb.hpp
+++ b/Machines/MSX/Cartridges/ASCII8kb.hpp
@@ -6,13 +6,11 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef ASCII8kb_hpp
-#define ASCII8kb_hpp
+#pragma once
 
 #include "../MemorySlotHandler.hpp"
 
-namespace MSX {
-namespace Cartridge {
+namespace MSX::Cartridge {
 
 class ASCII8kbROMSlotHandler: public MemorySlotHandler {
 	public:
@@ -59,6 +57,3 @@ class ASCII8kbROMSlotHandler: public MemorySlotHandler {
 };
 
 }
-}
-
-#endif /* ASCII8kb_hpp */

--- a/Machines/MSX/Cartridges/Konami.hpp
+++ b/Machines/MSX/Cartridges/Konami.hpp
@@ -6,13 +6,11 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef Konami_hpp
-#define Konami_hpp
+#pragma once
 
 #include "../MemorySlotHandler.hpp"
 
-namespace MSX {
-namespace Cartridge {
+namespace MSX::Cartridge {
 
 class KonamiROMSlotHandler: public MemorySlotHandler {
 	public:
@@ -52,6 +50,3 @@ class KonamiROMSlotHandler: public MemorySlotHandler {
 };
 
 }
-}
-
-#endif /* Konami_hpp */

--- a/Machines/MSX/Cartridges/KonamiWithSCC.hpp
+++ b/Machines/MSX/Cartridges/KonamiWithSCC.hpp
@@ -6,14 +6,12 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef KonamiWithSCC_hpp
-#define KonamiWithSCC_hpp
+#pragma once
 
 #include "../MemorySlotHandler.hpp"
 #include "../../../Components/KonamiSCC/KonamiSCC.hpp"
 
-namespace MSX {
-namespace Cartridge {
+namespace MSX::Cartridge {
 
 class KonamiWithSCCROMSlotHandler: public MemorySlotHandler {
 	public:
@@ -86,6 +84,3 @@ class KonamiWithSCCROMSlotHandler: public MemorySlotHandler {
 };
 
 }
-}
-
-#endif /* KonamiWithSCC_hpp */

--- a/Machines/MSX/DiskROM.hpp
+++ b/Machines/MSX/DiskROM.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef DiskROM_hpp
-#define DiskROM_hpp
+#pragma once
 
 #include "MemorySlotHandler.hpp"
 
@@ -41,5 +40,3 @@ class DiskROM: public MemorySlotHandler, public WD::WD1770 {
 };
 
 }
-
-#endif /* DiskROM_hpp */

--- a/Machines/MSX/Keyboard.hpp
+++ b/Machines/MSX/Keyboard.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef Machines_MSX_Keyboard_hpp
-#define Machines_MSX_Keyboard_hpp
+#pragma once
 
 #include "../KeyboardMachine.hpp"
 
@@ -37,6 +36,4 @@ struct KeyboardMapper: public MachineTypes::MappedKeyboardMachine::KeyboardMappe
 	uint16_t mapped_key_for_key(Inputs::Keyboard::Key key) const final;
 };
 
-};
-
-#endif /* Machines_MSX_Keyboard_hpp */
+}

--- a/Machines/MSX/MSX.hpp
+++ b/Machines/MSX/MSX.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef MSX_hpp
-#define MSX_hpp
+#pragma once
 
 #include "../../Configurable/Configurable.hpp"
 #include "../../Configurable/StandardOptions.hpp"
@@ -39,5 +38,3 @@ class Machine {
 };
 
 }
-
-#endif /* MSX_hpp */

--- a/Machines/MSX/MemorySlotHandler.hpp
+++ b/Machines/MSX/MemorySlotHandler.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef MemorySlotHandler_hpp
-#define MemorySlotHandler_hpp
+#pragma once
 
 #include "../../ClockReceiver/ClockReceiver.hpp"
 #include "../../Analyser/Dynamic/ConfidenceCounter.hpp"
@@ -147,5 +146,3 @@ class MemorySlotHandler {
 };
 
 }
-
-#endif /* MemorySlotHandler_hpp */

--- a/Machines/MachineTypes.hpp
+++ b/Machines/MachineTypes.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2020 Thomas Harte. All rights reserved.
 //
 
-#ifndef MachineTypes_h
-#define MachineTypes_h
+#pragma once
 
 // Rounds up everything in the MachineTypes namespace, all being
 // optional (at least, semantically) interfaces that machines
@@ -22,5 +21,3 @@
 #include "ScanProducer.hpp"
 #include "StateProducer.hpp"
 #include "TimedMachine.hpp"
-
-#endif /* MachineTypes_h */

--- a/Machines/MasterSystem/MasterSystem.hpp
+++ b/Machines/MasterSystem/MasterSystem.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef MasterSystem_hpp
-#define MasterSystem_hpp
+#pragma once
 
 #include "../../Configurable/Configurable.hpp"
 #include "../../Configurable/StandardOptions.hpp"
@@ -36,5 +35,3 @@ class Machine {
 };
 
 }
-
-#endif /* MasterSystem_hpp */

--- a/Machines/MediaTarget.hpp
+++ b/Machines/MediaTarget.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef MediaTarget_hpp
-#define MediaTarget_hpp
+#pragma once
 
 #include "../Analyser/Static/StaticAnalyser.hpp"
 #include "../Configurable/Configurable.hpp"
@@ -30,5 +29,3 @@ class MediaTarget {
 };
 
 }
-
-#endif /* MediaTarget_hpp */

--- a/Machines/MouseMachine.hpp
+++ b/Machines/MouseMachine.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
-#ifndef MouseMachine_hpp
-#define MouseMachine_hpp
+#pragma once
 
 #include "../Inputs/Mouse.hpp"
 
@@ -20,5 +19,3 @@ class MouseMachine {
 };
 
 }
-
-#endif /* MouseMachine_hpp */

--- a/Machines/Oric/BD500.hpp
+++ b/Machines/Oric/BD500.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2020 Thomas Harte. All rights reserved.
 //
 
-#ifndef BD500_hpp
-#define BD500_hpp
+#pragma once
 
 #include "../../Components/1770/1770.hpp"
 #include "../../Activity/Observer.hpp"
@@ -53,6 +52,4 @@ class BD500: public DiskController {
 		}
 };
 
-};
-
-#endif /* BD500_hpp */
+}

--- a/Machines/Oric/DiskController.hpp
+++ b/Machines/Oric/DiskController.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2020 Thomas Harte. All rights reserved.
 //
 
-#ifndef DiskController_h
-#define DiskController_h
+#pragma once
 
 namespace Oric {
 
@@ -58,8 +57,4 @@ class DiskController: public WD::WD1770 {
 		Storage::Disk::Drive::ReadyType ready_type_;
 };
 
-
-};
-
-
-#endif /* DiskController_h */
+}

--- a/Machines/Oric/Jasmin.hpp
+++ b/Machines/Oric/Jasmin.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2020 Thomas Harte. All rights reserved.
 //
 
-#ifndef Jasmin_hpp
-#define Jasmin_hpp
+#pragma once
 
 #include "../../Components/1770/1770.hpp"
 #include "../../Activity/Observer.hpp"
@@ -41,6 +40,4 @@ class Jasmin: public DiskController {
 		}
 };
 
-};
-
-#endif /* Jasmin_hpp */
+}

--- a/Machines/Oric/Keyboard.hpp
+++ b/Machines/Oric/Keyboard.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef Machines_Oric_Keyboard_hpp
-#define Machines_Oric_Keyboard_hpp
+#pragma once
 
 #include "../KeyboardMachine.hpp"
 #include "../Utility/Typer.hpp"
@@ -44,6 +43,4 @@ struct CharacterMapper: public ::Utility::CharacterMapper {
 	const uint16_t *sequence_for_character(char character) const final;
 };
 
-};
-
-#endif /* KeyboardMapper_hpp */
+}

--- a/Machines/Oric/Microdisc.hpp
+++ b/Machines/Oric/Microdisc.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef Microdisc_hpp
-#define Microdisc_hpp
+#pragma once
 
 #include "../../Components/1770/1770.hpp"
 #include "../../Activity/Observer.hpp"
@@ -43,5 +42,3 @@ class Microdisc: public DiskController {
 };
 
 }
-
-#endif /* Microdisc_hpp */

--- a/Machines/Oric/Oric.hpp
+++ b/Machines/Oric/Oric.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef Oric_hpp
-#define Oric_hpp
+#pragma once
 
 #include "../../Configurable/Configurable.hpp"
 #include "../../Configurable/StandardOptions.hpp"
@@ -44,4 +43,3 @@ class Machine {
 };
 
 }
-#endif /* Oric_hpp */

--- a/Machines/Oric/Video.hpp
+++ b/Machines/Oric/Video.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef Machines_Oric_Video_hpp
-#define Machines_Oric_Video_hpp
+#pragma once
 
 #include "../../Outputs/CRT/CRT.hpp"
 #include "../../ClockReceiver/ClockReceiver.hpp"
@@ -65,5 +64,3 @@ class VideoOutput {
 };
 
 }
-
-#endif /* Video_hpp */

--- a/Machines/PCCompatible/CGA.hpp
+++ b/Machines/PCCompatible/CGA.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef CGA_h
-#define CGA_h
+#pragma once
 
 #include "../../Components/6845/CRTC6845.hpp"
 #include "../../Outputs/CRT/CRT.hpp"
@@ -449,5 +448,3 @@ class CGA {
 };
 
 }
-
-#endif /* CGA_h */

--- a/Machines/PCCompatible/DMA.hpp
+++ b/Machines/PCCompatible/DMA.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef DMA_hpp
-#define DMA_hpp
+#pragma once
 
 #include "../../Numeric/RegisterSizes.hpp"
 
@@ -315,5 +314,3 @@ class DMA {
 };
 
 }
-
-#endif /* DMA_hpp */

--- a/Machines/PCCompatible/KeyboardMapper.hpp
+++ b/Machines/PCCompatible/KeyboardMapper.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef KeyboardMapper_hpp
-#define KeyboardMapper_hpp
+#pragma once
 
 #include "../KeyboardMachine.hpp"
 
@@ -136,5 +135,3 @@ class KeyboardMapper: public MachineTypes::MappedKeyboardMachine::KeyboardMapper
 };
 
 }
-
-#endif /* KeyboardMapper_hpp */

--- a/Machines/PCCompatible/MDA.hpp
+++ b/Machines/PCCompatible/MDA.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef MDA_h
-#define MDA_h
+#pragma once
 
 #include "../../Components/6845/CRTC6845.hpp"
 #include "../../Outputs/CRT/CRT.hpp"
@@ -235,5 +234,3 @@ class MDA {
 };
 
 }
-
-#endif /* MDA_h */

--- a/Machines/PCCompatible/Memory.hpp
+++ b/Machines/PCCompatible/Memory.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef Memory_hpp
-#define Memory_hpp
+#pragma once
 
 #include "Registers.hpp"
 #include "Segments.hpp"
@@ -175,5 +174,3 @@ struct Memory {
 };
 
 }
-
-#endif /* Memory_hpp */

--- a/Machines/PCCompatible/PCCompatible.hpp
+++ b/Machines/PCCompatible/PCCompatible.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef PCCompatible_hpp
-#define PCCompatible_hpp
+#pragma once
 
 #include "../../Configurable/Configurable.hpp"
 #include "../../Configurable/StandardOptions.hpp"
@@ -48,5 +47,3 @@ class Machine {
 };
 
 }
-
-#endif /* PCCompatible_hpp */

--- a/Machines/PCCompatible/PIC.hpp
+++ b/Machines/PCCompatible/PIC.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef PIC_hpp
-#define PIC_hpp
+#pragma once
 
 namespace PCCompatible {
 
@@ -169,5 +168,3 @@ class PIC {
 };
 
 }
-
-#endif /* PIC_hpp */

--- a/Machines/PCCompatible/PIT.hpp
+++ b/Machines/PCCompatible/PIT.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef PIT_hpp
-#define PIT_hpp
+#pragma once
 
 namespace PCCompatible {
 
@@ -255,5 +254,3 @@ class i8253 {
 };
 
 }
-
-#endif /* PIT_hpp */

--- a/Machines/PCCompatible/RTC.hpp
+++ b/Machines/PCCompatible/RTC.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef RTC_h
-#define RTC_h
+#pragma once
 
 #include <ctime>
 
@@ -121,5 +120,3 @@ class RTC {
 };
 
 }
-
-#endif /* RTC_h */

--- a/Machines/PCCompatible/Registers.hpp
+++ b/Machines/PCCompatible/Registers.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef Registers_hpp
-#define Registers_hpp
+#pragma once
 
 namespace PCCompatible {
 
@@ -69,5 +68,3 @@ struct Registers {
 };
 
 }
-
-#endif /* Registers_hpp */

--- a/Machines/PCCompatible/Segments.hpp
+++ b/Machines/PCCompatible/Segments.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef Segments_hpp
-#define Segments_hpp
+#pragma once
 
 #include "Registers.hpp"
 
@@ -54,5 +53,3 @@ class Segments {
 };
 
 }
-
-#endif /* Segments_hpp */

--- a/Machines/ROMMachine.hpp
+++ b/Machines/ROMMachine.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef ROMMachine_hpp
-#define ROMMachine_hpp
+#pragma once
 
 #include <functional>
 #include <map>
@@ -35,5 +34,3 @@ enum class Error {
 };
 
 }
-
-#endif /* ROMMachine_h */

--- a/Machines/ScanProducer.hpp
+++ b/Machines/ScanProducer.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2020 Thomas Harte. All rights reserved.
 //
 
-#ifndef ScanProducer_hpp
-#define ScanProducer_hpp
+#pragma once
 
 #include "../Outputs/ScanTarget.hpp"
 #include "../Configurable/StandardOptions.hpp"
@@ -100,5 +99,3 @@ class ScanProducer {
 };
 
 }
-
-#endif /* ScanProducer_hpp */

--- a/Machines/Sinclair/Keyboard/Keyboard.hpp
+++ b/Machines/Sinclair/Keyboard/Keyboard.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef Machines_ZX8081_Keyboard_hpp
-#define Machines_ZX8081_Keyboard_hpp
+#pragma once
 
 #include "../../KeyboardMachine.hpp"
 #include "../../Utility/Typer.hpp"
@@ -73,5 +72,3 @@ class CharacterMapper: public ::Utility::CharacterMapper {
 };
 
 }
-
-#endif /* KeyboardMapper_hpp */

--- a/Machines/Sinclair/ZX8081/Video.hpp
+++ b/Machines/Sinclair/ZX8081/Video.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef Machines_ZX8081_Video_hpp
-#define Machines_ZX8081_Video_hpp
+#pragma once
 
 #include "../../../Outputs/CRT/CRT.hpp"
 #include "../../../ClockReceiver/ClockReceiver.hpp"
@@ -58,5 +57,3 @@ class Video {
 };
 
 }
-
-#endif /* Video_hpp */

--- a/Machines/Sinclair/ZX8081/ZX8081.hpp
+++ b/Machines/Sinclair/ZX8081/ZX8081.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef ZX8081_hpp
-#define ZX8081_hpp
+#pragma once
 
 #include "../../../Configurable/Configurable.hpp"
 #include "../../../Configurable/StandardOptions.hpp"
@@ -47,5 +46,3 @@ class Machine {
 };
 
 }
-
-#endif /* ZX8081_hpp */

--- a/Machines/Sinclair/ZXSpectrum/State.hpp
+++ b/Machines/Sinclair/ZXSpectrum/State.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef State_hpp
-#define State_hpp
+#pragma once
 
 #include "../../../Reflection/Struct.hpp"
 #include "../../../Processors/Z80/State/State.hpp"
@@ -46,5 +45,3 @@ struct State: public Reflection::StructImpl<State> {
 };
 
 }
-
-#endif /* State_h */

--- a/Machines/Sinclair/ZXSpectrum/Video.hpp
+++ b/Machines/Sinclair/ZXSpectrum/Video.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef Video_hpp
-#define Video_hpp
+#pragma once
 
 #include "../../../Outputs/CRT/CRT.hpp"
 #include "../../../ClockReceiver/ClockReceiver.hpp"
@@ -484,5 +483,3 @@ struct State: public Reflection::StructImpl<State> {
 };
 
 }
-
-#endif /* Video_hpp */

--- a/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
+++ b/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
@@ -758,11 +758,11 @@ template<Model model> class ConcreteMachine:
 		std::array<uint8_t, 128*1024> ram_;
 
 		std::array<uint8_t, 16*1024> scratch_;
-		const uint8_t *read_pointers_[4];
-		uint8_t *write_pointers_[4];
-		uint8_t pages_[4];
-		bool is_contended_[4];
-		bool is_video_[4];
+		std::array<const uint8_t *, 4> read_pointers_;
+		std::array<uint8_t *, 4> write_pointers_;
+		std::array<uint8_t, 4> pages_;
+		std::array<bool, 4> is_contended_;
+		std::array<bool, 4> is_video_;
 
 		uint8_t port1ffd_ = 0;
 		uint8_t port7ffd_ = 0;

--- a/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
+++ b/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
@@ -60,36 +60,37 @@ class Joystick: public Inputs::ConcreteJoystick {
 			}) {}
 
 		void did_set_input(const Input &digital_input, bool is_active) final {
-#define APPLY_KEMPSTON(b)	if(is_active) kempston_ |= b; else kempston_ &= ~b;
-#define APPLY_SINCLAIR(b)	if(is_active) sinclair_ &= ~b; else sinclair_ |= b;
+			const auto apply_kempston = [&](uint8_t mask) {
+				if(is_active) kempston_ |= mask; else kempston_ &= ~mask;
+			};
+			const auto apply_sinclair = [&](uint16_t mask) {
+				if(is_active) sinclair_ &= ~mask; else sinclair_ |= mask;
+			};
 
 			switch(digital_input.type) {
 				default: return;
 
 				case Input::Right:
-					APPLY_KEMPSTON(0x01);
-					APPLY_SINCLAIR(0x0208);
+					apply_kempston(0x01);
+					apply_sinclair(0x0208);
 				break;
 				case Input::Left:
-					APPLY_KEMPSTON(0x02);
-					APPLY_SINCLAIR(0x0110);
+					apply_kempston(0x02);
+					apply_sinclair(0x0110);
 				break;
 				case Input::Down:
-					APPLY_KEMPSTON(0x04);
-					APPLY_SINCLAIR(0x0404);
+					apply_kempston(0x04);
+					apply_sinclair(0x0404);
 				break;
 				case Input::Up:
-					APPLY_KEMPSTON(0x08);
-					APPLY_SINCLAIR(0x0802);
+					apply_kempston(0x08);
+					apply_sinclair(0x0802);
 				break;
 				case Input::Fire:
-					APPLY_KEMPSTON(0x10);
-					APPLY_SINCLAIR(0x1001);
+					apply_kempston(0x10);
+					apply_sinclair(0x1001);
 				break;
 			}
-
-#undef APPLY_KEMPSTON
-#undef APPLY_SINCLAIR
 		}
 
 		/// @returns The value that a Kempston joystick interface would report if this joystick

--- a/Machines/Sinclair/ZXSpectrum/ZXSpectrum.hpp
+++ b/Machines/Sinclair/ZXSpectrum/ZXSpectrum.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef ZXSpectrum_hpp
-#define ZXSpectrum_hpp
+#pragma once
 
 #include "../../../Configurable/Configurable.hpp"
 #include "../../../Configurable/StandardOptions.hpp"
@@ -47,5 +46,3 @@ class Machine {
 };
 
 }
-
-#endif /* ZXSpectrum_hpp */

--- a/Machines/StateProducer.hpp
+++ b/Machines/StateProducer.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef State_h
-#define State_h
+#pragma once
 
 #include <memory>
 #include "../Analyser/Static/StaticAnalyser.hpp"
@@ -22,5 +21,3 @@ struct StateProducer {
 };
 
 };
-
-#endif /* State_h */

--- a/Machines/TimedMachine.hpp
+++ b/Machines/TimedMachine.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2020 Thomas Harte. All rights reserved.
 //
 
-#ifndef TimedMachine_h
-#define TimedMachine_h
+#pragma once
 
 #include "../ClockReceiver/ClockReceiver.hpp"
 #include "../ClockReceiver/TimeTypes.hpp"
@@ -98,5 +97,3 @@ class TimedMachine {
 };
 
 }
-
-#endif /* TimedMachine_h */

--- a/Machines/Utility/MachineForTarget.hpp
+++ b/Machines/Utility/MachineForTarget.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef MachineForTarget_hpp
-#define MachineForTarget_hpp
+#pragma once
 
 #include "../../Analyser/Static/StaticAnalyser.hpp"
 #include "../../Reflection/Struct.hpp"
@@ -94,5 +93,3 @@ std::map<std::string, std::unique_ptr<Reflection::Struct>> AllOptionsByMachineNa
 std::map<std::string, std::unique_ptr<Analyser::Static::Target>> TargetsByMachineName(bool meaningful_without_media_only);
 
 }
-
-#endif /* MachineForTarget_hpp */

--- a/Machines/Utility/MemoryFuzzer.hpp
+++ b/Machines/Utility/MemoryFuzzer.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef MemoryFuzzer_hpp
-#define MemoryFuzzer_hpp
+#pragma once
 
 #include <cstdint>
 #include <cstddef>
@@ -27,5 +26,3 @@ template <typename T> void Fuzz(T &buffer) {
 }
 
 }
-
-#endif /* MemoryFuzzer_hpp */

--- a/Machines/Utility/MemoryPacker.hpp
+++ b/Machines/Utility/MemoryPacker.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
-#ifndef MemoryPacker_hpp
-#define MemoryPacker_hpp
+#pragma once
 
 #include <cstdint>
 #include <vector>
@@ -43,4 +42,3 @@ void PackBigEndian16(const std::vector<uint8_t> &source, std::vector<uint16_t> &
 void PackBigEndian16(const std::vector<uint8_t> &source, std::vector<uint8_t> &target);
 
 }
-#endif /* MemoryPacker_hpp */

--- a/Machines/Utility/ROMCatalogue.hpp
+++ b/Machines/Utility/ROMCatalogue.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef ROMCatalogue_hpp
-#define ROMCatalogue_hpp
+#pragma once
 
 #include <algorithm>
 #include <cstdint>
@@ -313,5 +312,3 @@ struct Request {
 };
 
 }
-
-#endif /* ROMCatalogue_hpp */

--- a/Machines/Utility/StringSerialiser.hpp
+++ b/Machines/Utility/StringSerialiser.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef StringSerialiser_hpp
-#define StringSerialiser_hpp
+#pragma once
 
 #include <cstdint>
 #include <string>
@@ -27,5 +26,3 @@ class StringSerialiser {
 };
 
 }
-
-#endif /* StringSerialiser_hpp */

--- a/Machines/Utility/TypedDynamicMachine.hpp
+++ b/Machines/Utility/TypedDynamicMachine.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef TypedDynamicMachine_h
-#define TypedDynamicMachine_h
+#pragma once
 
 #include "MachineForTarget.hpp"
 
@@ -68,5 +67,3 @@ template<typename T> class TypedDynamicMachine: public ::Machine::DynamicMachine
 };
 
 }
-
-#endif /* TypedDynamicMachine_h */

--- a/Machines/Utility/Typer.hpp
+++ b/Machines/Utility/Typer.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef Typer_hpp
-#define Typer_hpp
+#pragma once
 
 #include <memory>
 #include <string>
@@ -151,5 +150,3 @@ class TypeRecipient: public Typer::Delegate {
 };
 
 }
-
-#endif /* Typer_hpp */

--- a/Numeric/BitReverse.hpp
+++ b/Numeric/BitReverse.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef BitReverse_hpp
-#define BitReverse_hpp
+#pragma once
 
 #include <cstdint>
 
@@ -58,5 +57,3 @@ template <typename IntT> constexpr IntT bit_reverse(IntT source) {
 }
 
 }
-
-#endif /* BitReverse_hpp */

--- a/Numeric/BitSpread.hpp
+++ b/Numeric/BitSpread.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef BitSpread_hpp
-#define BitSpread_hpp
+#pragma once
 
 namespace Numeric {
 
@@ -33,5 +32,3 @@ constexpr uint8_t unspread_bits(uint16_t input) {
 }
 
 }
-
-#endif /* BitSpread_hpp */

--- a/Numeric/CRC.hpp
+++ b/Numeric/CRC.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef CRC_hpp
-#define CRC_hpp
+#pragma once
 
 #include <cstdint>
 #include <vector>
@@ -120,5 +119,3 @@ struct CRC32: public Generator<uint32_t, 0xffffffff, 0xffffffff, true, true> {
 };
 
 }
-
-#endif /* CRC_hpp */

--- a/Numeric/Carry.hpp
+++ b/Numeric/Carry.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef Carry_hpp
-#define Carry_hpp
+#pragma once
 
 #include <limits>
 
@@ -79,5 +78,3 @@ IntT overflow(IntT lhs, IntT rhs, IntT result) {
 }
 
 }
-
-#endif /* Carry_hpp */

--- a/Numeric/LFSR.hpp
+++ b/Numeric/LFSR.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2020 Thomas Harte. All rights reserved.
 //
 
-#ifndef LFSR_h
-#define LFSR_h
+#pragma once
 
 #include <cstdint>
 #include <cstdlib>
@@ -81,5 +80,3 @@ template <typename IntType = uint64_t, IntType polynomial = LSFRPolynomial<IntTy
 template <uint64_t polynomial> class LFSRv: public LFSR<typename MinIntTypeValue<polynomial>::type, polynomial> {};
 
 }
-
-#endif /* LFSR_h */

--- a/Numeric/NumericCoder.hpp
+++ b/Numeric/NumericCoder.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef NumericCoder_hpp
-#define NumericCoder_hpp
+#pragma once
 
 namespace Numeric {
 
@@ -73,5 +72,3 @@ template <int... Sizes> class NumericCoder {
 };
 
 }
-
-#endif /* NumericCoder_hpp */

--- a/Numeric/RegisterSizes.hpp
+++ b/Numeric/RegisterSizes.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef RegisterSizes_hpp
-#define RegisterSizes_hpp
+#pragma once
 
 #include <cstdint>
 
@@ -88,5 +87,3 @@ using SlicedInt32 = SlicedInt<uint32_t>;
 }
 
 #pragma pack(pop)
-
-#endif /* RegisterSizes_hpp */

--- a/Numeric/Sizes.hpp
+++ b/Numeric/Sizes.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef Sizes_h
-#define Sizes_h
+#pragma once
 
 #include <limits>
 #include <type_traits>
@@ -33,5 +32,3 @@ template <uint64_t max_value> struct MinIntTypeValue {
 			>
 		>;
 };
-
-#endif /* Sizes_h */

--- a/OSBindings/Mac/Clock Signal/CSApplication.h
+++ b/OSBindings/Mac/Clock Signal/CSApplication.h
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
-#ifndef CSApplication_h
-#define CSApplication_h
+#pragma once
 
 #import <Cocoa/Cocoa.h>
 
@@ -28,6 +27,3 @@
 @interface CSApplication: NSApplication
 @property(nonatomic, weak, nullable) id<CSApplicationEventDelegate> eventDelegate;
 @end
-
-
-#endif /* CSApplication_h */

--- a/OSBindings/Mac/Clock Signal/Machine/KeyCodes.h
+++ b/OSBindings/Mac/Clock Signal/Machine/KeyCodes.h
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef KeyCodes_h
-#define KeyCodes_h
+#pragma once
 
 /*
 	Carbon somehow still manages to get into the unit test target; I can't figure out how. So I've
@@ -147,5 +146,3 @@ enum: uint16_t {
   VK_DownArrow                 = 0x7D,
   VK_UpArrow                   = 0x7E
 };
-
-#endif /* KeyCodes_h */

--- a/OSBindings/Mac/Clock SignalTests/Comparative68000.hpp
+++ b/OSBindings/Mac/Clock SignalTests/Comparative68000.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
-#ifndef Comparative68000_hpp
-#define Comparative68000_hpp
+#pragma once
 
 #include <zlib.h>
 
@@ -55,5 +54,3 @@ class ComparativeBusHandler: public CPU::MC68000::BusHandler {
 		int line_count = 0;
 		gzFile trace;
 };
-
-#endif /* Comparative68000_hpp */

--- a/OSBindings/Mac/Clock SignalTests/TestRunner68000.hpp
+++ b/OSBindings/Mac/Clock SignalTests/TestRunner68000.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
-#ifndef TestRunner68000_h
-#define TestRunner68000_h
+#pragma once
 
 #include <array>
 #include <functional>
@@ -135,5 +134,3 @@ class RAM68000: public CPU::MC68000::BusHandler {
 		int instructions_remaining_;
 		HalfCycles duration_;
 };
-
-#endif /* TestRunner68000_h */

--- a/Outputs/CRT/CRT.hpp
+++ b/Outputs/CRT/CRT.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2015 Thomas Harte. All rights reserved.
 //
 
-#ifndef CRT_hpp
-#define CRT_hpp
+#pragma once
 
 #include <array>
 #include <cstdint>
@@ -366,5 +365,3 @@ template <typename Receiver> class CRTFrequencyMismatchWarner: public Outputs::C
 };
 
 }
-
-#endif /* CRT_cpp */

--- a/Outputs/CRT/Internals/Flywheel.hpp
+++ b/Outputs/CRT/Internals/Flywheel.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef Flywheel_hpp
-#define Flywheel_hpp
+#pragma once
 
 #include <cassert>
 #include <cstdlib>
@@ -259,5 +258,3 @@ struct Flywheel {
 };
 
 }
-
-#endif /* Flywheel_hpp */

--- a/Outputs/DisplayMetrics.hpp
+++ b/Outputs/DisplayMetrics.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
-#ifndef DisplayMetrics_hpp
-#define DisplayMetrics_hpp
+#pragma once
 
 #include "ScanTarget.hpp"
 
@@ -56,5 +55,3 @@ class Metrics {
 };
 
 }
-
-#endif /* DisplayMetrics_hpp */

--- a/Outputs/Log.hpp
+++ b/Outputs/Log.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef Log_h
-#define Log_h
+#pragma once
 
 #ifdef NDEBUG
 
@@ -45,6 +44,3 @@
 #endif
 
 #endif
-
-
-#endif /* Log_h */

--- a/Outputs/OpenGL/OpenGL.hpp
+++ b/Outputs/OpenGL/OpenGL.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef OpenGL_h
-#define OpenGL_h
+#pragma once
 
 #include <cassert>
 #include <iostream>
@@ -57,5 +56,3 @@
 #else
 #define test_gl(command, ...) command(__VA_ARGS__)
 #endif
-
-#endif /* OpenGL_h */

--- a/Outputs/OpenGL/Primitives/Rectangle.hpp
+++ b/Outputs/OpenGL/Primitives/Rectangle.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef Rectangle_hpp
-#define Rectangle_hpp
+#pragma once
 
 #include "../OpenGL.hpp"
 #include "Shader.hpp"
@@ -37,5 +36,3 @@ class Rectangle {
 };
 
 }
-
-#endif /* Rectangle_hpp */

--- a/Outputs/OpenGL/Primitives/Shader.hpp
+++ b/Outputs/OpenGL/Primitives/Shader.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef Shader_hpp
-#define Shader_hpp
+#pragma once
 
 #include "../OpenGL.hpp"
 
@@ -129,5 +128,3 @@ protected:
 };
 
 }
-
-#endif /* Shader_hpp */

--- a/Outputs/OpenGL/Primitives/TextureTarget.hpp
+++ b/Outputs/OpenGL/Primitives/TextureTarget.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef TextureTarget_hpp
-#define TextureTarget_hpp
+#pragma once
 
 #include "../OpenGL.hpp"
 #include "Shader.hpp"
@@ -87,5 +86,3 @@ class TextureTarget {
 };
 
 }
-
-#endif /* TextureTarget_hpp */

--- a/Outputs/OpenGL/ScanTarget.hpp
+++ b/Outputs/OpenGL/ScanTarget.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef ScanTarget_hpp
-#define ScanTarget_hpp
+#pragma once
 
 #include "../Log.hpp"
 #include "../DisplayMetrics.hpp"
@@ -155,5 +154,3 @@ class ScanTarget: public Outputs::Display::BufferingScanTarget {	// TODO: use pr
 };
 
 }
-
-#endif /* ScanTarget_hpp */

--- a/Outputs/OpenGL/Screenshot.hpp
+++ b/Outputs/OpenGL/Screenshot.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
-#ifndef Screenshot_h
-#define Screenshot_h
+#pragma once
 
 #include "OpenGL.hpp"
 
@@ -53,5 +52,3 @@ struct Screenshot {
 };
 
 }
-
-#endif /* Screenshot_h */

--- a/Outputs/ScanTarget.hpp
+++ b/Outputs/ScanTarget.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef Outputs_Display_ScanTarget_h
-#define Outputs_Display_ScanTarget_h
+#pragma once
 
 #include <array>
 #include <cstddef>
@@ -451,5 +450,3 @@ struct NullScanTarget: public ScanTarget {
 };
 
 }
-
-#endif /* Outputs_Display_ScanTarget_h */

--- a/Outputs/ScanTargets/BufferingScanTarget.hpp
+++ b/Outputs/ScanTargets/BufferingScanTarget.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2020 Thomas Harte. All rights reserved.
 //
 
-#ifndef BufferingScanTarget_hpp
-#define BufferingScanTarget_hpp
+#pragma once
 
 #include "../ScanTarget.hpp"
 #include "../DisplayMetrics.hpp"
@@ -273,5 +272,3 @@ class BufferingScanTarget: public Outputs::Display::ScanTarget {
 };
 
 }
-
-#endif /* BufferingScanTarget_hpp */

--- a/Outputs/Speaker/Implementation/CompoundSource.hpp
+++ b/Outputs/Speaker/Implementation/CompoundSource.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef CompoundSource_h
-#define CompoundSource_h
+#pragma once
 
 #include "SampleSource.hpp"
 
@@ -174,5 +173,3 @@ template <typename... T> class CompoundSource:
 };
 
 }
-
-#endif /* CompoundSource_h */

--- a/Outputs/Speaker/Implementation/LowpassSpeaker.hpp
+++ b/Outputs/Speaker/Implementation/LowpassSpeaker.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef LowpassSpeaker_hpp
-#define LowpassSpeaker_hpp
+#pragma once
 
 #include "../Speaker.hpp"
 #include "../../../SignalProcessing/FIRFilter.hpp"
@@ -410,5 +409,3 @@ template <typename SampleSource> class PullLowpass: public LowpassBase<PullLowpa
 };
 
 }
-
-#endif /* LowpassSpeaker_hpp */

--- a/Outputs/Speaker/Implementation/SampleSource.hpp
+++ b/Outputs/Speaker/Implementation/SampleSource.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef SampleSource_hpp
-#define SampleSource_hpp
+#pragma once
 
 #include <cstddef>
 #include <cstdint>
@@ -71,5 +70,3 @@ class SampleSource {
 };
 
 }
-
-#endif /* SampleSource_hpp */

--- a/Outputs/Speaker/Speaker.hpp
+++ b/Outputs/Speaker/Speaker.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef Speaker_hpp
-#define Speaker_hpp
+#pragma once
 
 #include <atomic>
 #include <cstdint>
@@ -145,5 +144,3 @@ class Speaker {
 };
 
 }
-
-#endif /* Speaker_hpp */

--- a/Processors/6502/6502.hpp
+++ b/Processors/6502/6502.hpp
@@ -39,10 +39,10 @@ enum Personality {
 	PWDC65C02,			// like the Rockwell, but with STP and WAI
 };
 
-#define has_decimal_mode(p)	((p) >= Personality::P6502)
-#define is_65c02(p)			((p) >= Personality::PSynertek65C02)
-#define has_bbrbbsrmbsmb(p)	((p) >= Personality::PRockwell65C02)
-#define has_stpwai(p)		((p) >= Personality::PWDC65C02)
+constexpr bool has_decimal_mode(Personality p)	{	return p >= Personality::P6502;				}
+constexpr bool is_65c02(Personality p)			{	return p >= Personality::PSynertek65C02;	}
+constexpr bool has_bbrbbsrmbsmb(Personality p)	{	return p >= Personality::PRockwell65C02;	}
+constexpr bool has_stpwai(Personality p)		{	return p >= Personality::PWDC65C02;			}
 
 /*!
 	An opcode that is guaranteed to cause a 6502 to jam.

--- a/Processors/6502/6502.hpp
+++ b/Processors/6502/6502.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2015 Thomas Harte. All rights reserved.
 //
 
-#ifndef MOS6502_cpp
-#define MOS6502_cpp
+#pragma once
 
 #include <algorithm>
 #include <cassert>
@@ -170,5 +169,3 @@ template <Personality personality, typename BusHandler, bool uses_ready_line> cl
 #include "Implementation/6502Implementation.hpp"
 
 }
-
-#endif /* MOS6502_cpp */

--- a/Processors/6502/AllRAM/6502AllRAM.hpp
+++ b/Processors/6502/AllRAM/6502AllRAM.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2015 Thomas Harte. All rights reserved.
 //
 
-#ifndef MOS6502AllRAM_cpp
-#define MOS6502AllRAM_cpp
+#pragma once
 
 #include "../../6502Esque/6502Selector.hpp"
 #include "../../AllRAMProcessor.hpp"
@@ -33,5 +32,3 @@ class AllRAMProcessor:
 };
 
 }
-
-#endif /* MOS6502AllRAM_cpp */

--- a/Processors/6502/Implementation/6502Implementation.hpp
+++ b/Processors/6502/Implementation/6502Implementation.hpp
@@ -44,6 +44,33 @@ void Processor<personality, T, uses_ready_line>::run_for(const Cycles cycles) {
 		return number_of_cycles <= Cycles(0);
 	};
 
+	const auto read_op = [&](uint8_t &val, uint16_t address) {
+		next_bus_operation_ = BusOperation::ReadOpcode;
+		bus_address_ = address;
+		bus_value_ = &val;
+		val = 0xff;
+	};
+
+	const auto read_mem = [&](uint8_t &val, uint16_t address) {
+		next_bus_operation_ = BusOperation::Read;
+		bus_address_ = address;
+		bus_value_ = &val;
+		val = 0xff;
+	};
+
+	const auto throwaway_read = [&](uint16_t address) {
+		next_bus_operation_ = BusOperation::Read;
+		bus_address_ = address;
+		bus_value_ = &bus_throwaway_;
+		bus_throwaway_ = 0xff;
+	};
+
+	const auto write_mem = [&](uint8_t &val, uint16_t address) {
+		next_bus_operation_ = BusOperation::Write;
+		bus_address_ = address;
+		bus_value_ = &val;
+	};
+
 	while(number_of_cycles > Cycles(0)) {
 
 		// Deal with a potential RDY state, if this 6502 has anything connected to ready.
@@ -81,11 +108,6 @@ void Processor<personality, T, uses_ready_line>::run_for(const Cycles cycles) {
 
 				const MicroOp cycle = *scheduled_program_counter_;
 				scheduled_program_counter_++;
-
-#define read_op(val, addr)		next_bus_operation_ = BusOperation::ReadOpcode;	bus_address_ = addr;		bus_value_ = &val;				val = 0xff
-#define read_mem(val, addr)		next_bus_operation_ = BusOperation::Read;		bus_address_ = addr;		bus_value_ = &val;				val	= 0xff
-#define throwaway_read(addr)	next_bus_operation_ = BusOperation::Read;		bus_address_ = addr;		bus_value_ = &bus_throwaway_;	bus_throwaway_ = 0xff
-#define write_mem(val, addr)	next_bus_operation_ = BusOperation::Write;		bus_address_ = addr;		bus_value_ = &val
 
 				switch(cycle) {
 

--- a/Processors/6502/State/State.hpp
+++ b/Processors/6502/State/State.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2020 Thomas Harte. All rights reserved.
 //
 
-#ifndef MOS6502_State_hpp
-#define MOS6502_State_hpp
+#pragma once
 
 #include "../../../Reflection/Enum.hpp"
 #include "../../../Reflection/Struct.hpp"
@@ -89,5 +88,3 @@ struct State: public Reflection::StructImpl<State> {
 };
 
 }
-
-#endif /* MOS6502_State_hpp */

--- a/Processors/6502Esque/6502Esque.hpp
+++ b/Processors/6502Esque/6502Esque.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2020 Thomas Harte. All rights reserved.
 //
 
-#ifndef m6502Esque_h
-#define m6502Esque_h
+#pragma once
 
 #include "../../ClockReceiver/ClockReceiver.hpp"
 
@@ -143,5 +142,3 @@ template <typename addr_t> class BusHandler {
 };
 
 }
-
-#endif /* m6502Esque_h */

--- a/Processors/6502Esque/6502Selector.hpp
+++ b/Processors/6502Esque/6502Selector.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2020 Thomas Harte. All rights reserved.
 //
 
-#ifndef _502Selector_h
-#define _502Selector_h
+#pragma once
 
 #include "6502Esque.hpp"
 #include "../6502/6502.hpp"
@@ -73,5 +72,3 @@ constexpr bool has_extended_bus_output(Type processor_type) {
 }
 
 }
-
-#endif /* _502Selector_h */

--- a/Processors/6502Esque/Implementation/LazyFlags.hpp
+++ b/Processors/6502Esque/Implementation/LazyFlags.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2020 Thomas Harte. All rights reserved.
 //
 
-#ifndef LazyFlags_h
-#define LazyFlags_h
+#pragma once
 
 #include "../6502Esque.hpp"
 
@@ -76,5 +75,3 @@ struct LazyFlags {
 };
 
 }
-
-#endif /* LazyFlags_h */

--- a/Processors/65816/65816.hpp
+++ b/Processors/65816/65816.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2020 Thomas Harte. All rights reserved.
 //
 
-#ifndef WDC65816_hpp
-#define WDC65816_hpp
+#pragma once
 
 #include <cassert>
 #include <cstddef>
@@ -92,5 +91,3 @@ template <typename BusHandler, bool uses_ready_line> class Processor: public Pro
 #include "Implementation/65816Implementation.hpp"
 
 }
-
-#endif /* WDC65816_hpp */

--- a/Processors/68000/68000.hpp
+++ b/Processors/68000/68000.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2022 Thomas Harte. All rights reserved.
 //
 
-#ifndef MC68000_h
-#define MC68000_h
+#pragma once
 
 #include "../../ClockReceiver/ClockReceiver.hpp"
 #include "../../Numeric/RegisterSizes.hpp"
@@ -499,5 +498,3 @@ class Processor: private ProcessorBase {
 }
 
 #include "Implementation/68000Implementation.hpp"
-
-#endif /* MC68000_h */

--- a/Processors/68000/Implementation/68000Implementation.hpp
+++ b/Processors/68000/Implementation/68000Implementation.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2022 Thomas Harte. All rights reserved.
 //
 
-#ifndef MC68000Implementation_h
-#define MC68000Implementation_h
+#pragma once
 
 #include <cassert>
 #include <cstdio>
@@ -3109,5 +3108,3 @@ void Processor<BusHandler, dtack_is_implicit, permit_overrun, signal_will_perfor
 #endif
 
 }
-
-#endif /* MC68000Implementation_h */

--- a/Processors/68000/Implementation/68000Storage.hpp
+++ b/Processors/68000/Implementation/68000Storage.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2022 Thomas Harte. All rights reserved.
 //
 
-#ifndef MC68000Storage_h
-#define MC68000Storage_h
+#pragma once
 
 #include "../../../InstructionSets/M68k/Decoder.hpp"
 #include "../../../InstructionSets/M68k/Perform.hpp"
@@ -232,5 +231,3 @@ struct ProcessorBase: public InstructionSet::M68k::NullFlowController {
 };
 
 }
-
-#endif /* MC68000Storage_h */

--- a/Processors/AllRAMProcessor.hpp
+++ b/Processors/AllRAMProcessor.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef AllRAMProcessor_hpp
-#define AllRAMProcessor_hpp
+#pragma once
 
 #include <cstdint>
 #include <set>
@@ -47,5 +46,3 @@ class AllRAMProcessor {
 };
 
 }
-
-#endif /* AllRAMProcessor_hpp */

--- a/Processors/Z80/AllRAM/Z80AllRAM.hpp
+++ b/Processors/Z80/AllRAM/Z80AllRAM.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef Z80AllRAM_hpp
-#define Z80AllRAM_hpp
+#pragma once
 
 #include "../Z80.hpp"
 #include "../../AllRAMProcessor.hpp"
@@ -52,5 +51,3 @@ class AllRAMProcessor:
 };
 
 }
-
-#endif /* Z80AllRAM_hpp */

--- a/Processors/Z80/Implementation/Z80Implementation.hpp
+++ b/Processors/Z80/Implementation/Z80Implementation.hpp
@@ -165,14 +165,14 @@ template <	class T,
 		memptr_.full += direction;
 
 		uint8_t result = a_ - temp8_;
-		const uint8_t halfResult = (a_&0xf) - (temp8_&0xf);
+		const uint8_t half_result = (a_&0xf) - (temp8_&0xf);
 
 		parity_overflow_result_ = bc_.full ? Flag::Parity : 0;
-		half_carry_result_ = halfResult;
+		half_carry_result_ = half_result;
 		subtract_flag_ = Flag::Subtract;
 		sign_result_ = zero_result_ = result;
 
-		result -= (halfResult >> 4)&1;
+		result -= (half_result >> 4)&1;
 		bit53_result_ = uint8_t((result&0x8) | ((result&0x2) << 4));
 		set_did_compute_flags();
 	};
@@ -426,10 +426,10 @@ template <	class T,
 				case MicroOp::NEG: {
 					const int overflow = (a_ == 0x80);
 					const int result = -a_;
-					const int halfResult = -(a_&0xf);
+					const int half_result = -(a_&0xf);
 
 					a_ = uint8_t(result);
-					set_arithmetic_flags(result, halfResult, overflow ? 0xff : 0x00, Flag::Subtract, a_);
+					set_arithmetic_flags(result, half_result, overflow ? 0xff : 0x00, Flag::Subtract, a_);
 				} break;
 
 				case MicroOp::Increment8: {
@@ -520,11 +520,11 @@ template <	class T,
 					const uint16_t sourceValue = *static_cast<uint16_t *>(operation->source);
 					const uint16_t destinationValue = memptr_.full;
 					const int result = sourceValue + destinationValue;
-					const int halfResult = (sourceValue&0xfff) + (destinationValue&0xfff);
+					const int half_result = (sourceValue&0xfff) + (destinationValue&0xfff);
 
 					bit53_result_ = uint8_t(result >> 8);
 					carry_result_ = uint8_t(result >> 16);
-					half_carry_result_ = uint8_t(halfResult >> 8);
+					half_carry_result_ = uint8_t(half_result >> 8);
 					subtract_flag_ = 0;
 					set_did_compute_flags();
 
@@ -537,7 +537,7 @@ template <	class T,
 					const uint16_t sourceValue = *static_cast<uint16_t *>(operation->source);
 					const uint16_t destinationValue = memptr_.full;
 					const int result = sourceValue + destinationValue + (carry_result_ & Flag::Carry);
-					const int halfResult = (sourceValue&0xfff) + (destinationValue&0xfff) + (carry_result_ & Flag::Carry);
+					const int half_result = (sourceValue&0xfff) + (destinationValue&0xfff) + (carry_result_ & Flag::Carry);
 
 					const int overflow = (result ^ destinationValue) & ~(destinationValue ^ sourceValue);
 
@@ -546,7 +546,7 @@ template <	class T,
 					zero_result_	= uint8_t(result | sign_result_);
 					subtract_flag_	= 0;
 					carry_result_	= uint8_t(result >> 16);
-					half_carry_result_ = uint8_t(halfResult >> 8);
+					half_carry_result_ = uint8_t(half_result >> 8);
 					parity_overflow_result_ = uint8_t(overflow >> 13);
 					set_did_compute_flags();
 
@@ -559,7 +559,7 @@ template <	class T,
 					const uint16_t sourceValue = *static_cast<uint16_t *>(operation->source);
 					const uint16_t destinationValue = memptr_.full;
 					const int result = destinationValue - sourceValue - (carry_result_ & Flag::Carry);
-					const int halfResult = (destinationValue&0xfff) - (sourceValue&0xfff) - (carry_result_ & Flag::Carry);
+					const int half_result = (destinationValue&0xfff) - (sourceValue&0xfff) - (carry_result_ & Flag::Carry);
 
 					// subtraction, so parity rules are:
 					// signs of operands were different,
@@ -571,7 +571,7 @@ template <	class T,
 					zero_result_	= uint8_t(result | sign_result_);
 					subtract_flag_	= Flag::Subtract;
 					carry_result_	= uint8_t(result >> 16);
-					half_carry_result_ = uint8_t(halfResult >> 8);
+					half_carry_result_ = uint8_t(half_result >> 8);
 					parity_overflow_result_ = uint8_t(overflow >> 13);
 					set_did_compute_flags();
 

--- a/Processors/Z80/Implementation/Z80Storage.hpp
+++ b/Processors/Z80/Implementation/Z80Storage.hpp
@@ -115,6 +115,9 @@ class ProcessorStorage {
 			void *destination = nullptr;
 			PartialMachineCycle machine_cycle{};
 		};
+		static constexpr bool is_terminal(MicroOp::Type type) {
+			return type == MicroOp::MoveToNextProgram || type == MicroOp::DecodeOperation;
+		}
 
 		struct InstructionPage {
 			std::vector<MicroOp *> instructions;

--- a/Processors/Z80/State/State.hpp
+++ b/Processors/Z80/State/State.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2020 Thomas Harte. All rights reserved.
 //
 
-#ifndef Z80_State_hpp
-#define Z80_State_hpp
+#pragma once
 
 #include "../../../Reflection/Enum.hpp"
 #include "../../../Reflection/Struct.hpp"
@@ -96,5 +95,3 @@ struct State: public Reflection::StructImpl<State> {
 
 }
 }
-
-#endif /* Z80_State_hpp */

--- a/Processors/Z80/Z80.hpp
+++ b/Processors/Z80/Z80.hpp
@@ -9,6 +9,7 @@
 #ifndef Z80_hpp
 #define Z80_hpp
 
+#include <algorithm>
 #include <cassert>
 #include <vector>
 #include <cstdint>

--- a/Processors/Z80/Z80.hpp
+++ b/Processors/Z80/Z80.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef Z80_hpp
-#define Z80_hpp
+#pragma once
 
 #include <algorithm>
 #include <cassert>
@@ -538,5 +537,3 @@ template <class T, bool uses_bus_request, bool uses_wait_line> class Processor: 
 #include "Implementation/Z80Implementation.hpp"
 
 }
-
-#endif /* Z80_hpp */

--- a/Reflection/Dispatcher.hpp
+++ b/Reflection/Dispatcher.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef Dispatcher_hpp
-#define Dispatcher_hpp
+#pragma once
 
 #include <algorithm>
 #include <cstdint>
@@ -170,5 +169,3 @@ struct SubrangeDispatcher {
 #undef index2048
 
 }
-
-#endif /* Dispatcher_hpp */

--- a/Reflection/Enum.hpp
+++ b/Reflection/Enum.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2020 Thomas Harte. All rights reserved.
 //
 
-#ifndef Enum_hpp
-#define Enum_hpp
+#pragma once
 
 #include <algorithm>
 #include <cctype>
@@ -169,5 +168,3 @@ class Enum {
 };
 
 }
-
-#endif /* Enum_hpp */

--- a/Reflection/Struct.hpp
+++ b/Reflection/Struct.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2020 Thomas Harte. All rights reserved.
 //
 
-#ifndef Struct_hpp
-#define Struct_hpp
+#pragma once
 
 #include <cassert>
 #include <cstdarg>
@@ -428,5 +427,3 @@ template <typename Type> Type get(const Struct &target, const std::string &name,
 }
 
 }
-
-#endif /* Struct_hpp */

--- a/SignalProcessing/FIRFilter.cpp
+++ b/SignalProcessing/FIRFilter.cpp
@@ -11,7 +11,7 @@
 #include <cmath>
 
 #ifndef M_PI
-#define M_PI 3.1415926f
+static constexpr float M_PI = 3.1415926f;
 #endif
 
 using namespace SignalProcessing;

--- a/SignalProcessing/FIRFilter.hpp
+++ b/SignalProcessing/FIRFilter.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2011 Thomas Harte. All rights reserved.
 //
 
-#ifndef FIRFilter_hpp
-#define FIRFilter_hpp
+#pragma once
 
 // Use the Accelerate framework to vectorise, unless this is a Qt build.
 // Primarily that avoids gymnastics in the QMake file; it also eliminates
@@ -101,5 +100,3 @@ class FIRFilter {
 };
 
 }
-
-#endif

--- a/SignalProcessing/Stepper.hpp
+++ b/SignalProcessing/Stepper.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef Stepper_hpp
-#define Stepper_hpp
+#pragma once
 
 #include <cstdint>
 
@@ -94,5 +93,3 @@ class Stepper {
 };
 
 }
-
-#endif /* Stepper_hpp */

--- a/Storage/Cartridge/Cartridge.hpp
+++ b/Storage/Cartridge/Cartridge.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef Storage_Cartridge_hpp
-#define Storage_Cartridge_hpp
+#pragma once
 
 #include <vector>
 #include <memory>
@@ -81,5 +80,3 @@ class Cartridge {
 };
 
 }
-
-#endif /* ROM_hpp */

--- a/Storage/Cartridge/Encodings/CommodoreROM.hpp
+++ b/Storage/Cartridge/Encodings/CommodoreROM.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef CommodoreROM_hpp
-#define CommodoreROM_hpp
+#pragma once
 
 #include <vector>
 #include <cstdint>
@@ -17,5 +16,3 @@ namespace Storage::Cartridge::Encodings::CommodoreROM {
 bool isROM(const std::vector<uint8_t> &);
 
 }
-
-#endif /* CommodoreROM_hpp */

--- a/Storage/Cartridge/Formats/BinaryDump.hpp
+++ b/Storage/Cartridge/Formats/BinaryDump.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef Storage_Cartridge_BinaryDump_hpp
-#define Storage_Cartridge_BinaryDump_hpp
+#pragma once
 
 #include "../Cartridge.hpp"
 
@@ -25,5 +24,3 @@ class BinaryDump : public Cartridge {
 };
 
 }
-
-#endif /* AcornROM_hpp */

--- a/Storage/Cartridge/Formats/PRG.hpp
+++ b/Storage/Cartridge/Formats/PRG.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef Storage_Cartridge_PRG_hpp
-#define Storage_Cartridge_PRG_hpp
+#pragma once
 
 #include "../Cartridge.hpp"
 
@@ -25,5 +24,3 @@ class PRG : public Cartridge {
 };
 
 }
-
-#endif /* PRG_hpp */

--- a/Storage/Data/Commodore.hpp
+++ b/Storage/Data/Commodore.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef Storage_Data_Commodore_hpp
-#define Storage_Data_Commodore_hpp
+#pragma once
 
 #include <cstdint>
 #include <string>
@@ -17,5 +16,3 @@ namespace Storage::Data::Commodore {
 std::wstring petscii_from_bytes(const uint8_t *string, int length, bool shifted);
 
 }
-
-#endif /* Commodore_hpp */

--- a/Storage/Data/ZX8081.hpp
+++ b/Storage/Data/ZX8081.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef Storage_Data_ZX8081_hpp
-#define Storage_Data_ZX8081_hpp
+#pragma once
 
 #include <cstdint>
 #include <memory>
@@ -28,5 +27,3 @@ std::wstring StringFromData(const std::vector<uint8_t> &data, bool is_zx81);
 std::vector<uint8_t> DataFromString(const std::wstring &string, bool is_zx81);
 
 }
-
-#endif /* ZX8081_hpp */

--- a/Storage/Disk/Controller/DiskController.hpp
+++ b/Storage/Disk/Controller/DiskController.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef Storage_Disk_Controller_hpp
-#define Storage_Disk_Controller_hpp
+#pragma once
 
 #include "../Drive.hpp"
 #include "../DPLL/DigitalPhaseLockedLoop.hpp"
@@ -163,5 +162,3 @@ class Controller:
 };
 
 }
-
-#endif /* DiskDrive_hpp */

--- a/Storage/Disk/Controller/MFMDiskController.hpp
+++ b/Storage/Disk/Controller/MFMDiskController.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef MFMDiskController_hpp
-#define MFMDiskController_hpp
+#pragma once
 
 #include "DiskController.hpp"
 #include "../../../Numeric/CRC.hpp"
@@ -166,5 +165,3 @@ class MFMController: public Controller {
 };
 
 }
-
-#endif /* MFMDiskController_hpp */

--- a/Storage/Disk/DPLL/DigitalPhaseLockedLoop.hpp
+++ b/Storage/Disk/DPLL/DigitalPhaseLockedLoop.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef DigitalPhaseLockedLoop_hpp
-#define DigitalPhaseLockedLoop_hpp
+#pragma once
 
 #include <array>
 #include <cassert>
@@ -132,5 +131,3 @@ template <typename BitHandler, size_t length_of_history = 3> class DigitalPhaseL
 };
 
 }
-
-#endif /* DigitalPhaseLockedLoop_hpp */

--- a/Storage/Disk/Disk.hpp
+++ b/Storage/Disk/Disk.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef Disk_hpp
-#define Disk_hpp
+#pragma once
 
 #include <map>
 #include <memory>
@@ -69,5 +68,3 @@ class Disk {
 };
 
 }
-
-#endif /* Disk_hpp */

--- a/Storage/Disk/DiskImage/DiskImage.hpp
+++ b/Storage/Disk/DiskImage/DiskImage.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef DiskImage_hpp
-#define DiskImage_hpp
+#pragma once
 
 #include <map>
 #include <memory>
@@ -119,5 +118,3 @@ template <typename T> class DiskImageHolder: public DiskImageHolderBase, public 
 #include "DiskImageImplementation.hpp"
 
 }
-
-#endif /* DiskImage_hpp */

--- a/Storage/Disk/DiskImage/Formats/2MG.hpp
+++ b/Storage/Disk/DiskImage/Formats/2MG.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2020 Thomas Harte. All rights reserved.
 //
 
-#ifndef _MG_hpp
-#define _MG_hpp
+#pragma once
 
 #include "../DiskImage.hpp"
 #include "../../../MassStorage/MassStorageDevice.hpp"
@@ -34,5 +33,3 @@ class Disk2MG {
 };
 
 }
-
-#endif /* _MG_hpp */

--- a/Storage/Disk/DiskImage/Formats/AcornADF.hpp
+++ b/Storage/Disk/DiskImage/Formats/AcornADF.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef AcornADF_hpp
-#define AcornADF_hpp
+#pragma once
 
 #include "MFMSectorDump.hpp"
 
@@ -37,5 +36,3 @@ class AcornADF: public MFMSectorDump {
 };
 
 }
-
-#endif /* AcornADF_hpp */

--- a/Storage/Disk/DiskImage/Formats/AmigaADF.hpp
+++ b/Storage/Disk/DiskImage/Formats/AmigaADF.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef AmigaADF_hpp
-#define AmigaADF_hpp
+#pragma once
 
 #include "MFMSectorDump.hpp"
 
@@ -41,5 +40,3 @@ class AmigaADF: public DiskImage {
 };
 
 }
-
-#endif /* AmigaADF_hpp */

--- a/Storage/Disk/DiskImage/Formats/AppleDSK.hpp
+++ b/Storage/Disk/DiskImage/Formats/AppleDSK.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef AppleDSK_hpp
-#define AppleDSK_hpp
+#pragma once
 
 #include "../DiskImage.hpp"
 #include "../../../FileHolder.hpp"
@@ -46,5 +45,3 @@ class AppleDSK: public DiskImage {
 };
 
 }
-
-#endif /* AppleDSK_hpp */

--- a/Storage/Disk/DiskImage/Formats/CPCDSK.hpp
+++ b/Storage/Disk/DiskImage/Formats/CPCDSK.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef CPCDSK_hpp
-#define CPCDSK_hpp
+#pragma once
 
 #include "../DiskImage.hpp"
 #include "../../../FileHolder.hpp"
@@ -70,5 +69,3 @@ class CPCDSK: public DiskImage {
 };
 
 }
-
-#endif /* CPCDSK_hpp */

--- a/Storage/Disk/DiskImage/Formats/D64.hpp
+++ b/Storage/Disk/DiskImage/Formats/D64.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef D64_hpp
-#define D64_hpp
+#pragma once
 
 #include "../DiskImage.hpp"
 #include "../../../FileHolder.hpp"
@@ -39,5 +38,3 @@ class D64: public DiskImage {
 };
 
 }
-
-#endif /* D64_hpp */

--- a/Storage/Disk/DiskImage/Formats/DMK.hpp
+++ b/Storage/Disk/DiskImage/Formats/DMK.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef DMK_hpp
-#define DMK_hpp
+#pragma once
 
 #include "../DiskImage.hpp"
 #include "../../../FileHolder.hpp"
@@ -49,5 +48,3 @@ class DMK: public DiskImage {
 };
 
 }
-
-#endif /* DMK_hpp */

--- a/Storage/Disk/DiskImage/Formats/FAT12.hpp
+++ b/Storage/Disk/DiskImage/Formats/FAT12.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef FAT12_hpp
-#define FAT12_hpp
+#pragma once
 
 #include "MFMSectorDump.hpp"
 
@@ -35,5 +34,3 @@ class FAT12: public MFMSectorDump {
 };
 
 }
-
-#endif /* FAT12_hpp */

--- a/Storage/Disk/DiskImage/Formats/G64.hpp
+++ b/Storage/Disk/DiskImage/Formats/G64.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef G64_hpp
-#define G64_hpp
+#pragma once
 
 #include "../DiskImage.hpp"
 #include "../../../FileHolder.hpp"
@@ -42,5 +41,3 @@ class G64: public DiskImage {
 };
 
 }
-
-#endif /* G64_hpp */

--- a/Storage/Disk/DiskImage/Formats/HFE.hpp
+++ b/Storage/Disk/DiskImage/Formats/HFE.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef HFE_hpp
-#define HFE_hpp
+#pragma once
 
 #include "../DiskImage.hpp"
 #include "../../../FileHolder.hpp"
@@ -47,5 +46,3 @@ class HFE: public DiskImage {
 };
 
 }
-
-#endif /* HFE_hpp */

--- a/Storage/Disk/DiskImage/Formats/IMD.hpp
+++ b/Storage/Disk/DiskImage/Formats/IMD.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2023 Thomas Harte. All rights reserved.
 //
 
-#ifndef IMD_hpp
-#define IMD_hpp
+#pragma once
 
 #include "../DiskImage.hpp"
 #include "../../../FileHolder.hpp"
@@ -41,5 +40,3 @@ class IMD: public DiskImage {
 };
 
 }
-
-#endif /* IMD_hpp */

--- a/Storage/Disk/DiskImage/Formats/IPF.hpp
+++ b/Storage/Disk/DiskImage/Formats/IPF.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef IPF_hpp
-#define IPF_hpp
+#pragma once
 
 #include "../DiskImage.hpp"
 #include "../../Track/PCMTrack.hpp"
@@ -85,5 +84,3 @@ class IPF: public DiskImage, public TargetPlatform::TypeDistinguisher {
 };
 
 }
-
-#endif /* IPF_hpp */

--- a/Storage/Disk/DiskImage/Formats/MFMSectorDump.hpp
+++ b/Storage/Disk/DiskImage/Formats/MFMSectorDump.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef SectorDump_hpp
-#define SectorDump_hpp
+#pragma once
 
 #include "../DiskImage.hpp"
 #include "../../../FileHolder.hpp"
@@ -42,5 +41,3 @@ class MFMSectorDump: public DiskImage {
 };
 
 }
-
-#endif /* SectorDump_hpp */

--- a/Storage/Disk/DiskImage/Formats/MSA.hpp
+++ b/Storage/Disk/DiskImage/Formats/MSA.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
-#ifndef MSA_hpp
-#define MSA_hpp
+#pragma once
 
 #include "../DiskImage.hpp"
 #include "../../../FileHolder.hpp"
@@ -41,5 +40,3 @@ class MSA final: public DiskImage {
 };
 
 }
-
-#endif /* MSA_hpp */

--- a/Storage/Disk/DiskImage/Formats/MacintoshIMG.hpp
+++ b/Storage/Disk/DiskImage/Formats/MacintoshIMG.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
-#ifndef MacintoshIMG_hpp
-#define MacintoshIMG_hpp
+#pragma once
 
 #include "../DiskImage.hpp"
 #include "../../../FileHolder.hpp"
@@ -73,5 +72,3 @@ class MacintoshIMG: public DiskImage {
 };
 
 }
-
-#endif /* DiskCopy42_hpp */

--- a/Storage/Disk/DiskImage/Formats/NIB.hpp
+++ b/Storage/Disk/DiskImage/Formats/NIB.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef NIB_hpp
-#define NIB_hpp
+#pragma once
 
 #include "../DiskImage.hpp"
 #include "../../../FileHolder.hpp"
@@ -45,5 +44,3 @@ class NIB: public DiskImage {
 };
 
 }
-
-#endif /* NIB_hpp */

--- a/Storage/Disk/DiskImage/Formats/OricMFMDSK.hpp
+++ b/Storage/Disk/DiskImage/Formats/OricMFMDSK.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef OricMFMDSK_hpp
-#define OricMFMDSK_hpp
+#pragma once
 
 #include "../DiskImage.hpp"
 #include "../../../FileHolder.hpp"
@@ -46,5 +45,3 @@ class OricMFMDSK: public DiskImage {
 };
 
 }
-
-#endif /* OricMFMDSK_hpp */

--- a/Storage/Disk/DiskImage/Formats/PCBooter.hpp
+++ b/Storage/Disk/DiskImage/Formats/PCBooter.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef PCBooter_hpp
-#define PCBooter_hpp
+#pragma once
 
 #include "MFMSectorDump.hpp"
 
@@ -34,5 +33,3 @@ class PCBooter: public MFMSectorDump {
 };
 
 }
-
-#endif /* PCBooter_hpp */

--- a/Storage/Disk/DiskImage/Formats/SSD.hpp
+++ b/Storage/Disk/DiskImage/Formats/SSD.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef SSD_hpp
-#define SSD_hpp
+#pragma once
 
 #include "MFMSectorDump.hpp"
 
@@ -37,5 +36,3 @@ class SSD: public MFMSectorDump {
 };
 
 }
-
-#endif /* SSD_hpp */

--- a/Storage/Disk/DiskImage/Formats/STX.hpp
+++ b/Storage/Disk/DiskImage/Formats/STX.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
-#ifndef STX_hpp
-#define STX_hpp
+#pragma once
 
 #include "../DiskImage.hpp"
 #include "../../../FileHolder.hpp"
@@ -44,5 +43,3 @@ class STX: public DiskImage {
 };
 
 }
-
-#endif /* STX_hpp */

--- a/Storage/Disk/DiskImage/Formats/Utility/ImplicitSectors.hpp
+++ b/Storage/Disk/DiskImage/Formats/Utility/ImplicitSectors.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef ImplicitSectors_hpp
-#define ImplicitSectors_hpp
+#pragma once
 
 #include "../../../Track/Track.hpp"
 #include <memory>
@@ -22,5 +21,3 @@ std::shared_ptr<Track> track_for_sectors(const uint8_t *source, int number_of_se
 void decode_sectors(const Track &track, uint8_t *destination, uint8_t first_sector, uint8_t last_sector, uint8_t sector_size, Storage::Encodings::MFM::Density density);
 
 }
-
-#endif /* ImplicitSectors_hpp */

--- a/Storage/Disk/DiskImage/Formats/WOZ.hpp
+++ b/Storage/Disk/DiskImage/Formats/WOZ.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef WOZ_hpp
-#define WOZ_hpp
+#pragma once
 
 #include "../DiskImage.hpp"
 #include "../../../FileHolder.hpp"
@@ -56,5 +55,3 @@ class WOZ: public DiskImage {
 };
 
 }
-
-#endif /* WOZ_hpp */

--- a/Storage/Disk/Drive.hpp
+++ b/Storage/Disk/Drive.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef Drive_hpp
-#define Drive_hpp
+#pragma once
 
 #include "Disk.hpp"
 #include "Track/PCMSegment.hpp"
@@ -296,5 +295,3 @@ class Drive: public ClockingHint::Source, public TimedEventLoop {
 };
 
 }
-
-#endif /* Drive_hpp */

--- a/Storage/Disk/Encodings/AppleGCR/Encoder.hpp
+++ b/Storage/Disk/Encodings/AppleGCR/Encoder.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef AppleGCR_hpp
-#define AppleGCR_hpp
+#pragma once
 
 #include <cstdint>
 #include "../../../Disk/Track/PCMSegment.hpp"
@@ -92,5 +91,3 @@ Storage::Disk::PCMSegment five_and_three_data(const uint8_t *source);
 Storage::Disk::PCMSegment five_and_three_sync(int length);
 
 }
-
-#endif /* AppleGCR_hpp */

--- a/Storage/Disk/Encodings/AppleGCR/Sector.hpp
+++ b/Storage/Disk/Encodings/AppleGCR/Sector.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef Sector_h
-#define Sector_h
+#pragma once
 
 #include <cstdint>
 #include <vector>
@@ -75,5 +74,3 @@ struct Sector {
 };
 
 }
-
-#endif /* Sector_h */

--- a/Storage/Disk/Encodings/AppleGCR/SegmentParser.hpp
+++ b/Storage/Disk/Encodings/AppleGCR/SegmentParser.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2018 Thomas Harte. All rights reserved.
 //
 
-#ifndef TrackParser_hpp
-#define TrackParser_hpp
+#pragma once
 
 #include "Sector.hpp"
 #include "../../Track/PCMSegment.hpp"
@@ -22,5 +21,3 @@ namespace Storage::Encodings::AppleGCR {
 std::map<std::size_t, Sector> sectors_from_segment(const Disk::PCMSegment &segment);
 
 }
-
-#endif /* TrackParser_hpp */

--- a/Storage/Disk/Encodings/CommodoreGCR.hpp
+++ b/Storage/Disk/Encodings/CommodoreGCR.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef Storage_Disk_Encodings_CommodoreGCR_hpp
-#define Storage_Disk_Encodings_CommodoreGCR_hpp
+#pragma once
 
 #include "../../Storage.hpp"
 #include <cstdint>
@@ -48,5 +47,3 @@ namespace CommodoreGCR {
 }
 
 }
-
-#endif /* CommodoreGCR_hpp */

--- a/Storage/Disk/Encodings/MFM/Constants.hpp
+++ b/Storage/Disk/Encodings/MFM/Constants.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef Constants_h
-#define Constants_h
+#pragma once
 
 #include "../../../Storage.hpp"
 
@@ -52,5 +51,3 @@ constexpr Time bit_length(Density density) {
 }
 
 }
-
-#endif /* Constants_h */

--- a/Storage/Disk/Encodings/MFM/Encoder.hpp
+++ b/Storage/Disk/Encodings/MFM/Encoder.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef Storage_Disk_Encodings_MFM_hpp
-#define Storage_Disk_Encodings_MFM_hpp
+#pragma once
 
 #include <cstdint>
 #include <memory>
@@ -79,5 +78,3 @@ std::unique_ptr<Encoder> GetMFMEncoder(std::vector<bool> &target, std::vector<bo
 std::unique_ptr<Encoder> GetFMEncoder(std::vector<bool> &target, std::vector<bool> *fuzzy_target = nullptr);
 
 }
-
-#endif /* MFM_hpp */

--- a/Storage/Disk/Encodings/MFM/Parser.hpp
+++ b/Storage/Disk/Encodings/MFM/Parser.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef Parser_hpp
-#define Parser_hpp
+#pragma once
 
 #include "Constants.hpp"
 #include "Sector.hpp"
@@ -57,5 +56,3 @@ class Parser {
 };
 
 }
-
-#endif /* Parser_hpp */

--- a/Storage/Disk/Encodings/MFM/Sector.hpp
+++ b/Storage/Disk/Encodings/MFM/Sector.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef Sector_h
-#define Sector_h
+#pragma once
 
 #include <cstdint>
 #include <vector>
@@ -53,5 +52,3 @@ struct Sector {
 };
 
 }
-
-#endif /* Sector_h */

--- a/Storage/Disk/Encodings/MFM/SegmentParser.hpp
+++ b/Storage/Disk/Encodings/MFM/SegmentParser.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef SegmentParser_hpp
-#define SegmentParser_hpp
+#pragma once
 
 #include "Constants.hpp"
 #include "Sector.hpp"
@@ -26,5 +25,3 @@ using SectorMap = std::map<std::size_t, Sector>;
 SectorMap sectors_from_segment(const Disk::PCMSegment &segment, Density density);
 
 }
-
-#endif /* SegmentParser_hpp */

--- a/Storage/Disk/Encodings/MFM/Shifter.hpp
+++ b/Storage/Disk/Encodings/MFM/Shifter.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef Shifter_hpp
-#define Shifter_hpp
+#pragma once
 
 #include <cstdint>
 #include <memory>
@@ -79,5 +78,3 @@ class Shifter {
 };
 
 }
-
-#endif /* Shifter_hpp */

--- a/Storage/Disk/Parsers/CPM.hpp
+++ b/Storage/Disk/Parsers/CPM.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef Storage_Disk_Parsers_CPM_hpp
-#define Storage_Disk_Parsers_CPM_hpp
+#pragma once
 
 #include "../Disk.hpp"
 
@@ -43,5 +42,3 @@ struct Catalogue {
 std::unique_ptr<Catalogue> GetCatalogue(const std::shared_ptr<Storage::Disk::Disk> &disk, const ParameterBlock &parameters);
 
 }
-
-#endif /* Storage_Disk_Parsers_CPM_hpp */

--- a/Storage/Disk/Parsers/FAT.hpp
+++ b/Storage/Disk/Parsers/FAT.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef Storage_Disk_Parsers_FAT_hpp
-#define Storage_Disk_Parsers_FAT_hpp
+#pragma once
 
 #include "../Disk.hpp"
 
@@ -71,5 +70,3 @@ std::optional<std::vector<uint8_t>> GetFile(const std::shared_ptr<Storage::Disk:
 std::optional<Directory> GetDirectory(const std::shared_ptr<Storage::Disk::Disk> &disk, const Volume &volume, const File &file);
 
 }
-
-#endif /* FAT_hpp */

--- a/Storage/Disk/Track/PCMSegment.hpp
+++ b/Storage/Disk/Track/PCMSegment.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef PCMSegment_hpp
-#define PCMSegment_hpp
+#pragma once
 
 #include <cstdint>
 #include <memory>
@@ -203,5 +202,3 @@ class PCMSegmentEventSource {
 };
 
 }
-
-#endif /* PCMSegment_hpp */

--- a/Storage/Disk/Track/PCMTrack.hpp
+++ b/Storage/Disk/Track/PCMTrack.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef PCMTrack_hpp
-#define PCMTrack_hpp
+#pragma once
 
 #include "Track.hpp"
 #include "PCMSegment.hpp"
@@ -89,5 +88,3 @@ class PCMTrack: public Track {
 };
 
 }
-
-#endif /* PCMTrack_hpp */

--- a/Storage/Disk/Track/Track.hpp
+++ b/Storage/Disk/Track/Track.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef Track_h
-#define Track_h
+#pragma once
 
 #include "../../Storage.hpp"
 #include <tuple>
@@ -126,5 +125,3 @@ class Track {
 };
 
 }
-
-#endif /* Track_h */

--- a/Storage/Disk/Track/TrackSerialiser.hpp
+++ b/Storage/Disk/Track/TrackSerialiser.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef TrackSerialiser_h
-#define TrackSerialiser_h
+#pragma once
 
 #include "../DPLL/DigitalPhaseLockedLoop.hpp"
 #include "PCMSegment.hpp"
@@ -32,5 +31,3 @@ namespace Storage::Disk {
 PCMSegment track_serialisation(const Track &track, Time length_of_a_bit);
 
 }
-
-#endif /* TrackSerialiser_h */

--- a/Storage/Disk/Track/UnformattedTrack.hpp
+++ b/Storage/Disk/Track/UnformattedTrack.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef UnformattedTrack_hpp
-#define UnformattedTrack_hpp
+#pragma once
 
 #include "Track.hpp"
 
@@ -24,5 +23,3 @@ class UnformattedTrack: public Track {
 };
 
 }
-
-#endif /* UnformattedTrack_hpp */

--- a/Storage/FileHolder.hpp
+++ b/Storage/FileHolder.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef FileHolder_hpp
-#define FileHolder_hpp
+#pragma once
 
 #include <sys/stat.h>
 #include <array>
@@ -249,5 +248,3 @@ class FileHolder final {
 };
 
 }
-
-#endif /* FileHolder_hpp */

--- a/Storage/MassStorage/Encodings/AppleIIVolume.hpp
+++ b/Storage/MassStorage/Encodings/AppleIIVolume.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2022 Thomas Harte. All rights reserved.
 //
 
-#ifndef AppleIIVolume_h
-#define AppleIIVolume_h
+#pragma once
 
 #include "ApplePartitionMap.hpp"
 
@@ -28,5 +27,3 @@ struct VolumeProvider {
 using Mapper = Storage::MassStorage::Encodings::Apple::PartitionMap<VolumeProvider>;
 
 }
-
-#endif /* AppleIIVolume_h */

--- a/Storage/MassStorage/Encodings/ApplePartitionMap.hpp
+++ b/Storage/MassStorage/Encodings/ApplePartitionMap.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2022 Thomas Harte. All rights reserved.
 //
 
-#ifndef ApplePartitionMap_hpp
-#define ApplePartitionMap_hpp
+#pragma once
 
 #include <cstddef>
 #include <cstdint>
@@ -247,5 +246,3 @@ template <typename VolumeProvider> class PartitionMap {
 };
 
 }
-
-#endif /* ApplePartitionMap_hpp */

--- a/Storage/MassStorage/Encodings/MacintoshVolume.hpp
+++ b/Storage/MassStorage/Encodings/MacintoshVolume.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
-#ifndef MacintoshVolume_hpp
-#define MacintoshVolume_hpp
+#pragma once
 
 #include <cstddef>
 #include <cstdint>
@@ -54,5 +53,3 @@ struct VolumeProvider {
 using Mapper = Storage::MassStorage::Encodings::Apple::PartitionMap<VolumeProvider>;
 
 }
-
-#endif /* MacintoshVolume_hpp */

--- a/Storage/MassStorage/Formats/DAT.hpp
+++ b/Storage/MassStorage/Formats/DAT.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef MassStorage_DAT_hpp
-#define MassStorage_DAT_hpp
+#pragma once
 
 #include "RawSectorDump.hpp"
 
@@ -24,5 +23,3 @@ class DAT: public RawSectorDump<256> {
 };
 
 }
-
-#endif /* MassStorage_DAT_hpp */

--- a/Storage/MassStorage/Formats/DSK.hpp
+++ b/Storage/MassStorage/Formats/DSK.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef MassStorage_DSK_hpp
-#define MassStorage_DSK_hpp
+#pragma once
 
 #include "RawSectorDump.hpp"
 
@@ -24,5 +23,3 @@ class DSK: public RawSectorDump<512> {
 };
 
 }
-
-#endif /* MassStorage_DSK_hpp */

--- a/Storage/MassStorage/Formats/HDV.hpp
+++ b/Storage/MassStorage/Formats/HDV.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2022 Thomas Harte. All rights reserved.
 //
 
-#ifndef HDV_hpp
-#define HDV_hpp
+#pragma once
 
 #include "../MassStorageDevice.hpp"
 #include "../../FileHolder.hpp"
@@ -50,5 +49,3 @@ class HDV: public MassStorageDevice {
 };
 
 }
-
-#endif /* HDV_hpp */

--- a/Storage/MassStorage/Formats/HFV.hpp
+++ b/Storage/MassStorage/Formats/HFV.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
-#ifndef HFV_hpp
-#define HFV_hpp
+#pragma once
 
 #include "../MassStorageDevice.hpp"
 #include "../../FileHolder.hpp"
@@ -48,5 +47,3 @@ class HFV: public MassStorageDevice, public Encodings::Macintosh::Volume {
 };
 
 }
-
-#endif /* HFV_hpp */

--- a/Storage/MassStorage/Formats/RawSectorDump.hpp
+++ b/Storage/MassStorage/Formats/RawSectorDump.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef RawSectorDump_h
-#define RawSectorDump_h
+#pragma once
 
 #include "../MassStorageDevice.hpp"
 #include "../../FileHolder.hpp"
@@ -53,5 +52,3 @@ template <long sector_size> class RawSectorDump: public MassStorageDevice {
 };
 
 }
-
-#endif /* RawSectorDump_h */

--- a/Storage/MassStorage/MassStorageDevice.hpp
+++ b/Storage/MassStorage/MassStorageDevice.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
-#ifndef MassStorageDevice_hpp
-#define MassStorageDevice_hpp
+#pragma once
 
 #include <cstddef>
 #include <cstdint>
@@ -55,5 +54,3 @@ class MassStorageDevice {
 };
 
 }
-
-#endif /* MassStorageDevice_hpp */

--- a/Storage/MassStorage/SCSI/DirectAccessDevice.hpp
+++ b/Storage/MassStorage/SCSI/DirectAccessDevice.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
-#ifndef SCSI_DirectAccessDevice_hpp
-#define SCSI_DirectAccessDevice_hpp
+#pragma once
 
 #include "Target.hpp"
 #include "../MassStorageDevice.hpp"
@@ -36,5 +35,3 @@ class DirectAccessDevice: public Target::Executor {
 };
 
 }
-
-#endif /* SCSI_DirectAccessDevice_hpp */

--- a/Storage/MassStorage/SCSI/SCSI.hpp
+++ b/Storage/MassStorage/SCSI/SCSI.hpp
@@ -57,8 +57,8 @@ enum Line: BusState {
 	Request			= 1 << 17,
 };
 
-#define us(x)	(x) / 1000000.0
-#define ns(x)	(x) / 1000000000.0
+constexpr double us(double t)	{	return t / 1'000'000.0;		}
+constexpr double ns(double t)	{	return t / 1'000'000'000.0;	}
 
 /// The minimum amount of time that reset must be held for.
 constexpr double ResetHoldTime		= us(25.0);

--- a/Storage/MassStorage/SCSI/SCSI.hpp
+++ b/Storage/MassStorage/SCSI/SCSI.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
-#ifndef SCSI_hpp
-#define SCSI_hpp
+#pragma once
 
 #include <array>
 #include <limits>
@@ -167,5 +166,3 @@ class Bus: public ClockingHint::Source, public Activity::Source {
 };
 
 }
-
-#endif /* SCSI_hpp */

--- a/Storage/MassStorage/SCSI/Target.hpp
+++ b/Storage/MassStorage/SCSI/Target.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
-#ifndef SCSI_Target_hpp
-#define SCSI_Target_hpp
+#pragma once
 
 #include "SCSI.hpp"
 #include "../../../Outputs/Log.hpp"
@@ -396,5 +395,3 @@ template <typename Executor> class Target: public Bus::Observer, public Responde
 #include "TargetImplementation.hpp"
 
 }
-
-#endif /* SCSI_Target_hpp */

--- a/Storage/MassStorage/SCSI/TargetImplementation.hpp
+++ b/Storage/MassStorage/SCSI/TargetImplementation.hpp
@@ -6,6 +6,8 @@
 //  Copyright © 2019 Thomas Harte. All rights reserved.
 //
 
+#pragma once
+
 template <typename Executor> Target<Executor>::Target(Bus &bus, int scsi_id) :
 	bus_(bus),
 	scsi_id_mask_(BusState(1 << scsi_id)),

--- a/Storage/State/SNA.hpp
+++ b/Storage/State/SNA.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef Storage_State_SNA_hpp
-#define Storage_State_SNA_hpp
+#pragma once
 
 #include "../../Analyser/Static/StaticAnalyser.hpp"
 
@@ -18,5 +17,3 @@ struct SNA {
 };
 
 }
-
-#endif /* Storage_State_SNA_hpp */

--- a/Storage/State/SZX.hpp
+++ b/Storage/State/SZX.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef Storage_State_SZX_hpp
-#define Storage_State_SZX_hpp
+#pragma once
 
 #include "../../Analyser/Static/StaticAnalyser.hpp"
 
@@ -18,5 +17,3 @@ struct SZX {
 };
 
 }
-
-#endif /* Storage_State_SZX_hpp */

--- a/Storage/State/Z80.hpp
+++ b/Storage/State/Z80.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef Storage_State_Z80_hpp
-#define Storage_State_Z80_hpp
+#pragma once
 
 #include "../../Analyser/Static/StaticAnalyser.hpp"
 
@@ -18,5 +17,3 @@ struct Z80 {
 };
 
 }
-
-#endif /* Storage_State_Z80_hpp */

--- a/Storage/Storage.hpp
+++ b/Storage/Storage.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef Storage_hpp
-#define Storage_hpp
+#pragma once
 
 #include <cmath>
 #include <cstdint>
@@ -294,5 +293,3 @@ struct Time {
 };
 
 }
-
-#endif /* Storage_h */

--- a/Storage/Tape/Formats/CAS.hpp
+++ b/Storage/Tape/Formats/CAS.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef CAS_hpp
-#define CAS_hpp
+#pragma once
 
 #include "../Tape.hpp"
 #include "../../FileHolder.hpp"
@@ -67,5 +66,3 @@ class CAS: public Tape {
 };
 
 }
-
-#endif /* CAS_hpp */

--- a/Storage/Tape/Formats/CSW.hpp
+++ b/Storage/Tape/Formats/CSW.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef CSW_hpp
-#define CSW_hpp
+#pragma once
 
 #include "../Tape.hpp"
 
@@ -62,5 +61,3 @@ class CSW: public Tape {
 };
 
 }
-
-#endif /* CSW_hpp */

--- a/Storage/Tape/Formats/CommodoreTAP.hpp
+++ b/Storage/Tape/Formats/CommodoreTAP.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef CommodoreTAP_hpp
-#define CommodoreTAP_hpp
+#pragma once
 
 #include "../Tape.hpp"
 #include "../../FileHolder.hpp"
@@ -49,5 +48,3 @@ class CommodoreTAP: public Tape {
 };
 
 }
-
-#endif /* CommodoreTAP_hpp */

--- a/Storage/Tape/Formats/OricTAP.hpp
+++ b/Storage/Tape/Formats/OricTAP.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef OricTAP_hpp
-#define OricTAP_hpp
+#pragma once
 
 #include "../Tape.hpp"
 #include "../../FileHolder.hpp"
@@ -54,5 +53,3 @@ class OricTAP: public Tape {
 };
 
 }
-
-#endif /* OricTAP_hpp */

--- a/Storage/Tape/Formats/TZX.hpp
+++ b/Storage/Tape/Formats/TZX.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef TZX_hpp
-#define TZX_hpp
+#pragma once
 
 #include "../PulseQueuedTape.hpp"
 #include "../../FileHolder.hpp"
@@ -99,5 +98,3 @@ class TZX: public PulseQueuedTape {
 };
 
 }
-
-#endif /* TZX_hpp */

--- a/Storage/Tape/Formats/TapePRG.hpp
+++ b/Storage/Tape/Formats/TapePRG.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef Storage_Tape_PRG_hpp
-#define Storage_Tape_PRG_hpp
+#pragma once
 
 #include "../Tape.hpp"
 #include "../../FileHolder.hpp"
@@ -70,5 +69,3 @@ class PRG: public Tape {
 };
 
 }
-
-#endif /* T64_hpp */

--- a/Storage/Tape/Formats/TapeUEF.hpp
+++ b/Storage/Tape/Formats/TapeUEF.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef TapeUEF_hpp
-#define TapeUEF_hpp
+#pragma once
 
 #include "../PulseQueuedTape.hpp"
 
@@ -73,5 +72,3 @@ class UEF : public PulseQueuedTape, public TargetPlatform::TypeDistinguisher {
 };
 
 }
-
-#endif /* TapeUEF_hpp */

--- a/Storage/Tape/Formats/ZX80O81P.hpp
+++ b/Storage/Tape/Formats/ZX80O81P.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef ZX80O81P_hpp
-#define ZX80O81P_hpp
+#pragma once
 
 #include "../Tape.hpp"
 
@@ -59,5 +58,3 @@ class ZX80O81P: public Tape, public TargetPlatform::TypeDistinguisher {
 };
 
 }
-
-#endif /* ZX80O_hpp */

--- a/Storage/Tape/Formats/ZXSpectrumTAP.hpp
+++ b/Storage/Tape/Formats/ZXSpectrumTAP.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef SpectrumTAP_hpp
-#define SpectrumTAP_hpp
+#pragma once
 
 #include "../Tape.hpp"
 #include "../../FileHolder.hpp"
@@ -55,5 +54,3 @@ class ZXSpectrumTAP: public Tape {
 };
 
 }
-
-#endif /* SpectrumTAP_hpp */

--- a/Storage/Tape/Parsers/Acorn.hpp
+++ b/Storage/Tape/Parsers/Acorn.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef Storage_Tape_Parsers_Acorn_hpp
-#define Storage_Tape_Parsers_Acorn_hpp
+#pragma once
 
 #include "TapeParser.hpp"
 #include "../../../Numeric/CRC.hpp"
@@ -65,5 +64,3 @@ class Parser: public Storage::Tape::Parser<SymbolType>, public Shifter::Delegate
 };
 
 }
-
-#endif /* Acorn_hpp */

--- a/Storage/Tape/Parsers/Commodore.hpp
+++ b/Storage/Tape/Parsers/Commodore.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef Storage_Tape_Parsers_Commodore_hpp
-#define Storage_Tape_Parsers_Commodore_hpp
+#pragma once
 
 #include "TapeParser.hpp"
 #include <memory>
@@ -130,5 +129,3 @@ class Parser: public Storage::Tape::PulseClassificationParser<WaveType, SymbolTy
 };
 
 }
-
-#endif /* Commodore_hpp */

--- a/Storage/Tape/Parsers/MSX.hpp
+++ b/Storage/Tape/Parsers/MSX.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef Storage_Tape_Parsers_MSX_hpp
-#define Storage_Tape_Parsers_MSX_hpp
+#pragma once
 
 #include "../Tape.hpp"
 
@@ -48,5 +47,3 @@ class Parser {
 };
 
 }
-
-#endif /* Storage_Tape_Parsers_MSX_hpp */

--- a/Storage/Tape/Parsers/Oric.hpp
+++ b/Storage/Tape/Parsers/Oric.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef Storage_Tape_Parsers_Oric_hpp
-#define Storage_Tape_Parsers_Oric_hpp
+#pragma once
 
 #include "TapeParser.hpp"
 
@@ -51,5 +50,3 @@ class Parser: public Storage::Tape::PulseClassificationParser<WaveType, SymbolTy
 };
 
 }
-
-#endif /* Oric_hpp */

--- a/Storage/Tape/Parsers/Spectrum.hpp
+++ b/Storage/Tape/Parsers/Spectrum.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef Storage_Tape_Parsers_Spectrum_hpp
-#define Storage_Tape_Parsers_Spectrum_hpp
+#pragma once
 
 #include "TapeParser.hpp"
 
@@ -130,5 +129,3 @@ class Parser: public Storage::Tape::PulseClassificationParser<WaveType, SymbolTy
 };
 
 }
-
-#endif /* Spectrum_hpp */

--- a/Storage/Tape/Parsers/TapeParser.hpp
+++ b/Storage/Tape/Parsers/TapeParser.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef TapeParser_hpp
-#define TapeParser_hpp
+#pragma once
 
 #include "../Tape.hpp"
 
@@ -156,5 +155,3 @@ template <typename WaveType, typename SymbolType> class PulseClassificationParse
 };
 
 }
-
-#endif /* TapeParser_hpp */

--- a/Storage/Tape/Parsers/ZX8081.hpp
+++ b/Storage/Tape/Parsers/ZX8081.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef Storage_Tape_Parsers_ZX8081_hpp
-#define Storage_Tape_Parsers_ZX8081_hpp
+#pragma once
 
 #include "TapeParser.hpp"
 
@@ -56,5 +55,3 @@ class Parser: public Storage::Tape::PulseClassificationParser<WaveType, SymbolTy
 };
 
 }
-
-#endif /* ZX8081_hpp */

--- a/Storage/Tape/PulseQueuedTape.hpp
+++ b/Storage/Tape/PulseQueuedTape.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef PulseQueuedTape_hpp
-#define PulseQueuedTape_hpp
+#pragma once
 
 #include "Tape.hpp"
 #include <vector>
@@ -48,5 +47,3 @@ class PulseQueuedTape: public Tape {
 };
 
 }
-
-#endif /* PulseQueuedTape_hpp */

--- a/Storage/Tape/Tape.hpp
+++ b/Storage/Tape/Tape.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef Tape_hpp
-#define Tape_hpp
+#pragma once
 
 #include <memory>
 
@@ -164,5 +163,3 @@ class BinaryTapePlayer : public TapePlayer {
 };
 
 }
-
-#endif /* Tape_hpp */

--- a/Storage/TargetPlatforms.hpp
+++ b/Storage/TargetPlatforms.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2017 Thomas Harte. All rights reserved.
 //
 
-#ifndef TargetPlatforms_hpp
-#define TargetPlatforms_hpp
+#pragma once
 
 namespace TargetPlatform {
 
@@ -54,5 +53,3 @@ class TypeDistinguisher {
 };
 
 }
-
-#endif /* TargetPlatforms_h */

--- a/Storage/TimedEventLoop.hpp
+++ b/Storage/TimedEventLoop.hpp
@@ -6,8 +6,7 @@
 //  Copyright 2016 Thomas Harte. All rights reserved.
 //
 
-#ifndef TimedEventLoop_hpp
-#define TimedEventLoop_hpp
+#pragma once
 
 #include "Storage.hpp"
 #include "../ClockReceiver/ClockReceiver.hpp"
@@ -107,5 +106,3 @@ namespace Storage {
 	};
 
 }
-
-#endif /* TimedEventLoop_hpp */


### PR DESCRIPTION
Touching, inter alia:
* the Z80;
* the 6502; and
* the static analyser.

... as well as switching all include guards to `#pragma once` because it seems very well-supported, and eliminates the moderate gymnastics of trying to find unique preprocessor names for headers.