### PR TITLE
Include <cstddef> and use std::nullptr_t not nullptr_t

### DIFF
--- a/Analyser/Static/StaticAnalyser.cpp
+++ b/Analyser/Static/StaticAnalyser.cpp
@@ -9,6 +9,7 @@
 #include "StaticAnalyser.hpp"
 
 #include <algorithm>
+#include <cstddef>
 #include <cstdlib>
 #include <cstring>
 #include <iterator>
@@ -179,7 +180,7 @@ static Media GetMediaAndPlatforms(const std::string &file_name, TargetPlatform::
 			std::visit([&](auto &&arg) {
 				using Type = typename std::decay<decltype(arg)>::type;
 
-				if constexpr (std::is_same<Type, nullptr_t>::value) {
+				if constexpr (std::is_same<Type, std::nullptr_t>::value) {
 					// It's valid for no media to be returned.
 				} else if constexpr (std::is_same<Type, Disk::DiskImageHolderBase *>::value) {
 					accumulator.insert(TargetPlatform::DiskII, std::shared_ptr<Disk::DiskImageHolderBase>(arg));

--- a/Storage/Disk/DiskImage/Formats/2MG.hpp
+++ b/Storage/Disk/DiskImage/Formats/2MG.hpp
@@ -13,6 +13,7 @@
 
 #include "../../../FileHolder.hpp"
 
+#include <cstddef>
 #include <variant>
 
 namespace Storage::Disk {
@@ -28,7 +29,7 @@ namespace Storage::Disk {
 
 class Disk2MG {
 	public:
-		using DiskOrMassStorageDevice = std::variant<nullptr_t, DiskImageHolderBase *, Storage::MassStorage::MassStorageDevice *>;
+		using DiskOrMassStorageDevice = std::variant<std::nullptr_t, DiskImageHolderBase *, Storage::MassStorage::MassStorageDevice *>;
 		static DiskOrMassStorageDevice open(const std::string &file_name);
 };
 


### PR DESCRIPTION
Fixes `error: use of undeclared identifier 'nullptr_t'; did you mean 'nullptr'?` when compiling with Xcode 12.4.