### PR TITLE
Update CI to build on macOS 11, 12, 13, and 14.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ jobs:
     name: Mac UI on ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest]
+        os: [macos-11, macos-12, macos-13, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
@@ -17,7 +17,7 @@ jobs:
     name: SDL UI on ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-11, macos-12, macos-13, macos-14, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout


### PR DESCRIPTION
GitHub Actions now offers macOS 14 runners:

https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/

macos-latest will remain on macOS 12 until it switches to macOS 14 in the second quarter of 2024. So that you don't have to wait that long to get automated checks running on something newer than macOS 12, this PR switches from macos-latest to explicitly listing macos-11, macos-12, macos-13, and macos-14.

macos-11 is deprecated and will be removed by June 2024 but could be helpful until then.

macos-14 is arm64; macos-13 and earlier are x86_64.