### PR TITLE
Switch trailing files to #pragma once.

### DIFF
--- a/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
@@ -1550,6 +1550,7 @@
 		4B6AAEA8230E40250078E864 /* Target.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Target.cpp; sourceTree = "<group>"; };
 		4B6AAEA9230E40250078E864 /* SCSI.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = SCSI.hpp; sourceTree = "<group>"; };
 		4B6AAEAA230E40250078E864 /* TargetImplementation.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = TargetImplementation.hpp; sourceTree = "<group>"; };
+		4B6BBE682B5E0E5800E4C085 /* TypeInfo.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = TypeInfo.hpp; sourceTree = "<group>"; };
 		4B6ED2EE208E2F8A0047B343 /* WOZ.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WOZ.cpp; sourceTree = "<group>"; };
 		4B6ED2EF208E2F8A0047B343 /* WOZ.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = WOZ.hpp; sourceTree = "<group>"; };
 		4B6FD0342923061300EC4760 /* HDV.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = HDV.cpp; sourceTree = "<group>"; };
@@ -2959,10 +2960,11 @@
 		4B3AF7CF2413470E00873C0B /* Reflection */ = {
 			isa = PBXGroup;
 			children = (
+				4B47F6C4241C87A100ED06F7 /* Struct.cpp */,
 				4BDA7F8129C4C223007A10A5 /* Dispatcher.hpp */,
 				4B3AF7D02413470E00873C0B /* Enum.hpp */,
-				4B47F6C4241C87A100ED06F7 /* Struct.cpp */,
 				4B3AF7D12413472200873C0B /* Struct.hpp */,
+				4B6BBE682B5E0E5800E4C085 /* TypeInfo.hpp */,
 			);
 			name = Reflection;
 			path = ../../Reflection;

--- a/OSBindings/Qt/audiobuffer.h
+++ b/OSBindings/Qt/audiobuffer.h
@@ -1,5 +1,4 @@
-#ifndef AUDIOSOURCE_H
-#define AUDIOSOURCE_H
+#pragma once
 
 #include <cstdint>
 #include <mutex>
@@ -93,5 +92,3 @@ struct AudioBuffer: public QIODevice {
 		mutable size_t readPointer = 0;
 		size_t writePointer = 0;
 };
-
-#endif // AUDIOSOURCE_H

--- a/OSBindings/Qt/functionthread.h
+++ b/OSBindings/Qt/functionthread.h
@@ -1,5 +1,4 @@
-#ifndef FUNCTIONTHREAD_H
-#define FUNCTIONTHREAD_H
+#pragma once
 
 #include <atomic>
 #include <QApplication>
@@ -87,5 +86,3 @@ class FunctionThread: public QThread {
 		std::unique_ptr<FunctionPerformer> performer;
 		std::atomic_flag performerFlag;
 };
-
-#endif // FUNCTIONTHREAD_H

--- a/OSBindings/Qt/keyboard.h
+++ b/OSBindings/Qt/keyboard.h
@@ -1,5 +1,4 @@
-#ifndef KEYBOARD_H
-#define KEYBOARD_H
+#pragma once
 
 #include <QKeyEvent>
 #include <map>
@@ -14,5 +13,3 @@ class KeyboardMapper {
 	private:
 		std::map<quint32, Inputs::Keyboard::Key> keyByKeySym;
 };
-
-#endif // MAINWINDOW_H

--- a/OSBindings/Qt/mainwindow.h
+++ b/OSBindings/Qt/mainwindow.h
@@ -1,5 +1,4 @@
-#ifndef MAINWINDOW_H
-#define MAINWINDOW_H
+#pragma once
 
 #include <QtGlobal>
 
@@ -172,5 +171,3 @@ class MainWindow : public QMainWindow, public Outputs::Speaker::Speaker::Delegat
 
 		void addActivityObserver();
 };
-
-#endif // MAINWINDOW_H

--- a/OSBindings/Qt/scantargetwidget.h
+++ b/OSBindings/Qt/scantargetwidget.h
@@ -1,5 +1,4 @@
-#ifndef SCANTARGETWIDGET_H
-#define SCANTARGETWIDGET_H
+#pragma once
 
 #include <QOpenGLWidget>
 
@@ -72,5 +71,3 @@ class ScanTargetWidget : public QOpenGLWidget {
 	private slots:
 		void vsync();
 };
-
-#endif // SCANTARGETWIDGET_H

--- a/OSBindings/Qt/settings.h
+++ b/OSBindings/Qt/settings.h
@@ -1,5 +1,4 @@
-#ifndef SETTINGS_H
-#define SETTINGS_H
+#pragma once
 
 #include <QSettings>
 
@@ -7,5 +6,3 @@ class Settings: public QSettings {
 	public:
 		Settings() : QSettings("thomasharte", "Clock Signal") {}
 };
-
-#endif // SETTINGS_H

--- a/OSBindings/Qt/timer.h
+++ b/OSBindings/Qt/timer.h
@@ -1,5 +1,4 @@
-#ifndef TIMER_H
-#define TIMER_H
+#pragma once
 
 #include <atomic>
 
@@ -30,5 +29,3 @@ class Timer : public QObject
 		FunctionThread thread;
 		std::unique_ptr<QTimer> timer;
 };
-
-#endif // TIMER_H

--- a/Reflection/TypeInfo.hpp
+++ b/Reflection/TypeInfo.hpp
@@ -6,8 +6,7 @@
 //  Copyright © 2020 Thomas Harte. All rights reserved.
 //
 
-#ifndef TypeInfo_hpp
-#define TypeInfo_hpp
+#pragma once
 
 #define ForAllInts(x)	\
 	x(uint8_t);			\
@@ -59,6 +58,3 @@ inline size_t size(const std::type_info *type) {
 }
 
 }
-
-
-#endif /* TypeInfo_hpp */


### PR DESCRIPTION
Also adds TypeInfo.hpp to the Xcode project, which had previously omitted it.