### PR TITLE
Switch to a better logging interface.

### DIFF
--- a/Analyser/Static/Commodore/StaticAnalyser.cpp
+++ b/Analyser/Static/Commodore/StaticAnalyser.cpp
@@ -93,7 +93,7 @@ Analyser::Static::TargetList Analyser::Static::Commodore::GetTargets(const Media
 		// make a first guess based on loading address
 		switch(files.front().starting_address) {
 			default:
-				LOG("Unrecognised loading address for Commodore program: " << PADHEX(4) << files.front().starting_address);
+				Log::Logger<Log::Source::CommodoreStaticAnalyser>().error().append("Unrecognised loading address for Commodore program: %04x", files.front().starting_address);
 				[[fallthrough]];
 			case 0x1001:
 				memory_model = Target::MemoryModel::Unexpanded;

--- a/Components/1770/1770.cpp
+++ b/Components/1770/1770.cpp
@@ -13,7 +13,7 @@
 
 namespace {
 
-auto logger = Log::Logger<Log::Source::WDFDC>();
+Log::Logger<Log::Source::WDFDC> logger;
 
 }
 

--- a/Components/1770/1770.cpp
+++ b/Components/1770/1770.cpp
@@ -12,9 +12,7 @@
 #include "../../Outputs/Log.hpp"
 
 namespace {
-
 Log::Logger<Log::Source::WDFDC> logger;
-
 }
 
 using namespace WD;

--- a/Components/1770/1770.cpp
+++ b/Components/1770/1770.cpp
@@ -9,9 +9,13 @@
 #include "1770.hpp"
 
 #include "../../Storage/Disk/Encodings/MFM/Constants.hpp"
-
-#define LOG_PREFIX "[WD FDC] "
 #include "../../Outputs/Log.hpp"
+
+namespace {
+
+auto logger = Log::Logger(Log::Source::WDFDC);
+
+}
 
 using namespace WD;
 
@@ -29,10 +33,10 @@ void WD1770::write(int address, uint8_t value) {
 			if((value&0xf0) == 0xd0) {
 				if(value == 0xd0) {
 					// Force interrupt **immediately**.
-					LOG("Force interrupt immediately");
+					logger.info().append("Force interrupt immediately");
 					posit_event(int(Event1770::ForceInterrupt));
 				} else {
-					ERROR("!!!TODO: force interrupt!!!");
+					logger.error().append("TODO: force interrupt");
 					update_status([] (Status &status) {
 						status.type = Status::One;
 					});
@@ -103,10 +107,10 @@ uint8_t WD1770::read(int address) {
 			return status;
 		}
 		case 1:
-			LOG("Returned track " << int(track_));
+			logger.info().append("Returned track %d", track_);
 			return track_;
 		case 2:
-			LOG("Returned sector " << int(sector_));
+			logger.info().append("Returned sector %d", sector_);
 			return sector_;
 		case 3:
 			update_status([] (Status &status) {
@@ -212,7 +216,7 @@ void WD1770::posit_event(int new_event_type) {
 	// Wait for a new command, branch to the appropriate handler.
 	case 0:
 	wait_for_command:
-		LOG("Idle...");
+		logger.info().append("Idle...");
 		set_data_mode(DataMode::Scanning);
 		index_hole_count_ = 0;
 
@@ -229,7 +233,7 @@ void WD1770::posit_event(int new_event_type) {
 			status.track_zero = false;	// Always reset by a non-type 1; so reset regardless and set properly later.
 		});
 
-		LOG("Starting " << PADHEX(2) << int(command_));
+		logger.info().append("Starting %02x", command_);
 
 		if(!(command_ & 0x80)) goto begin_type_1;
 		if(!(command_ & 0x40)) goto begin_type_2;
@@ -259,7 +263,7 @@ void WD1770::posit_event(int new_event_type) {
 			status.data_request = false;
 		});
 
-		LOG("Step/Seek/Restore with track " << int(track_) << " data " << int(data_));
+		logger.info().append("Step/Seek/Restore with track %d data %d", track_, data_);
 		if(!has_motor_on_line() && !has_head_load_line()) goto test_type1_type;
 
 		if(has_motor_on_line()) goto begin_type1_spin_up;
@@ -339,7 +343,7 @@ void WD1770::posit_event(int new_event_type) {
 		READ_ID();
 
 		if(index_hole_count_ == 6) {
-			LOG("Nothing found to verify");
+			logger.info().append("Nothing found to verify");
 			update_status([] (Status &status) {
 				status.seek_error = true;
 			});
@@ -357,7 +361,7 @@ void WD1770::posit_event(int new_event_type) {
 			}
 
 			if(header_[0] == track_) {
-				LOG("Reached track " << std::dec << int(track_));
+				logger.info().append("Reached track %d", track_);
 				update_status([] (Status &status) {
 					status.crc_error = false;
 				});
@@ -430,7 +434,7 @@ void WD1770::posit_event(int new_event_type) {
 		READ_ID();
 
 		if(index_hole_count_ == 5) {
-			LOG("Failed to find sector " << std::dec << int(sector_));
+			logger.info().append("Failed to find sector %d", sector_);
 			update_status([] (Status &status) {
 				status.record_not_found = true;
 			});
@@ -440,12 +444,12 @@ void WD1770::posit_event(int new_event_type) {
 			distance_into_section_ = 0;
 			set_data_mode(DataMode::Scanning);
 
-			LOG("Considering " << std::dec << int(header_[0]) << "/" << int(header_[2]));
+			logger.info().append("Considering %d/%d", header_[0], header_[2]);
 			if(		header_[0] == track_ && header_[2] == sector_ &&
 					(has_motor_on_line() || !(command_&0x02) || ((command_&0x08) >> 3) == header_[1])) {
-				LOG("Found " << std::dec << int(header_[0]) << "/" << int(header_[2]));
+				logger.info().append("Found %d/%d", header_[0], header_[2]);
 				if(get_crc_generator().get_value()) {
-					LOG("CRC error; back to searching");
+					logger.info().append("CRC error; back to searching");
 					update_status([] (Status &status) {
 						status.crc_error = true;
 					});
@@ -503,18 +507,18 @@ void WD1770::posit_event(int new_event_type) {
 			set_data_mode(DataMode::Scanning);
 
 			if(get_crc_generator().get_value()) {
-				LOG("CRC error; terminating");
+				logger.info().append("CRC error; terminating");
 				update_status([] (Status &status) {
 					status.crc_error = true;
 				});
 				goto wait_for_command;
 			}
 
-			LOG("Finished reading sector " << std::dec << int(sector_));
+			logger.info().append("Finished reading sector %d", sector_);
 
 			if(command_ & 0x10) {
 				sector_++;
-				LOG("Advancing to search for sector " << std::dec << int(sector_));
+				logger.info().append("Advancing to search for sector %d", sector_);
 				goto test_type2_write_protection;
 			}
 			goto wait_for_command;
@@ -598,7 +602,7 @@ void WD1770::posit_event(int new_event_type) {
 			sector_++;
 			goto test_type2_write_protection;
 		}
-		LOG("Wrote sector " << std::dec << int(sector_));
+		logger.info().append("Wrote sector %d", sector_);
 		goto wait_for_command;
 
 

--- a/Components/1770/1770.cpp
+++ b/Components/1770/1770.cpp
@@ -103,7 +103,7 @@ uint8_t WD1770::read(int address) {
 				if(status_.type == Status::One)
 					status |= (status_.spin_up ? Flag::SpinUp : 0);
 			}
-//			LOG("Returned status " << PADHEX(2) << int(status) << " of type " << 1+int(status_.type));
+//			logger.info().append("Returned status %02x of type %d", status, 1+int(status_.type));
 			return status;
 		}
 		case 1:

--- a/Components/1770/1770.cpp
+++ b/Components/1770/1770.cpp
@@ -13,7 +13,7 @@
 
 namespace {
 
-auto logger = Log::Logger(Log::Source::WDFDC);
+auto logger = Log::Logger<Log::Source::WDFDC>();
 
 }
 

--- a/Components/68901/MFP68901.cpp
+++ b/Components/68901/MFP68901.cpp
@@ -11,12 +11,13 @@
 #include <algorithm>
 #include <cstring>
 
-#ifndef NDEBUG
-#define NDEBUG
-#endif
-
-#define LOG_PREFIX "[MFP] "
 #include "../../Outputs/Log.hpp"
+
+namespace {
+
+Log::Logger<Log::Source::MFP68901> logger;
+
+}
 
 using namespace Motorola::MFP68901;
 
@@ -64,11 +65,11 @@ uint8_t MFP68901::read(int address) {
 		case 0x11:	case 0x12:	return get_timer_data(address - 0xf);
 
 		// USART block: TODO.
-		case 0x13:		LOG("Read: sync character generator");	break;
-		case 0x14:		LOG("Read: USART control");				break;
-		case 0x15:		LOG("Read: receiver status");			break;
-		case 0x16:		LOG("Read: transmitter status");		break;
-		case 0x17:		LOG("Read: USART data");				break;
+		case 0x13:		logger.error().append("Read: sync character generator");	break;
+		case 0x14:		logger.error().append("Read: USART control");				break;
+		case 0x15:		logger.error().append("Read: receiver status");			break;
+		case 0x16:		logger.error().append("Read: transmitter status");		break;
+		case 0x17:		logger.error().append("Read: USART data");				break;
 	}
 	return 0x00;
 }
@@ -169,11 +170,11 @@ void MFP68901::write(int address, uint8_t value) {
 		break;
 
 		// USART block: TODO.
-		case 0x13:		LOG("Write: sync character generator");	break;
-		case 0x14:		LOG("Write: USART control");			break;
-		case 0x15:		LOG("Write: receiver status");			break;
-		case 0x16:		LOG("Write: transmitter status");		break;
-		case 0x17:		LOG("Write: USART data");				break;
+		case 0x13:		logger.error().append("Write: sync character generator");	break;
+		case 0x14:		logger.error().append("Write: USART control");				break;
+		case 0x15:		logger.error().append("Write: receiver status");			break;
+		case 0x16:		logger.error().append("Write: transmitter status");			break;
+		case 0x17:		logger.error().append("Write: USART data");					break;
 	}
 
 	update_clocking_observer();
@@ -220,7 +221,7 @@ HalfCycles MFP68901::next_sequence_point() {
 // MARK: - Timers
 
 void MFP68901::set_timer_mode(int timer, TimerMode mode, int prescale, bool reset_timer) {
-	LOG("Timer " << timer << " mode set: " << int(mode) << "; prescale: " << prescale);
+	logger.error().append("Timer %d mode set: %d; prescale: %d", timer, mode, prescale);
 	timers_[timer].mode = mode;
 	if(reset_timer) {
 		timers_[timer].prescale_count = 0;
@@ -398,7 +399,7 @@ int MFP68901::acknowledge_interrupt() {
 
 	int selected = 0;
 	while((1 << selected) != mask) ++selected;
-//	LOG("Interrupt acknowledged: " << selected);
+//	logger.error().append("Interrupt acknowledged: %d", selected);
 	return (interrupt_vector_ & 0xf0) | uint8_t(selected);
 }
 

--- a/Components/8530/z8530.cpp
+++ b/Components/8530/z8530.cpp
@@ -262,7 +262,7 @@ void z8530::Channel::write(bool data, uint8_t pointer, uint8_t value) {
 				switch((value >> 3)&7) {
 					default:	/* Do nothing. */		break;
 					case 2:
-//						LOG("reset ext/status interrupts.");
+//						log.info().append("reset ext/status interrupts.");
 						external_status_interrupt_ = false;
 						external_interrupt_status_ = 0;
 					break;

--- a/Components/9918/Implementation/9918.cpp
+++ b/Components/9918/Implementation/9918.cpp
@@ -22,6 +22,8 @@ namespace {
 constexpr unsigned int CRTCyclesPerLine = 1365;
 constexpr unsigned int CRTCyclesDivider = 4;
 
+Log::Logger<Log::Source::TMS9918> logger;
+
 }
 
 template <Personality personality>
@@ -837,7 +839,7 @@ void Base<personality>::commit_register(int reg, uint8_t value) {
 				Storage<personality>::solid_background_ = value & 0x20;
 				Storage<personality>::sprites_enabled_ = !(value & 0x02);
 				if(value & 0x01) {
-					LOG("TODO: Yamaha greyscale");
+					logger.error().append("TODO: Yamaha greyscale");
 				}
 				// b7: "1 = input on colour bus, enable mouse; 1 = output on colour bus, disable mouse" [documentation clearly in error]
 				// b6: 1 = enable light pen
@@ -854,7 +856,7 @@ void Base<personality>::commit_register(int reg, uint8_t value) {
 				// TODO: on the Yamaha, at least, tie this interrupt overtly to vertical state.
 
 				if(value & 0x08) {
-					LOG("TODO: Yamaha interlace mode");
+					logger.error().append("TODO: Yamaha interlace mode");
 				}
 
 				// b7: 1 = 212 lines of pixels; 0 = 192
@@ -918,7 +920,7 @@ void Base<personality>::commit_register(int reg, uint8_t value) {
 			case 20:
 			case 21:
 			case 22:
-//				LOG("TODO: Yamaha colour burst selection; " << PADHEX(2) << +value);
+//				logger.error().append("TODO: Yamaha colour burst selection; %02x", value);
 				// Documentation is "fill with 0s for no colour burst; magic pattern for colour burst"
 			break;
 
@@ -1004,7 +1006,7 @@ void Base<personality>::commit_register(int reg, uint8_t value) {
 				// Kill the command immediately if it's done in zero operations
 				// (e.g. a line of length 0).
 				if(!Storage<personality>::command_ && (value >> 4)) {
-					LOG("TODO: Yamaha command " << PADHEX(2) << +value);
+					logger.error().append("TODO: Yamaha command %02x", value);
 				}
 
 				// Seed timing information if a command was found.

--- a/InstructionSets/M50740/Executor.cpp
+++ b/InstructionSets/M50740/Executor.cpp
@@ -8,19 +8,18 @@
 
 #include "Executor.hpp"
 
+#include "../../Machines/Utility/MemoryFuzzer.hpp"
+#include "../../Outputs/Log.hpp"
+
 #include <algorithm>
 #include <cassert>
 #include <cstring>
-
-#include "../../Machines/Utility/MemoryFuzzer.hpp"
-
-#define LOG_PREFIX "[M50740] "
-#include "../../Outputs/Log.hpp"
 
 using namespace InstructionSet::M50740;
 
 namespace {
 	constexpr int port_remap[] = {0, 1, 2, 0, 3};
+	Log::Logger<Log::Source::M50740> logger;
 }
 
 Executor::Executor(PortHandler &port_handler) : port_handler_(port_handler) {
@@ -83,13 +82,13 @@ uint8_t Executor::read(uint16_t address) {
 	port_handler_.run_ports_for(cycles_since_port_handler_.flush<Cycles>());
 	switch(address) {
 		default:
-			LOG("Unrecognised read from " << PADHEX(4) << address);
+			logger.error().append("Unrecognised read from %02x", address);
 		return 0xff;
 
 		// "Port R"; sixteen four-bit ports
 		case 0xd0: case 0xd1: case 0xd2: case 0xd3: case 0xd4: case 0xd5: case 0xd6: case 0xd7:
 		case 0xd8: case 0xd9: case 0xda: case 0xdb: case 0xdc: case 0xdd: case 0xde: case 0xdf:
-			LOG("Unimplemented Port R read from " << PADHEX(4) << address);
+			logger.error().append("Unimplemented Port R read from %04x", address);
 		return 0x00;
 
 		// Ports P0–P3.
@@ -134,7 +133,7 @@ void Executor::write(uint16_t address, uint8_t value) {
 
 	// ROM 'writes' are almost as easy (albeit unexpected).
 	if(address >= 0x100) {
-		LOG("Attempted ROM write of " << PADHEX(2) << value << " to " << PADHEX(4) << address);
+		logger.info().append("Attempted ROM write of %02x to %04x", value, address);
 		return;
 	}
 
@@ -143,13 +142,13 @@ void Executor::write(uint16_t address, uint8_t value) {
 
 	switch(address) {
 		default:
-			LOG("Unrecognised write of " << PADHEX(2) << value << " to " << PADHEX(4) << address);
+			logger.error().append("Unrecognised write of %02x to %04x", value, address);
 		break;
 
 		// "Port R"; sixteen four-bit ports
 		case 0xd0: case 0xd1: case 0xd2: case 0xd3: case 0xd4: case 0xd5: case 0xd6: case 0xd7:
 		case 0xd8: case 0xd9: case 0xda: case 0xdb: case 0xdc: case 0xdd: case 0xde: case 0xdf:
-			LOG("Unimplemented Port R write of " << PADHEX(2) << value << " from " << PADHEX(4) << address);
+			logger.error().append("Unimplemented Port R write of %02x to %04x", value, address);
 		break;
 
 		// Ports P0–P3.
@@ -779,7 +778,7 @@ template <Operation operation> void Executor::perform(uint8_t *operand [[maybe_u
 		*/
 
 		default:
-			LOG("Unimplemented operation: " << operation);
+			logger.error().append("Unimplemented operation: %d", operation);
 			assert(false);
 	}
 #undef set_nz
@@ -823,13 +822,13 @@ inline void Executor::subtract_duration(int duration) {
 			}
 		} break;
 		case 0x04:
-			LOG("TODO: Timer X; Pulse output mode");
+			logger.error().append("TODO: Timer X; Pulse output mode");
 		break;
 		case 0x08:
-			LOG("TODO: Timer X; Event counter mode");
+			logger.error().append("TODO: Timer X; Event counter mode");
 		break;
 		case 0x0c:
-			LOG("TODO: Timer X; Pulse width measurement mode");
+			logger.error().append("TODO: Timer X; Pulse width measurement mode");
 		break;
 	}
 }

--- a/Machines/Amiga/Audio.cpp
+++ b/Machines/Amiga/Audio.cpp
@@ -10,9 +10,6 @@
 
 #include "Flags.hpp"
 
-#define LOG_PREFIX "[Audio] "
-#include "../../Outputs/Log.hpp"
-
 #include <cassert>
 #include <tuple>
 

--- a/Machines/Amiga/Blitter.cpp
+++ b/Machines/Amiga/Blitter.cpp
@@ -9,19 +9,15 @@
 #include "Blitter.hpp"
 
 #include "Minterms.hpp"
+#include "../../Outputs/Log.hpp"
 
 #include <cassert>
-
-#ifndef NDEBUG
-#define NDEBUG
-#endif
-
-#define LOG_PREFIX "[Blitter] "
-#include "../../Outputs/Log.hpp"
 
 using namespace Amiga;
 
 namespace {
+
+Log::Logger<Log::Source::AmigaBlitter> logger;
 
 /// @returns Either the final carry flag or the output nibble when using fill mode given that it either @c is_exclusive fill mode, or isn't;
 /// and the specified initial @c carry and input @c nibble.
@@ -130,18 +126,18 @@ void Blitter<record_bus>::set_control(int index, uint16_t value) {
 		sequencer_.set_control(value >> 8);
 	}
 	shifts_[index] = value >> 12;
-	LOG("Set control " << index << " to " << PADHEX(4) << value);
+	logger.info().append("Set control %d to %04x", index, value);
 }
 
 template <bool record_bus>
 void Blitter<record_bus>::set_first_word_mask(uint16_t value) {
-	LOG("Set first word mask: " << PADHEX(4) << value);
+	logger.info().append("Set first word mask: %04x", value);
 	a_mask_[0] = value;
 }
 
 template <bool record_bus>
 void Blitter<record_bus>::set_last_word_mask(uint16_t value) {
-	LOG("Set last word mask: " << PADHEX(4) << value);
+	logger.info().append("Set last word mask: %04x", value);
 	a_mask_[1] = value;
 }
 
@@ -153,7 +149,7 @@ void Blitter<record_bus>::set_size(uint16_t value) {
 	if(!width_) width_ = 0x40;
 	height_ = value >> 6;
 	if(!height_) height_ = 1024;
-	LOG("Set size to " << std::dec << width_ << ", " << height_);
+	logger.info().append("Set size to %d, %d", width_, height_);
 
 	// Current assumption: writing this register informs the
 	// blitter that it should treat itself as about to start a new line.
@@ -161,7 +157,7 @@ void Blitter<record_bus>::set_size(uint16_t value) {
 
 template <bool record_bus>
 void Blitter<record_bus>::set_minterms(uint16_t value) {
-	LOG("Set minterms " << PADHEX(4) << value);
+	logger.info().append("Set minterms: %02x", value & 0xff);
 	minterms_ = value & 0xff;
 }
 
@@ -178,7 +174,7 @@ void Blitter<record_bus>::set_minterms(uint16_t value) {
 
 template <bool record_bus>
 void Blitter<record_bus>::set_data(int channel, uint16_t value) {
-	LOG("Set data " << channel << " to " << PADHEX(4) << value);
+	logger.info().append("Set data %d to %04x", channel, value);
 
 	// Ugh, backed myself into a corner. TODO: clean.
 	switch(channel) {
@@ -193,7 +189,7 @@ template <bool record_bus>
 uint16_t Blitter<record_bus>::get_status() {
 	const uint16_t result =
 		(not_zero_flag_ ? 0x0000 : 0x2000) | (height_ ? 0x4000 : 0x0000);
-	LOG("Returned status of " << result);
+	logger.info().append("Returned status of %04x", result);
 	return result;
 }
 

--- a/Machines/Amiga/Blitter.cpp
+++ b/Machines/Amiga/Blitter.cpp
@@ -163,13 +163,13 @@ void Blitter<record_bus>::set_minterms(uint16_t value) {
 
 //template <bool record_bus>
 //void Blitter<record_bus>::set_vertical_size([[maybe_unused]] uint16_t value) {
-//	LOG("Set vertical size " << PADHEX(4) << value);
+//	logger.info().append("Set vertical size %04x", value);
 //	// TODO. This is ECS only, I think. Ditto set_horizontal_size.
 //}
 //
 //template <bool record_bus>
 //void Blitter<record_bus>::set_horizontal_size([[maybe_unused]] uint16_t value) {
-//	LOG("Set horizontal size " << PADHEX(4) << value);
+//	logger.info().append("Set horizontal size %04x", value);
 //}
 
 template <bool record_bus>

--- a/Machines/Amiga/Chipset.cpp
+++ b/Machines/Amiga/Chipset.cpp
@@ -8,16 +8,15 @@
 
 #include "Chipset.hpp"
 
-#ifndef NDEBUG
-#define NDEBUG
-#endif
-
-#define LOG_PREFIX "[Amiga chipset] "
 #include "../../Outputs/Log.hpp"
 
 #include <algorithm>
 #include <cassert>
 #include <tuple>
+
+namespace {
+Log::Logger<Log::Source::AmigaChipset> logger;
+}
 
 using namespace Amiga;
 
@@ -869,10 +868,10 @@ void Chipset::write(uint32_t address, uint16_t value, bool allow_conversion) {
 		break;
 
 		case 0x02a:		// VPOSW
-			LOG("TODO: write vertical position high " << PADHEX(4) << value);
+			logger.error().append("TODO: write vertical position high %04x", value);
 		break;
 		case 0x02c:		// VHPOSW
-			LOG("TODO: write vertical position low " << PADHEX(4) << value);
+			logger.error().append("TODO: write vertical position low %04x", value);
 			is_long_field_ = value & 0x8000;
 		break;
 
@@ -887,11 +886,11 @@ void Chipset::write(uint32_t address, uint16_t value, bool allow_conversion) {
 		case 0x024:	disk_.set_length(value);			break;		// DSKLEN
 
 		case 0x026:		// DSKDAT
-			LOG("TODO: disk DMA; " << PADHEX(4) << value << " to " << address);
+			logger.error().append("TODO: disk DMA; %04x to %04x", value, address);
 		break;
 
 		case 0x09e:		// ADKCON
-			LOG("Write disk control");
+			logger.info().append("Write disk control");
 			ApplySetClear(paula_disk_control_, 0x7fff);
 
 			disk_controller_.set_control(paula_disk_control_);
@@ -905,7 +904,7 @@ void Chipset::write(uint32_t address, uint16_t value, bool allow_conversion) {
 
 		// Refresh.
 		case 0x028:		// REFPTR
-			LOG("TODO (maybe): refresh; " << PADHEX(4) << value << " to " << PADHEX(8) << address);
+			logger.info().append("TODO (maybe): refresh; %04x to %08x", value, address);
 		break;
 
 		// Serial port.
@@ -944,7 +943,7 @@ void Chipset::write(uint32_t address, uint16_t value, bool allow_conversion) {
 		break;
 		case 0x092:		// DDFSTRT
 			if(fetch_window_[0] != value) {
-				LOG("Fetch window start set to " << std::dec << value);
+				logger.info().append("Fetch window start set to %d", value);
 			}
 			fetch_window_[0] = value & 0xfe;
 		break;
@@ -952,7 +951,7 @@ void Chipset::write(uint32_t address, uint16_t value, bool allow_conversion) {
 			// TODO: something in my interpretation of ddfstart and ddfstop
 			// means a + 8 is needed below for high-res displays. Investigate.
 			if(fetch_window_[1] != value) {
-				LOG("Fetch window stop set to " << std::dec << fetch_window_[1]);
+				logger.info().append("Fetch window stop set to %d", fetch_window_[1]);
 			}
 			fetch_window_[1] = value & 0xfe;
 		break;
@@ -989,7 +988,7 @@ void Chipset::write(uint32_t address, uint16_t value, bool allow_conversion) {
 		break;
 
 		case 0x106:		// BPLCON3 (ECS)
-			LOG("TODO: Bitplane control; " << PADHEX(4) << value << " to " << PADHEX(8) << address);
+			logger.error().append("TODO: Bitplane control; %04x to %08x", value, address);
 		break;
 
 		case 0x108:	bitplanes_.set_modulo<0>(value);	break;	// BPL1MOD
@@ -1001,7 +1000,7 @@ void Chipset::write(uint32_t address, uint16_t value, bool allow_conversion) {
 		case 0x116:
 		case 0x118:
 		case 0x11a:
-			LOG("TODO: Bitplane data; " << PADHEX(4) << value << " to " << PADHEX(8) << address);
+			logger.error().append("TODO: Bitplane data; %04x to %08x", value, address);
 		break;
 
 		// Blitter.
@@ -1056,7 +1055,7 @@ void Chipset::write(uint32_t address, uint16_t value, bool allow_conversion) {
 		case 0x088:	copper_.reload<0>();				break;
 		case 0x08a:	copper_.reload<1>();				break;
 		case 0x08c:
-			LOG("TODO: coprocessor instruction fetch identity " << PADHEX(4) << value);
+			logger.error().append("TODO: coprocessor instruction fetch identity %04x", value);
 		break;
 
 		// Sprites.
@@ -1149,10 +1148,10 @@ uint16_t Chipset::read(uint32_t address, bool allow_conversion) {
 
 		// Disk DMA and control.
 		case 0x010:		// ADKCONR
-			LOG("Read disk control");
+			logger.info().append("Read disk control");
 		return paula_disk_control_;
 		case 0x01a:		// DSKBYTR
-			LOG("TODO: disk status");
+			logger.error().append("TODO: disk status");
 			assert(false);	// Not yet implemented.
 		return 0xffff;
 
@@ -1194,7 +1193,7 @@ Chipset::CIAAHandler::CIAAHandler(MemoryMap &map, DiskController &controller, Mo
 void Chipset::CIAAHandler::set_port_output(MOS::MOS6526::Port port, uint8_t value) {
 	if(port) {
 		// CIA A, Port B: Parallel port output.
-		LOG("TODO: parallel output " << PADHEX(2) << +value);
+		logger.info().append("TODO: parallel output %02x", value);
 	} else {
 		// CIA A, Port A:
 		//
@@ -1216,7 +1215,7 @@ void Chipset::CIAAHandler::set_port_output(MOS::MOS6526::Port port, uint8_t valu
 
 uint8_t Chipset::CIAAHandler::get_port_input(MOS::MOS6526::Port port) {
 	if(port) {
-		LOG("TODO: parallel input?");
+		logger.info().append("TODO: parallel input?");
 	} else {
 		// Use the mouse as FIR0, the joystick as FIR1.
 		return
@@ -1256,12 +1255,12 @@ void Chipset::CIABHandler::set_port_output(MOS::MOS6526::Port port, uint8_t valu
 		// b2: SEL
 		// b1: POUT
 		// b0: BUSY
-		LOG("TODO: DTR/RTS/etc: " << PADHEX(2) << +value);
+		logger.error().append("TODO: DTR/RTS/etc: %02x", value);
 	}
 }
 
 uint8_t Chipset::CIABHandler::get_port_input(MOS::MOS6526::Port) {
-	LOG("Unexpected: input for CIA B");
+	logger.error().append("Unexpected: input for CIA B");
 	return 0xff;
 }
 

--- a/Machines/Amiga/Chipset.cpp
+++ b/Machines/Amiga/Chipset.cpp
@@ -877,7 +877,7 @@ void Chipset::write(uint32_t address, uint16_t value, bool allow_conversion) {
 
 		// Joystick/mouse input.
 		case 0x034:		// POTGO
-//			LOG("TODO: pot port start");
+//			logger.error().append("TODO: pot port start");
 		break;
 
 		// Disk DMA and control.
@@ -1143,7 +1143,7 @@ uint16_t Chipset::read(uint32_t address, bool allow_conversion) {
 		case 0x00c:	return joystick(0).get_position();		// JOY1DAT
 
 		case 0x016:		// POTGOR / POTINP
-//			LOG("TODO: pot port read");
+//			logger.error().append("TODO: pot port read");
 		return 0xff00;
 
 		// Disk DMA and control.

--- a/Machines/Amiga/Copper.cpp
+++ b/Machines/Amiga/Copper.cpp
@@ -6,15 +6,10 @@
 //  Copyright © 2021 Thomas Harte. All rights reserved.
 //
 
-#ifndef NDEBUG
-#define NDEBUG
-#endif
-
-#define LOG_PREFIX "[Copper] "
-#include "../../Outputs/Log.hpp"
-
-#include "Chipset.hpp"
 #include "Copper.hpp"
+#include "Chipset.hpp"
+
+#include "../../Outputs/Log.hpp"
 
 using namespace Amiga;
 
@@ -30,6 +25,8 @@ bool satisfies_raster(uint16_t position, uint16_t blitter_status, uint16_t *inst
 	const uint16_t mask = 0x8000 | (instruction[1] & 0x7ffe);
 	return (position & mask) >= (instruction[0] & mask);
 }
+
+Log::Logger<Log::Source::AmigaCopper> logger;
 
 }
 
@@ -85,7 +82,7 @@ bool Copper::advance_dma(uint16_t position, uint16_t blitter_status) {
 
 		case State::Waiting:
 			if(satisfies_raster(position, blitter_status, instruction_)) {
-				LOG("Unblocked waiting for " << PADHEX(4) << instruction_[0] << " at " << PADHEX(4) << position << " with mask " << PADHEX(4) << (instruction_[1] & 0x7ffe));
+				logger.info().append("Unblocked waiting for %04x at %04x with mask %04x", instruction_[0], position, instruction_[1] & 0x7ffe);
 				state_ = State::FetchFirstWord;
 			}
 		return false;
@@ -94,7 +91,7 @@ bool Copper::advance_dma(uint16_t position, uint16_t blitter_status) {
 			instruction_[0] = ram_[address_ & ram_mask_];
 			++address_;
 			state_ = State::FetchSecondWord;
-			LOG("First word fetch at " << PADHEX(4) << position);
+			logger.info().append("First word fetch at %04x", position);
 		break;
 
 		case State::FetchSecondWord: {
@@ -105,7 +102,7 @@ bool Copper::advance_dma(uint16_t position, uint16_t blitter_status) {
 			// Read in the second instruction word.
 			instruction_[1] = ram_[address_ & ram_mask_];
 			++address_;
-			LOG("Second word fetch at " << PADHEX(4) << position);
+			logger.info().append("Second word fetch at %04x", position);
 
 			// Check for a MOVE.
 			if(!(instruction_[0] & 1)) {
@@ -113,7 +110,7 @@ bool Copper::advance_dma(uint16_t position, uint16_t blitter_status) {
 					// Stop if this move would be a privilege violation.
 					instruction_[0] &= 0x1fe;
 					if((instruction_[0] < 0x10) || (instruction_[0] < 0x20 && !(control_&1))) {
-						LOG("Invalid MOVE to " << PADHEX(4) << instruction_[0] << "; stopping");
+						logger.info().append("Invalid MOVE to %04x; stopping", instruction_[0]);
 						state_ = State::Stopped;
 						break;
 					}

--- a/Machines/Amiga/Disk.cpp
+++ b/Machines/Amiga/Disk.cpp
@@ -8,12 +8,11 @@
 
 #include "Chipset.hpp"
 
-#ifndef NDEBUG
-#define NDEBUG
-#endif
-
-#define LOG_PREFIX "[Disk] "
 #include "../../Outputs/Log.hpp"
+
+namespace {
+Log::Logger<Log::Source::AmigaDisk> logger;
+}
 
 using namespace Amiga;
 
@@ -46,7 +45,7 @@ void Chipset::DiskDMA::set_length(uint16_t value) {
 		buffer_read_ = buffer_write_ = 0;
 
 		if(dma_enable_) {
-			LOG("Disk DMA " << (write_ ? "write" : "read") << " of " << length_ << " to " << PADHEX(8) << pointer_[0]);
+			logger.info().append("Disk DMA %s of %d to %08x", write_ ? "write" : "read", length_, pointer_[0]);
 		}
 
 		state_ = sync_with_word_ ? State::WaitingForSync : State::Reading;
@@ -110,7 +109,7 @@ void Chipset::DiskController::process_input_bit(int value) {
 }
 
 void Chipset::DiskController::set_sync_word(uint16_t value) {
-	LOG("Set disk sync word to " << PADHEX(4) << value);
+	logger.info().append("Set disk sync word to %04x", value);
 	sync_word_ = value;
 }
 
@@ -128,7 +127,7 @@ void Chipset::DiskController::set_control(uint16_t control) {
 	bit_length.clock_rate = (control & 0x100) ? 500000 : 250000;
 	set_expected_bit_length(bit_length);
 
-	LOG((sync_with_word_ ? "Will" : "Won't") << " sync with word; bit length is " << ((control & 0x100) ? "short" : "long"));
+	logger.info().append("%s sync with word; bit length is %s", sync_with_word_ ? "Will" : "Won't", (control & 0x100) ? "short" : "long");
 }
 
 void Chipset::DiskController::process_index_hole() {
@@ -182,7 +181,7 @@ void Chipset::DiskController::set_mtr_sel_side_dir_step(uint8_t value) {
 			// ID and definitely latch the new motor state.
 			if(!is_selected) {
 				drive_ids_[c] <<= 1;
-				LOG("Shifted drive ID shift register for drive " << +c << " to " << PADHEX(4) << std::bitset<16>{drive_ids_[c]});
+				logger.info().append("Shifted drive ID shift register for drive %d to %08x", c, drive_ids_[c]);
 			} else {
 				// Motor transition on -> off => reload register.
 				if(!motor_on && drive.get_motor_on()) {
@@ -191,7 +190,7 @@ void Chipset::DiskController::set_mtr_sel_side_dir_step(uint8_t value) {
 					//	0x5555'5555 = 5.25" drive;
 					//	0x0000'0000 = no drive.
 					drive_ids_[c] = 0xffff'ffff;
-					LOG("Reloaded drive ID shift register for drive " << +c);
+					logger.info().append("Reloaded drive ID shift register for drive %d", c);
 				}
 
 				// Also latch the new motor state.
@@ -204,7 +203,7 @@ void Chipset::DiskController::set_mtr_sel_side_dir_step(uint8_t value) {
 
 		// Possibly step.
 		if(did_step && is_selected) {
-			LOG("Stepped drive " << +c << " by " << std::dec << +direction.as_int());
+			logger.info().append("Stepped drive %d by %d", c, direction.as_int());
 			drive.step(direction);
 		}
 	}

--- a/Machines/Apple/ADB/ReactiveDevice.cpp
+++ b/Machines/Apple/ADB/ReactiveDevice.cpp
@@ -8,10 +8,13 @@
 
 #include "ReactiveDevice.hpp"
 
-#define LOG_PREFIX "[ADB device] "
 #include "../../../Outputs/Log.hpp"
 
 using namespace Apple::ADB;
+
+namespace {
+Log::Logger<Log::Source::ADBDevice> logger;
+}
 
 ReactiveDevice::ReactiveDevice(Apple::ADB::Bus &bus, uint8_t adb_device_id) :
 	bus_(bus),
@@ -125,7 +128,7 @@ void ReactiveDevice::adb_bus_did_observe_event(Bus::Event event, uint8_t value) 
 		phase_ = Phase::AwaitingAttention;
 
 		command_ = decode_command(value);
-//		LOG(command_);
+//		logger.info().append("%d", command_);
 
 		// If this command doesn't apply here, but a service request is requested,
 		// post a service request.

--- a/Machines/Apple/AppleIIgs/ADB.cpp
+++ b/Machines/Apple/AppleIIgs/ADB.cpp
@@ -16,7 +16,6 @@
 #include "../../../InstructionSets/M50740/Parser.hpp"
 #include "../../../InstructionSets/Disassembler.hpp"
 
-#define LOG_PREFIX "[ADB GLU] "
 #include "../../../Outputs/Log.hpp"
 
 using namespace Apple::IIgs::ADB;
@@ -39,6 +38,8 @@ enum class CPUFlags: uint8_t {
 enum class MicrocontrollerFlags: uint8_t {
 	CommandRegisterFull = 0x40,
 };
+
+Log::Logger<Log::Source::ADBGLU> logger;
 
 }
 
@@ -246,7 +247,7 @@ void GLU::set_port_output(int port, uint8_t value) {
 		case 3:
 			if(modifier_state_ != (value & 0x30)) {
 				modifier_state_ = value & 0x30;
-				LOG("Modifier state: " << int(value & 0x30));
+				logger.info().append("Modifier state: %02x", modifier_state_);
 			}
 
 			// Output is inverted respective to input; the microcontroller

--- a/Machines/Apple/Macintosh/Macintosh.cpp
+++ b/Machines/Apple/Macintosh/Macintosh.cpp
@@ -50,7 +50,7 @@ namespace {
 
 constexpr int CLOCK_RATE = 7833600;
 constexpr auto KEYBOARD_CLOCK_RATE = HalfCycles(CLOCK_RATE / 100000);
-
+Log::Logger<Log::Source::Macintosh> logger;
 
 //	Former default PRAM:
 //
@@ -723,7 +723,7 @@ template <Analyser::Static::Macintosh::Target::Model model> class ConcreteMachin
 					if(port == Port::B && line == Line::Two) {
 						keyboard_.set_input(value);
 					}
-					else LOG("Unhandled control line output: " << (port ? 'B' : 'A') << int(line));
+					else logger.error().append("Unhandled 6522 control line output: %c%d", port ? 'B' : 'A', int(line));
 				}
 
 				void run_for(HalfCycles duration) {

--- a/Machines/Atari/ST/AtariST.cpp
+++ b/Machines/Atari/ST/AtariST.cpp
@@ -29,13 +29,16 @@
 
 #include "../../../Outputs/Speaker/Implementation/LowpassSpeaker.hpp"
 
-#define LOG_PREFIX "[ST] "
 #include "../../../Outputs/Log.hpp"
 
 #include "../../Utility/MemoryPacker.hpp"
 #include "../../Utility/MemoryFuzzer.hpp"
 
 #include "../../../Analyser/Static/AtariST/Target.hpp"
+
+namespace {
+Log::Logger<Log::Source::NCR5380> logger;
+}
 
 namespace Atari {
 namespace ST {
@@ -186,7 +189,7 @@ class ConcreteMachine:
 
 			// Check for assertion of reset.
 			if(cycle.operation & CPU::MC68000::Operation::Reset) {
-				LOG("Unhandled Reset");
+				logger.error().append("Unhandled Reset");
 			}
 
 			// A null cycle leaves nothing else to do.

--- a/Machines/Atari/ST/AtariST.cpp
+++ b/Machines/Atari/ST/AtariST.cpp
@@ -37,7 +37,7 @@
 #include "../../../Analyser/Static/AtariST/Target.hpp"
 
 namespace {
-Log::Logger<Log::Source::NCR5380> logger;
+Log::Logger<Log::Source::AtariST> logger;
 }
 
 namespace Atari {

--- a/Machines/Atari/ST/DMAController.cpp
+++ b/Machines/Atari/ST/DMAController.cpp
@@ -8,7 +8,6 @@
 
 #include "DMAController.hpp"
 
-#define LOG_PREFIX "[DMA] "
 #include "../../../Outputs/Log.hpp"
 
 #include <cstdio>

--- a/Machines/Atari/ST/DMAController.cpp
+++ b/Machines/Atari/ST/DMAController.cpp
@@ -17,6 +17,8 @@ using namespace Atari::ST;
 
 namespace {
 
+Log::Logger<Log::Source::AtariSTDMAController> logger;
+
 enum Control: uint16_t {
 	Direction = 0x100,
 	DRQSource = 0x80,
@@ -121,7 +123,7 @@ void DMAController::write(int address, uint16_t value) {
 }
 
 void DMAController::set_floppy_drive_selection(bool drive1, bool drive2, bool side2) {
-//	LOG("Selected: " << (drive1 ? "1" : "-") << (drive2 ? "2" : "-") << (side2 ? "s" : "-"));
+//	logger.info().append("Selected: %s%s%s", drive1 ? "1" : "-", drive2 ? "2" : "-", side2 ? "s" : "-");
 	fdc_.set_floppy_drive_selection(drive1, drive2, side2);
 }
 
@@ -191,12 +193,6 @@ int DMAController::bus_grant(uint16_t *ram, size_t size) {
 		// Check that the older buffer is full; stop if not.
 		if(!buffer_[active_buffer_ ^ 1].is_full) return 0;
 
-//#define b(i, n) " " << PADHEX(2) << int(buffer_[i].contents[n])
-//#define b2(i, n) b(i, n) << b(i, n+1)
-//#define b4(i, n) b2(i, n) << b2(i, n+2)
-//#define b16(i) b4(i, 0) << b4(i, 4) << b4(i, 8) << b4(i, 12)
-//		LOG("[1] to " << PADHEX(6) << address_ << b16(active_buffer_ ^ 1));
-
 		for(int c = 0; c < 8; ++c) {
 			if(size_t(address_) < size) {
 				ram[address_ >> 1] = uint16_t(
@@ -210,12 +206,6 @@ int DMAController::bus_grant(uint16_t *ram, size_t size) {
 
 		// Check that the newer buffer is full; stop if not.
 		if(!buffer_[active_buffer_ ].is_full) return 8;
-
-//		LOG("[2] to " << PADHEX(6) << address_ << b16(active_buffer_));
-//#undef b16
-//#undef b4
-//#undef b2
-//#undef b
 
 		for(int c = 0; c < 8; ++c) {
 			if(size_t(address_) < size) {

--- a/Machines/Atari/ST/IntelligentKeyboard.cpp
+++ b/Machines/Atari/ST/IntelligentKeyboard.cpp
@@ -8,10 +8,13 @@
 
 #include "IntelligentKeyboard.hpp"
 
+#include "../../../Outputs/Log.hpp"
+
 #include <algorithm>
 
-#define LOG_PREFIX "[IKYB] "
-#include "../../../Outputs/Log.hpp"
+namespace {
+Log::Logger<Log::Source::IntelligentKeyboard> logger;
+}
 
 using namespace Atari::ST;
 
@@ -157,7 +160,7 @@ void IntelligentKeyboard::dispatch_command(uint8_t command) {
 	// If not, exit. If so, perform and drop out of the switch.
 	switch(command_sequence_.front()) {
 		default:
-			LOG("Unrecognised IKBD command " << PADHEX(2) << +command);
+			logger.error().append("Unrecognised IKBD command %02x", command);
 		break;
 
 		case 0x80:
@@ -260,11 +263,11 @@ void IntelligentKeyboard::reset() {
 }
 
 void IntelligentKeyboard::resume() {
-	LOG("Unimplemented: resume");
+	logger.error().append("Unimplemented: resume");
 }
 
 void IntelligentKeyboard::pause() {
-	LOG("Unimplemented: pause");
+	logger.error().append("Unimplemented: pause");
 }
 
 void IntelligentKeyboard::disable_mouse() {
@@ -287,7 +290,7 @@ void IntelligentKeyboard::set_mouse_position(uint16_t x, uint16_t y) {
 }
 
 void IntelligentKeyboard::set_mouse_keycode_reporting(uint8_t, uint8_t) {
-	LOG("Unimplemented: set mouse keycode reporting");
+	logger.error().append("Unimplemented: set mouse keycode reporting");
 }
 
 void IntelligentKeyboard::set_mouse_threshold(uint8_t x, uint8_t y) {
@@ -309,7 +312,7 @@ void IntelligentKeyboard::set_mouse_y_upward() {
 }
 
 void IntelligentKeyboard::set_mouse_button_actions(uint8_t) {
-	LOG("Unimplemented: set mouse button actions");
+	logger.error().append("Unimplemented: set mouse button actions");
 }
 
 void IntelligentKeyboard::interrogate_mouse_position() {
@@ -499,9 +502,9 @@ void IntelligentKeyboard::interrogate_joysticks() {
 }
 
 void IntelligentKeyboard::set_joystick_monitoring_mode(uint8_t) {
-	LOG("Unimplemented: joystick monitoring mode");
+	logger.error().append("Unimplemented: joystick monitoring mode");
 }
 
 void IntelligentKeyboard::set_joystick_fire_button_monitoring_mode() {
-	LOG("Unimplemented: joystick fire button monitoring mode");
+	logger.error().append("Unimplemented: joystick fire button monitoring mode");
 }

--- a/Machines/Commodore/Vic-20/Vic20.cpp
+++ b/Machines/Commodore/Vic-20/Vic20.cpp
@@ -36,6 +36,10 @@
 #include <array>
 #include <cstdint>
 
+namespace {
+Log::Logger<Log::Source::Vic20> logger;
+}
+
 namespace Commodore::Vic20 {
 
 enum ROMSlot {
@@ -530,12 +534,12 @@ class ConcreteMachine:
 							const uint16_t tape_buffer_pointer = uint16_t(ram_[0xb2]) | uint16_t(ram_[0xb3] << 8);
 							header->serialise(&ram_[tape_buffer_pointer], 0x8000 - tape_buffer_pointer);
 							hold_tape_ = true;
-							LOG("Vic-20: Found header");
+							logger.info().append("Found header");
 						} else {
 							// no header found, so pretend this hack never interceded
 							tape_->get_tape()->set_offset(tape_position);
 							hold_tape_ = false;
-							LOG("Vic-20: Didn't find header");
+							logger.info().append("Didn't find header");
 						}
 
 						// clear status and the verify flag
@@ -576,11 +580,11 @@ class ConcreteMachine:
 								m6502_.set_value_of(CPU::MOS6502::Register::ProgramCounter, 0xfccf);
 								*value = 0xea;	// i.e. NOP implied
 								hold_tape_ = true;
-								LOG("Vic-20: Found data");
+								logger.info().append("Found data");
 							} else {
 								tape_->get_tape()->set_offset(tape_position);
 								hold_tape_ = false;
-								LOG("Vic-20: Didn't find data");
+								logger.info().append("Didn't find data");
 							}
 						}
 					}

--- a/Machines/Enterprise/Enterprise.cpp
+++ b/Machines/Enterprise/Enterprise.cpp
@@ -18,11 +18,13 @@
 
 #include "../../Analyser/Static/Enterprise/Target.hpp"
 #include "../../ClockReceiver/JustInTime.hpp"
+#include "../../Outputs/Log.hpp"
 #include "../../Outputs/Speaker/Implementation/LowpassSpeaker.hpp"
 #include "../../Processors/Z80/Z80.hpp"
 
-#define LOG_PREFIX "[Enterprise] "
-#include "../../Outputs/Log.hpp"
+namespace {
+Log::Logger<Log::Source::Enterprise> logger;
+}
 
 namespace Enterprise {
 
@@ -347,7 +349,7 @@ template <bool has_disk_controller, bool is_6mhz> class ConcreteMachine:
 				case PartialMachineCycle::Input:
 					switch(address & 0xff) {
 						default:
-							LOG("Unhandled input from " << PADHEX(2) << (address & 0xff));
+							logger.error().append("Unhandled input from %02x", address & 0xff);
 							*cycle.value = 0xff;
 						break;
 
@@ -412,7 +414,7 @@ template <bool has_disk_controller, bool is_6mhz> class ConcreteMachine:
 				case PartialMachineCycle::Output:
 					switch(address & 0xff) {
 						default:
-							LOG("Unhandled output: " << PADHEX(2) << *cycle.value << " to " << PADHEX(2) << (address & 0xff));
+							logger.error().append("Unhandled output: %02x to %02x", *cycle.value, address & 0xff);
 						break;
 
 						case 0x10:	case 0x11:	case 0x12:	case 0x13:
@@ -511,12 +513,12 @@ template <bool has_disk_controller, bool is_6mhz> class ConcreteMachine:
 						break;
 						case 0xb6:
 							// Just 8 bits of printer data.
-							LOG("TODO: printer output " << PADHEX(2) << *cycle.value);
+							logger.info().append("TODO: printer output: %02x", *cycle.value);
 						break;
 						case 0xb7:
 							// b0 = serial data out
 							// b1 = serial status out
-							LOG("TODO: serial output " << PADHEX(2) << *cycle.value);
+							logger.info().append("TODO: serial output: %02x", *cycle.value);
 						break;
 					}
 				break;

--- a/Machines/MSX/MSX.cpp
+++ b/Machines/MSX/MSX.cpp
@@ -49,6 +49,10 @@
 
 #include "../../Analyser/Static/MSX/Target.hpp"
 
+namespace {
+Log::Logger<Log::Source::MSX> logger;
+}
+
 namespace MSX {
 
 class AYPortHandler: public GI::AY38910::PortHandler {
@@ -874,14 +878,14 @@ class ConcreteMachine:
 							// b0-b3: keyboard line
 							machine_.set_keyboard_line(value & 0xf);
 						} break;
-						default: LOG("Unrecognised: MSX set 8255 output port " << port << " to value " << PADHEX(2) << value); break;
+						default: logger.error().append("Unrecognised: MSX set 8255 output port %d to value %02x", port, value); break;
 					}
 				}
 
 				uint8_t get_value(int port) {
 					if(port == 1) {
 						return machine_.read_keyboard();
-					} else LOG("MSX attempted to read from 8255 port " << port);
+					} else logger.error().append("MSX attempted to read from 8255 port %d");
 					return 0xff;
 				}
 

--- a/Machines/MasterSystem/MasterSystem.cpp
+++ b/Machines/MasterSystem/MasterSystem.cpp
@@ -23,7 +23,6 @@
 #include "../../Outputs/Speaker/Implementation/LowpassSpeaker.hpp"
 #include "../../Outputs/Speaker/Implementation/CompoundSource.hpp"
 
-#define LOG_PREFIX "[SMS] "
 #include "../../Outputs/Log.hpp"
 
 #include "../../Analyser/Static/Sega/Target.hpp"
@@ -34,6 +33,7 @@
 
 namespace {
 constexpr int audio_divider = 1;
+Log::Logger<Log::Source::MasterSystem> logger;
 }
 
 namespace Sega {
@@ -255,17 +255,17 @@ template <Analyser::Static::Sega::Target::Model model> class ConcreteMachine:
 						}
 
 						if(write_pointers_[address >> 10]) write_pointers_[address >> 10][address & 1023] = *cycle.value;
-//						else LOG("Ignored write to ROM");
+//						else logger.info().append("Ignored write to ROM");
 					break;
 
 					case CPU::Z80::PartialMachineCycle::Input:
 						switch(address & 0xc1) {
 							case 0x00:
-								LOG("TODO: [input] memory control");
+								logger.error().append("TODO: [input] memory control");
 								*cycle.value = 0xff;
 							break;
 							case 0x01:
-								LOG("TODO: [input] I/O port control");
+								logger.error().append("TODO: [input] I/O port control");
 								*cycle.value = 0xff;
 							break;
 							case 0x40:
@@ -305,7 +305,7 @@ template <Analyser::Static::Sega::Target::Model model> class ConcreteMachine:
 							} break;
 
 							default:
-								ERROR("[input] Clearly some sort of typo");
+								logger.error().append("[input] Clearly some sort of typo");
 							break;
 						}
 					break;
@@ -315,7 +315,7 @@ template <Analyser::Static::Sega::Target::Model model> class ConcreteMachine:
 							case 0x00:		// i.e. even ports less than 0x40.
 								if constexpr (is_master_system(model)) {
 									// TODO: Obey the RAM enable.
-									LOG("Memory control: " << PADHEX(2) << +memory_control_);
+									logger.info().append("Memory control: %02x", memory_control_);
 									memory_control_ = *cycle.value;
 									page_cartridge();
 								}
@@ -357,7 +357,7 @@ template <Analyser::Static::Sega::Target::Model model> class ConcreteMachine:
 							break;
 
 							default:
-								ERROR("[output] Clearly some sort of typo");
+								logger.error().append("[output] Clearly some sort of typo");
 							break;
 						}
 					break;

--- a/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
+++ b/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
@@ -24,7 +24,6 @@
 // just grab the CPC's version of an FDC.
 #include "../../AmstradCPC/FDC.hpp"
 
-#define LOG_PREFIX "[Spectrum] "
 #include "../../../Outputs/Log.hpp"
 
 #include "../../../Outputs/Speaker/Implementation/CompoundSource.hpp"

--- a/OSBindings/Mac/Clock Signal.xcodeproj/xcshareddata/xcschemes/Clock Signal Kiosk.xcscheme
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/xcshareddata/xcschemes/Clock Signal Kiosk.xcscheme
@@ -53,7 +53,7 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "&quot;/Users/thomasharte/Desktop/Soft/Master System/R-Type (NTSC).sms&quot;"
+            argument = "&quot;/Users/thomasharte/Library/Mobile Documents/com~apple~CloudDocs/Soft/Master System/R-Type (NTSC).sms&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument

--- a/Outputs/Log.hpp
+++ b/Outputs/Log.hpp
@@ -24,6 +24,7 @@ enum class Source {
 	AmigaChipset,
 	AmigaBlitter,
 	AtariST,
+	AtariSTDMAController,
 	CommodoreStaticAnalyser,
 	DirectAccessDevice,
 	Enterprise,
@@ -81,6 +82,7 @@ constexpr const char *prefix(Source source) {
 		case Source::AmigaCopper:				return "Copper";
 		case Source::AmigaDisk:					return "Disk";
 		case Source::AtariST:					return "AtariST";
+		case Source::AtariSTDMAController:		return "DMA";
 		case Source::CommodoreStaticAnalyser:	return "Commodore Static Analyser";
 		case Source::Enterprise:				return "Enterprise";
 		case Source::i8272:						return "i8272";

--- a/Outputs/Log.hpp
+++ b/Outputs/Log.hpp
@@ -29,10 +29,12 @@ enum class Source {
 	M50740,
 	Macintosh,
 	MasterSystem,
+	MultiMachine,
 	MFP68901,
 	MSX,
 	NCR5380,
 	OpenGL,
+	PCMTrack,
 	SCC,
 	SCSI,
 	SZX,
@@ -52,6 +54,7 @@ constexpr bool is_enabled(Source source) {
 		default: return true;
 
 		// The following are all things I'm not actively working on.
+		case Source::MFP68901:
 		case Source::NCR5380:
 		case Source::SCC:	return false;
 	}
@@ -65,7 +68,10 @@ constexpr const char *prefix(Source source) {
 		case Source::AtariST:					return "AtariST";
 		case Source::CommodoreStaticAnalyser:	return "Commodore StaticAnalyser";
 		case Source::i8272:						return "i8272";
+		case Source::MFP68901:					return "MFP68901";
+		case Source::MultiMachine:				return "Multi machine";
 		case Source::NCR5380:					return "5380";
+		case Source::PCMTrack:					return "PCM Track";
 		case Source::SCSI:						return "SCSI";
 		case Source::SCC:						return "SCC";
 		case Source::SZX:						return "SZX";
@@ -81,12 +87,14 @@ constexpr const char *prefix(Source source) {
 template <Source source>
 class Logger {
 	public:
+		static constexpr bool enabled = is_enabled(source);
+
 		Logger() {}
 
 		struct LogLine {
 			public:
 				LogLine(FILE *stream) : stream_(stream) {
-					if constexpr (!is_enabled(source)) return;
+					if constexpr (!enabled) return;
 
 					const auto source_prefix = prefix(source);
 					if(source_prefix) {
@@ -95,12 +103,12 @@ class Logger {
 				}
 
 				~LogLine() {
-					if constexpr (!is_enabled(source)) return;
+					if constexpr (!enabled) return;
 					fprintf(stream_, "\n");
 				}
 
 				void append(const char *format, ...) {
-					if constexpr (!is_enabled(source)) return;
+					if constexpr (!enabled) return;
 					va_list args;
 					va_start(args, format);
 					vfprintf(stream_, format, args);

--- a/Outputs/Log.hpp
+++ b/Outputs/Log.hpp
@@ -13,7 +13,7 @@ namespace Log {
 // But I prefer C files to C++ streams, so here it is for now.
 
 enum class Source {
-	ADB,
+	ADBGLU,
 	Amiga,
 	AmigaDisk,
 	AmigaCopper,
@@ -61,11 +61,16 @@ constexpr const char *prefix(Source source) {
 	switch(source) {
 		default: return nullptr;
 
+		case Source::ADBGLU:					return "ADB GLU";
+		case Source::AtariST:					return "AtariST";
 		case Source::CommodoreStaticAnalyser:	return "Commodore StaticAnalyser";
 		case Source::i8272:						return "i8272";
 		case Source::NCR5380:					return "5380";
 		case Source::SCSI:						return "SCSI";
 		case Source::SCC:						return "SCC";
+		case Source::SZX:						return "SZX";
+		case Source::TapeUEF:					return "UEF";
+		case Source::TZX:						return "TZX";
 		case Source::WDFDC:						return "WD FDC";
 	}
 }

--- a/Outputs/Log.hpp
+++ b/Outputs/Log.hpp
@@ -15,6 +15,7 @@ namespace Log {
 enum class Source {
 	WDFDC,
 	SCSI,
+	SCC,
 };
 
 constexpr bool is_enabled(Source source) {
@@ -25,6 +26,8 @@ constexpr bool is_enabled(Source source) {
 	// Allow for compile-time source-level enabling and disabling of different sources.
 	switch(source) {
 		default: return true;
+
+		case Source::SCC:	return false;
 	}
 }
 
@@ -32,6 +35,7 @@ constexpr const char *prefix(Source source) {
 	switch(source) {
 		case Source::WDFDC:	return "WD FDC";
 		case Source::SCSI:	return "SCSI";
+		case Source::SCC:	return "SCC";
 	}
 }
 

--- a/Outputs/Log.hpp
+++ b/Outputs/Log.hpp
@@ -13,9 +13,33 @@ namespace Log {
 // But I prefer C files to C++ streams, so here it is for now.
 
 enum class Source {
-	WDFDC,
-	SCSI,
+	ADB,
+	Amiga,
+	AmigaDisk,
+	AmigaCopper,
+	AmigaChipset,
+	AmigaBlitter,
+	AtariST,
+	DirectAccessDevice,
+	Enterprise,
+	i8272,
+	IntelligentKeyboard,
+	IWM,
+	M50740,
+	Macintosh,
+	MasterSystem,
+	MFP68901,
+	MSX,
+	NCR5380,
+	OpenGL,
 	SCC,
+	SCSI,
+	StaticAnalyser,
+	SZX,
+	TapeUEF,
+	TMS9918,
+	TZX,
+	WDFDC,
 };
 
 constexpr bool is_enabled(Source source) {
@@ -27,15 +51,19 @@ constexpr bool is_enabled(Source source) {
 	switch(source) {
 		default: return true;
 
+		// The following are all things I'm not actively working on.
+		case Source::NCR5380:
 		case Source::SCC:	return false;
 	}
 }
 
 constexpr const char *prefix(Source source) {
 	switch(source) {
-		case Source::WDFDC:	return "WD FDC";
-		case Source::SCSI:	return "SCSI";
-		case Source::SCC:	return "SCC";
+		case Source::StaticAnalyser:	return "Analyser";
+		case Source::WDFDC:				return "WD FDC";
+		case Source::SCSI:				return "SCSI";
+		case Source::SCC:				return "SCC";
+		case Source::NCR5380:			return "5380";
 	}
 }
 

--- a/Outputs/Log.hpp
+++ b/Outputs/Log.hpp
@@ -54,6 +54,7 @@ constexpr bool is_enabled(Source source) {
 		default: return true;
 
 		// The following are all things I'm not actively working on.
+		case Source::IWM:
 		case Source::MFP68901:
 		case Source::NCR5380:
 		case Source::SCC:	return false;
@@ -68,6 +69,7 @@ constexpr const char *prefix(Source source) {
 		case Source::AtariST:					return "AtariST";
 		case Source::CommodoreStaticAnalyser:	return "Commodore StaticAnalyser";
 		case Source::i8272:						return "i8272";
+		case Source::IWM:						return "IWM";
 		case Source::MFP68901:					return "MFP68901";
 		case Source::MultiMachine:				return "Multi machine";
 		case Source::NCR5380:					return "5380";

--- a/Outputs/Log.hpp
+++ b/Outputs/Log.hpp
@@ -20,6 +20,7 @@ enum class Source {
 	AmigaChipset,
 	AmigaBlitter,
 	AtariST,
+	CommodoreStaticAnalyser,
 	DirectAccessDevice,
 	Enterprise,
 	i8272,
@@ -34,7 +35,6 @@ enum class Source {
 	OpenGL,
 	SCC,
 	SCSI,
-	StaticAnalyser,
 	SZX,
 	TapeUEF,
 	TMS9918,
@@ -59,11 +59,14 @@ constexpr bool is_enabled(Source source) {
 
 constexpr const char *prefix(Source source) {
 	switch(source) {
-		case Source::StaticAnalyser:	return "Analyser";
-		case Source::WDFDC:				return "WD FDC";
-		case Source::SCSI:				return "SCSI";
-		case Source::SCC:				return "SCC";
-		case Source::NCR5380:			return "5380";
+		default: return nullptr;
+
+		case Source::CommodoreStaticAnalyser:	return "Commodore StaticAnalyser";
+		case Source::i8272:						return "i8272";
+		case Source::NCR5380:					return "5380";
+		case Source::SCSI:						return "SCSI";
+		case Source::SCC:						return "SCC";
+		case Source::WDFDC:						return "WD FDC";
 	}
 }
 

--- a/Outputs/Log.hpp
+++ b/Outputs/Log.hpp
@@ -59,6 +59,8 @@ constexpr bool is_enabled(Source source) {
 		default: return true;
 
 		// The following are all things I'm not actively working on.
+		case Source::AmigaBlitter:
+		case Source::AmigaChipset:
 		case Source::AmigaCopper:
 		case Source::AmigaDisk:
 		case Source::IWM:
@@ -74,6 +76,8 @@ constexpr const char *prefix(Source source) {
 
 		case Source::ADBDevice:					return "ADB device";
 		case Source::ADBGLU:					return "ADB GLU";
+		case Source::AmigaBlitter:				return "Blitter";
+		case Source::AmigaChipset:				return "Chipset";
 		case Source::AmigaCopper:				return "Copper";
 		case Source::AmigaDisk:					return "Disk";
 		case Source::AtariST:					return "AtariST";

--- a/Outputs/Log.hpp
+++ b/Outputs/Log.hpp
@@ -8,11 +8,15 @@
 
 #pragma once
 
+#include <cstdio>
+#include <cstdarg>
+
 namespace Log {
 // TODO: if adopting C++20, std::format would be a better model to apply below.
 // But I prefer C files to C++ streams, so here it is for now.
 
 enum class Source {
+	ADBDevice,
 	ADBGLU,
 	Amiga,
 	AmigaDisk,
@@ -41,6 +45,7 @@ enum class Source {
 	TapeUEF,
 	TMS9918,
 	TZX,
+	Vic20,
 	WDFDC,
 };
 
@@ -54,6 +59,8 @@ constexpr bool is_enabled(Source source) {
 		default: return true;
 
 		// The following are all things I'm not actively working on.
+		case Source::AmigaCopper:
+		case Source::AmigaDisk:
 		case Source::IWM:
 		case Source::MFP68901:
 		case Source::NCR5380:
@@ -65,26 +72,34 @@ constexpr const char *prefix(Source source) {
 	switch(source) {
 		default: return nullptr;
 
+		case Source::ADBDevice:					return "ADB device";
 		case Source::ADBGLU:					return "ADB GLU";
+		case Source::AmigaCopper:				return "Copper";
+		case Source::AmigaDisk:					return "Disk";
 		case Source::AtariST:					return "AtariST";
-		case Source::CommodoreStaticAnalyser:	return "Commodore StaticAnalyser";
+		case Source::CommodoreStaticAnalyser:	return "Commodore Static Analyser";
+		case Source::Enterprise:				return "Enterprise";
 		case Source::i8272:						return "i8272";
+		case Source::IntelligentKeyboard:		return "IKYB";
 		case Source::IWM:						return "IWM";
+		case Source::M50740:					return "M50740";
+		case Source::Macintosh:					return "Macintosh";
+		case Source::MasterSystem:				return "SMS";
 		case Source::MFP68901:					return "MFP68901";
-		case Source::MultiMachine:				return "Multi machine";
+		case Source::MultiMachine:				return "Multi-machine";
+		case Source::MSX:						return "MSX";
 		case Source::NCR5380:					return "5380";
+		case Source::OpenGL:					return "OpenGL";
 		case Source::PCMTrack:					return "PCM Track";
 		case Source::SCSI:						return "SCSI";
 		case Source::SCC:						return "SCC";
 		case Source::SZX:						return "SZX";
 		case Source::TapeUEF:					return "UEF";
 		case Source::TZX:						return "TZX";
+		case Source::Vic20:						return "Vic20";
 		case Source::WDFDC:						return "WD FDC";
 	}
 }
-
-#include <cstdio>
-#include <cstdarg>
 
 template <Source source>
 class Logger {

--- a/Outputs/OpenGL/Primitives/Shader.cpp
+++ b/Outputs/OpenGL/Primitives/Shader.cpp
@@ -14,8 +14,7 @@
 using namespace Outputs::Display::OpenGL;
 
 namespace {
-// The below is disabled because it isn't context-specific. Work to do.
-thread_local Shader *bound_shader = nullptr;
+thread_local const Shader *bound_shader = nullptr;
 Log::Logger<Log::Source::OpenGL> logger;
 }
 
@@ -107,20 +106,20 @@ void Shader::init(const std::string &vertex_shader, const std::string &fragment_
 }
 
 Shader::~Shader() {
-//	if(bound_shader == this) Shader::unbind();
+	if(bound_shader == this) Shader::unbind();
 	glDeleteProgram(shader_program_);
 }
 
 void Shader::bind() const {
-//	if(bound_shader != this) {
+	if(bound_shader != this) {
 		test_gl(glUseProgram, shader_program_);
-//		bound_shader = this;
-//	}
+		bound_shader = this;
+	}
 	flush_functions();
 }
 
 void Shader::unbind() {
-//	bound_shader = nullptr;
+	bound_shader = nullptr;
 	test_gl(glUseProgram, 0);
 }
 

--- a/Outputs/OpenGL/Primitives/Shader.cpp
+++ b/Outputs/OpenGL/Primitives/Shader.cpp
@@ -14,9 +14,9 @@
 using namespace Outputs::Display::OpenGL;
 
 namespace {
-	// The below is disabled because it isn't context/thread-specific. Which makes it
-	// fairly 'unuseful'.
-//	Shader *bound_shader = nullptr;
+// The below is disabled because it isn't context-specific. Work to do.
+thread_local Shader *bound_shader = nullptr;
+Log::Logger<Log::Source::OpenGL> logger;
 }
 
 GLuint Shader::compile_shader(const std::string &source, GLenum type) {
@@ -25,22 +25,22 @@ GLuint Shader::compile_shader(const std::string &source, GLenum type) {
 	test_gl(glShaderSource, shader, 1, &c_str, NULL);
 	test_gl(glCompileShader, shader);
 
-#ifndef NDEBUG
-	GLint isCompiled = 0;
-	test_gl(glGetShaderiv, shader, GL_COMPILE_STATUS, &isCompiled);
-	if(isCompiled == GL_FALSE) {
-		GLint logLength;
-		test_gl(glGetShaderiv, shader, GL_INFO_LOG_LENGTH, &logLength);
-		if(logLength > 0) {
-			const auto length = std::vector<GLchar>::size_type(logLength);
-			std::vector<GLchar> log(length);
-			test_gl(glGetShaderInfoLog, shader, logLength, &logLength, log.data());
-			LOG("Compile log:\n" << log.data());
-		}
+	if constexpr (logger.enabled) {
+		GLint isCompiled = 0;
+		test_gl(glGetShaderiv, shader, GL_COMPILE_STATUS, &isCompiled);
+		if(isCompiled == GL_FALSE) {
+			GLint logLength;
+			test_gl(glGetShaderiv, shader, GL_INFO_LOG_LENGTH, &logLength);
+			if(logLength > 0) {
+				const auto length = std::vector<GLchar>::size_type(logLength);
+				std::vector<GLchar> log(length);
+				test_gl(glGetShaderInfoLog, shader, logLength, &logLength, log.data());
+				logger.error().append("Compile log: %s", log.data());
+			}
 
-		throw (type == GL_VERTEX_SHADER) ? VertexShaderCompilationError : FragmentShaderCompilationError;
+			throw (type == GL_VERTEX_SHADER) ? VertexShaderCompilationError : FragmentShaderCompilationError;
+		}
 	}
-#endif
 
 	return shader;
 }
@@ -69,41 +69,41 @@ void Shader::init(const std::string &vertex_shader, const std::string &fragment_
 
 	for(const auto &binding : attribute_bindings) {
 		test_gl(glBindAttribLocation, shader_program_, binding.index, binding.name.c_str());
-#ifndef NDEBUG
-		const auto error = glGetError();
-		switch(error) {
-			case 0: break;
-			case GL_INVALID_VALUE:
-				LOG("GL_INVALID_VALUE when attempting to bind " << binding.name << " to index " << binding.index << " (i.e. index is greater than or equal to GL_MAX_VERTEX_ATTRIBS)");
-			break;
-			case GL_INVALID_OPERATION:
-				LOG("GL_INVALID_OPERATION when attempting to bind " << binding.name << " to index " << binding.index << " (i.e. name begins with gl_)");
-			break;
-			default:
-				LOG("Error " << error << " when attempting to bind " << binding.name << " to index " << binding.index);
-			break;
+
+		if constexpr (logger.enabled) {
+			const auto error = glGetError();
+			switch(error) {
+				case 0: break;
+				case GL_INVALID_VALUE:
+					logger.error().append("GL_INVALID_VALUE when attempting to bind %s to index %d (i.e. index is greater than or equal to GL_MAX_VERTEX_ATTRIBS)", binding.name.c_str(), binding.index);
+				break;
+				case GL_INVALID_OPERATION:
+					logger.error().append("GL_INVALID_OPERATION when attempting to bind %s to index %d (i.e. name begins with gl_)", binding.name.c_str(), binding.index);
+				break;
+				default:
+					logger.error().append("Error %d when attempting to bind %s to index %d", error, binding.name.c_str(), binding.index);
+				break;
+			}
 		}
-#endif
 	}
 
 	test_gl(glLinkProgram, shader_program_);
 
-#ifndef NDEBUG
-	GLint logLength;
-	test_gl(glGetProgramiv, shader_program_, GL_INFO_LOG_LENGTH, &logLength);
-	if(logLength > 0) {
-		GLchar *log = new GLchar[std::size_t(logLength)];
-		test_gl(glGetProgramInfoLog, shader_program_, logLength, &logLength, log);
-		LOG("Link log:\n" << log);
-		delete[] log;
-	}
+	if constexpr (logger.enabled) {
+		GLint logLength;
+		test_gl(glGetProgramiv, shader_program_, GL_INFO_LOG_LENGTH, &logLength);
+		if(logLength > 0) {
+			std::vector<GLchar> log(logLength);
+			test_gl(glGetProgramInfoLog, shader_program_, logLength, &logLength, log.data());
+			logger.error().append("Link log: %s", log.data());
+		}
 
-	GLint didLink = 0;
-	test_gl(glGetProgramiv, shader_program_, GL_LINK_STATUS, &didLink);
-	if(didLink == GL_FALSE) {
-		throw ProgramLinkageError;
+		GLint didLink = 0;
+		test_gl(glGetProgramiv, shader_program_, GL_LINK_STATUS, &didLink);
+		if(didLink == GL_FALSE) {
+			throw ProgramLinkageError;
+		}
 	}
-#endif
 }
 
 Shader::~Shader() {
@@ -139,7 +139,7 @@ void Shader::enable_vertex_attribute_with_pointer(const std::string &name, GLint
 		test_gl(glVertexAttribPointer, GLuint(location), size, type, normalised, stride, pointer);
 		test_gl(glVertexAttribDivisor, GLuint(location), divisor);
 	} else {
-		LOG("Couldn't enable vertex attribute " << name);
+		logger.error().append("Couldn't enable vertex attribute %s", name.c_str());
 	}
 }
 
@@ -147,10 +147,10 @@ void Shader::enable_vertex_attribute_with_pointer(const std::string &name, GLint
 #define with_location(func, ...) {\
 		const GLint location = glGetUniformLocation(shader_program_, name.c_str());	\
 		if(location == -1) { \
-			LOG("Couldn't get location for uniform " << name);	\
+			logger.error().append("Couldn't get location for uniform %s", name.c_str());	\
 		} else { \
 			func(location, __VA_ARGS__);	\
-			if(glGetError()) LOG("Error setting uniform " << name << " via " << #func);	\
+			if(glGetError()) logger.error().append("Error setting uniform %s via %s", name.c_str(), #func);	\
 		} \
 	}
 

--- a/Outputs/OpenGL/ScanTarget.cpp
+++ b/Outputs/OpenGL/ScanTarget.cpp
@@ -60,6 +60,8 @@ constexpr GLenum formatForDepth(std::size_t depth) {
 	}
 }
 
+Log::Logger<Log::Source::OpenGL> logger;
+
 }
 
 template <typename T> void ScanTarget::allocate_buffer(const T &array, GLuint &buffer_name, GLuint &vertex_array_name) {
@@ -343,7 +345,7 @@ void ScanTarget::update(int, int output_height) {
 		// Work with the accumulation_buffer_ potentially starts from here onwards; set its flag.
 		while(is_drawing_to_accumulation_buffer_.test_and_set());
 		if(did_create_accumulation_texture) {
-			LOG("Changed output resolution to " << proportional_width << " by " << framebuffer_height);
+			logger.info().append("Changed output resolution to %d by %d", proportional_width, framebuffer_height);
 			display_metrics_.announce_did_resize();
 			std::unique_ptr<OpenGL::TextureTarget> new_framebuffer(
 				new TextureTarget(

--- a/Outputs/OpenGL/ScanTarget.hpp
+++ b/Outputs/OpenGL/ScanTarget.hpp
@@ -55,7 +55,10 @@ class ScanTarget: public Outputs::Display::BufferingScanTarget {	// TODO: use pr
 		struct OpenGLVersionDumper {
 			OpenGLVersionDumper() {
 				// Note the OpenGL version, as the first thing this class does prior to construction.
-				LOG("Constructing scan target with OpenGL " << glGetString(GL_VERSION) << "; shading language version " << glGetString(GL_SHADING_LANGUAGE_VERSION));
+				Log::Logger<Log::Source::OpenGL>().info().append(
+					"Constructing scan target with OpenGL %s; shading language version %s",
+					glGetString(GL_VERSION),
+					glGetString(GL_SHADING_LANGUAGE_VERSION));
 			}
 		} dumper_;
 #endif

--- a/Storage/Disk/Track/PCMTrack.cpp
+++ b/Storage/Disk/Track/PCMTrack.cpp
@@ -9,6 +9,12 @@
 #include "PCMTrack.hpp"
 #include "../../../Outputs/Log.hpp"
 
+namespace {
+
+Log::Logger<Log::Source::PCMTrack> logger;
+
+}
+
 using namespace Storage::Disk;
 
 PCMTrack::PCMTrack() : segment_pointer_(0) {}
@@ -60,7 +66,7 @@ PCMTrack *PCMTrack::resampled_clone(Track *original, size_t bits_per_track) {
 		return pcm_original->resampled_clone(bits_per_track);
 	}
 
-	ERROR("NOT IMPLEMENTED: resampling non-PCMTracks");
+	logger.error().append("NOT IMPLEMENTED: resampling non-PCMTracks");
 	return nullptr;
 }
 

--- a/Storage/MassStorage/SCSI/DirectAccessDevice.cpp
+++ b/Storage/MassStorage/SCSI/DirectAccessDevice.cpp
@@ -11,6 +11,12 @@
 
 using namespace SCSI;
 
+namespace {
+
+Log::Logger<Log::Source::DirectAccessDevice> logger;
+
+}
+
 void DirectAccessDevice::set_storage(const std::shared_ptr<Storage::MassStorage::MassStorageDevice> &device) {
 	device_ = device;
 }
@@ -19,7 +25,7 @@ bool DirectAccessDevice::read(const Target::CommandState &state, Target::Respond
 	if(!device_) return false;
 
 	const auto specs = state.read_write_specs();
-	LOG("Read: " << std::dec << specs.number_of_blocks << " from " << specs.address);
+	logger.info().append("Read: %d from %d", specs.number_of_blocks, specs.address);
 
 	std::vector<uint8_t> output = device_->get_block(specs.address);
 	for(uint32_t offset = 1; offset < specs.number_of_blocks; ++offset) {
@@ -38,7 +44,7 @@ bool DirectAccessDevice::write(const Target::CommandState &state, Target::Respon
 	if(!device_) return false;
 
 	const auto specs = state.read_write_specs();
-	LOG("Write: " << specs.number_of_blocks << " to " << specs.address);
+	logger.info().append("Write: %d to %d", specs.number_of_blocks, specs.address);
 
 	responder.receive_data(device_->get_block_size() * specs.number_of_blocks, [this, specs] (const Target::CommandState &state, Target::Responder &responder) {
 		const auto received_data = state.received_data();

--- a/Storage/MassStorage/SCSI/Target.hpp
+++ b/Storage/MassStorage/SCSI/Target.hpp
@@ -347,6 +347,7 @@ template <typename Executor> class Target: public Bus::Observer, public Responde
 
 	private:
 		Executor executor_;
+		Log::Logger<Log::Source::SCSI> log_;
 
 		// Bus::Observer.
 		void scsi_bus_did_change(Bus *, BusState new_state, double time_since_change) final;

--- a/Storage/MassStorage/SCSI/TargetImplementation.hpp
+++ b/Storage/MassStorage/SCSI/TargetImplementation.hpp
@@ -178,7 +178,7 @@ template <typename Executor> bool Target<Executor>::dispatch_command() {
 #define G1(x)	(0x20|x)
 #define G5(x)	(0xa0|x)
 
-	LOG("---Command " << PADHEX(2) << int(command_[0]) << "---");
+	log_.info().append("---Command %02x---", command_[0]);
 
 	switch(command_[0]) {
 		default:		return false;
@@ -278,5 +278,5 @@ template <typename Executor> void Target<Executor>::end_command() {
 	bus_state_ = DefaultBusState;
 	set_device_output(bus_state_);
 
-	LOG("---Done---");
+	log_.info().append("---Done---");
 }

--- a/Storage/State/SZX.cpp
+++ b/Storage/State/SZX.cpp
@@ -25,6 +25,7 @@ namespace {
 constexpr uint32_t block(const char *str) {
 	return uint32_t(str[0] | (str[1] << 8) | (str[2] << 16) | (str[3] << 24));
 }
+Log::Logger<Log::Source::SZX> logger;
 
 }
 
@@ -81,7 +82,7 @@ std::unique_ptr<Analyser::Static::Target> SZX::load(const std::string &file_name
 
 		switch(blockID) {
 			default:
-				LOG("Unhandled block " << char(blockID) << char(blockID >> 8) << char(blockID >> 16) << char(blockID >> 24));
+				logger.info().append("Unhandled block %c%c%c%c", char(blockID), char(blockID >> 8), char(blockID >> 16), char(blockID >> 24));
 			break;
 
 			// ZXSTZ80REGS

--- a/Storage/State/SZX.cpp
+++ b/Storage/State/SZX.cpp
@@ -12,8 +12,6 @@
 
 #include "../../Analyser/Static/ZXSpectrum/Target.hpp"
 #include "../../Machines/Sinclair/ZXSpectrum/State.hpp"
-
-#define LOG_PREFIX "[SZX] "
 #include "../../Outputs/Log.hpp"
 
 #include <zlib.h>

--- a/Storage/Tape/Formats/TZX.cpp
+++ b/Storage/Tape/Formats/TZX.cpp
@@ -14,8 +14,11 @@
 using namespace Storage::Tape;
 
 namespace {
-const unsigned int StandardTZXClock = 3500000;
-const unsigned int TZXClockMSMultiplier = 3500;
+
+constexpr unsigned int StandardTZXClock = 3500000;
+constexpr unsigned int TZXClockMSMultiplier = 3500;
+Log::Logger<Log::Source::TZX> logger;
+
 }
 
 TZX::TZX(const std::string &file_name) :
@@ -92,7 +95,7 @@ void TZX::get_next_pulses() {
 			default:
 				// In TZX each chunk has a different way of stating or implying its length,
 				// so there is no route past an unimplemented chunk.
-				LOG("Unknown TZX chunk: " << PADHEX(4) << chunk_id);
+				logger.error().append("Unknown TZX chunk: %04x", chunk_id);
 				set_is_at_end(true);
 			return;
 		}

--- a/Storage/Tape/Formats/TapeUEF.cpp
+++ b/Storage/Tape/Formats/TapeUEF.cpp
@@ -12,8 +12,13 @@
 #include <cstdlib>
 #include <cmath>
 
-#define LOG_PREFIX "[UEF] "
 #include "../../../Outputs/Log.hpp"
+
+namespace {
+
+Log::Logger<Log::Source::TapeUEF> logger;
+
+}
 
 // MARK: - ZLib extensions
 
@@ -156,7 +161,7 @@ void UEF::get_next_pulses() {
 			break;
 
 			default:
-				LOG("Skipping chunk of type " << PADHEX(4) << next_chunk.id);
+				logger.info().append("Skipping chunk of type %04x", next_chunk.id);
 			break;
 		}
 


### PR DESCRIPTION
Improvements:
* no longer macro based;
* loggers explicitly identify themselves, so no more forcing NDEBUG per-file;
* switches to C-style formatting rather the old-C++ streams, in lieu of being able to use std::format (as I'm not going to introduce fmt as a dependency just to paper over this small, ephemeral crack).

Implicitly: this continues my attempt to eliminate use of macros where more modern C++ approaches exist, but also takes the opportunity to clean up various things I don't like about my current logging.