### PR TITLE
Fix IOSEL and DEVSEL assignments.

### DIFF
--- a/Machines/Apple/AppleII/AppleII.cpp
+++ b/Machines/Apple/AppleII/AppleII.cpp
@@ -929,14 +929,14 @@ template <Analyser::Static::AppleII::Target::Model model, bool has_mockingboard>
 							This also sets the active card for the C8 region.
 						*/
 						active_card_ = card_number = (address - 0xc100) >> 8;
-						select = Apple::II::Card::Device;
+						select = Apple::II::Card::IO;
 					} else {
 						/*
 							Decode the area conventionally used by cards for registers:
 								C0n0 to C0nF: card n - 8.
 						*/
 						card_number = (address - 0xc090) >> 4;
-						select = Apple::II::Card::IO;
+						select = Apple::II::Card::Device;
 					}
 
 					// If the selected card is a just-in-time card, update the just-in-time cards,

--- a/Machines/Apple/AppleII/Card.hpp
+++ b/Machines/Apple/AppleII/Card.hpp
@@ -41,12 +41,12 @@ class Card {
 		virtual ~Card() {}
 		enum Select: int {
 			None		= 0,		// No select line is active.
-			IO			= 1 << 0,	// IO select is active; i.e. access is in range $C0x0 to $C0xf.
-			Device		= 1 << 1,	// Device select is active; i.e. access is in range $Cx00 to $Cxff.
+			Device		= 1 << 0,	// Device select ('DEVSEL') is active; i.e. access is in range $C0x0 to $C0xf.
+			IO			= 1 << 1,	// IO select ('IOSEL') is active; i.e. access is in range $Cx00 to $Cxff.
 
 			C8Region	= 1 << 2,	// Access is to the region $c800 to $cfff, was preceded by at least
 									// one Device access to this card, and has not yet been followed up
-									// by an access to $cfff.
+									// by an access to $cfff. IOSTRB on original hardware.
 		};
 
 		// TODO: I think IO and Device are the wrong way around above.
@@ -112,7 +112,7 @@ class Card {
 		}
 
 	protected:
-		int select_constraints_ = IO | Device;
+		int select_constraints_ = Device | IO;
 		Delegate *delegate_ = nullptr;
 		void set_select_constraints(int constraints) {
 			if(constraints == select_constraints_) return;

--- a/Machines/Apple/AppleII/DiskIICard.cpp
+++ b/Machines/Apple/AppleII/DiskIICard.cpp
@@ -46,14 +46,14 @@ void DiskIICard::perform_bus_operation(Select select, bool is_read, uint16_t add
 	diskii_.set_data_input(*value);
 	switch(select) {
 		default: break;
-		case IO: {
+		case Device: {
 			const int disk_value = diskii_.read_address(address);
 			if(is_read) {
 				if(disk_value != diskii_.DidNotLoad)
 					*value = uint8_t(disk_value);
 			}
 		} break;
-		case Device:
+		case IO:
 			if(is_read) *value = boot_[address & 0xff];
 		break;
 	}
@@ -74,7 +74,7 @@ void DiskIICard::set_activity_observer(Activity::Observer *observer) {
 
 void DiskIICard::set_component_prefers_clocking(ClockingHint::Source *, ClockingHint::Preference preference) {
 	diskii_clocking_preference_ = preference;
-	set_select_constraints((preference != ClockingHint::Preference::RealTime) ? (IO | Device) : None);
+	set_select_constraints((preference != ClockingHint::Preference::RealTime) ? (Device | IO) : None);
 }
 
 Storage::Disk::Drive &DiskIICard::get_drive(int drive) {

--- a/Machines/Apple/AppleII/Mockingboard.hpp
+++ b/Machines/Apple/AppleII/Mockingboard.hpp
@@ -60,7 +60,7 @@ class Mockingboard: public Card {
 		}
 
 		void perform_bus_operation(Select select, bool is_read, uint16_t address, uint8_t *value) final {
-			if(!(select & Device)) {
+			if(!(select & IO)) {
 				return;
 			}
 

--- a/Machines/Apple/AppleII/SCSICard.cpp
+++ b/Machines/Apple/AppleII/SCSICard.cpp
@@ -79,13 +79,13 @@ void SCSICard::perform_bus_operation(Select select, bool is_read, uint16_t addre
 	switch(select) {
 		default: break;
 
-		case Select::Device:
+		case Select::IO:
 			if(is_read) {
 				*value = rom_[address & 255];
 			}
 		break;
 
-		case Select::IO:
+		case Select::Device:
 			address &= 0xf;
 			switch(address) {
 				case 0x0:	case 0x1:	case 0x2:	case 0x3:


### PR DESCRIPTION
So `IO` and `Device` signals are no longer labelled the wrong way around.