### PR TITLE
Mention Macintosh 128K and 512K in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ It currently contains emulations of the:
 * ColecoVision;
 * Commodore Vic-20 (and Commodore 1540/1);
 * Enterprise 64/128;
-* Macintosh 512ke and Plus;
+* Macintosh 128K, 512K, 512Ke, and Plus;
 * MSX 1 and 2;
 * Oric 1/Atmos;
 * Sega Master System;


### PR DESCRIPTION
I was going to ask how difficult it would be to add support for the Macintosh 128K and 512K but it seems you already support them! This PR mentions this in the README. (Unless these emulations are unfinished and you don't want to mention them yet…)