### PR TITLE
Fix color video performance on macOS 10.15+

### DIFF
--- a/OSBindings/Mac/Clock Signal/Views/CSScanTargetView.m
+++ b/OSBindings/Mac/Clock Signal/Views/CSScanTargetView.m
@@ -145,12 +145,7 @@ static CVReturn DisplayLinkCallback(__unused CVDisplayLinkRef displayLink, const
 }
 
 - (void)awakeFromNib {
-	// Use the preferred device if available.
-	if(@available(macOS 10.15, *)) {
-		self.device = self.preferredDevice;
-	} else {
-		self.device = MTLCreateSystemDefaultDevice();
-	}
+	self.device = MTLCreateSystemDefaultDevice();
 
 	// Configure for explicit drawing.
 	self.paused = YES;


### PR DESCRIPTION
Closes #1178

I don't know why this fixes it but it does.

Thanks to @RRyanClark for suggesting I look in the area of code that calls `MTLCreateSystemDefaultDevice`.