### PR TITLE
Ensure Master System horizontal scroll is latched every line.

### DIFF
--- a/Components/9918/Implementation/9918.cpp
+++ b/Components/9918/Implementation/9918.cpp
@@ -222,13 +222,13 @@ void TMS9918<personality>::run_for(const HalfCycles cycles) {
 			// Latch scrolling position, if necessary.
 			// ---------------------------------------
 			if constexpr (is_sega_vdp(personality)) {
-				if(!this->fetch_pointer_.row) {
-					// TODO: where did this magic constant come from? https://www.smspower.org/forums/17970-RoadRashHow#111000 mentioned in passing
-					// that "the vertical scroll register is latched at the start of the active display" and this is two clocks before that, so it's
-					// not uncompelling. I can just no longer find my source.
-					constexpr auto latch_time = LineLayout<personality>::EndOfLeftBorder - 2;
-					static_assert(latch_time > 0);
-					if(this->fetch_pointer_.column < latch_time && end_column >= latch_time) {
+				// TODO: where did this magic constant come from? https://www.smspower.org/forums/17970-RoadRashHow#111000 mentioned in passing
+				// that "the vertical scroll register is latched at the start of the active display" and this is two clocks before that, so it's
+				// not uncompelling. I can just no longer find my source.
+				constexpr auto latch_time = LineLayout<personality>::EndOfLeftBorder - 2;
+				static_assert(latch_time > 0);
+				if(this->fetch_pointer_.column < latch_time && end_column >= latch_time) {
+					if(!this->fetch_pointer_.row) {
 						Storage<personality>::latched_vertical_scroll_ = Storage<personality>::vertical_scroll_;
 
 						if(Storage<personality>::mode4_enable_) {


### PR DESCRIPTION
Old code was:

    if(this is first row) { if(this is latch time) { latch vertical; } latch horizontal; }

This is corrected to:

    if(this is latch time) { if(this is first row) { latch vertical; } latch horizontal; }

So:
* horizontal scrolling is now latched _every line_; and
* vertical scrolling is now latched _once per frame_.

Which I think is correct.