### PR TITLE
Express offset test as positive logic.

### DIFF
--- a/InstructionSets/ARM/Executor.hpp
+++ b/InstructionSets/ARM/Executor.hpp
@@ -248,14 +248,14 @@ struct Executor {
 
 		// Calculate offset.
 		uint32_t offset;
-		if constexpr (flags.offset_is_immediate()) {
-			offset = transfer.immediate();
-		} else {
+		if constexpr (flags.offset_is_register()) {
 			// The 8 shift control bits are described in 6.2.3, but
 			// the register specified shift amounts are not available
 			// in this instruction class.
 			uint32_t carry = registers_.c();
 			offset = decode_shift<false, false>(transfer, carry, 4);
+		} else {
+			offset = transfer.immediate();
 		}
 
 		// Obtain base address.

--- a/InstructionSets/ARM/Executor.hpp
+++ b/InstructionSets/ARM/Executor.hpp
@@ -544,8 +544,7 @@ struct Executor {
 		registers_.exception<Registers::Exception::UndefinedInstruction>();
 	}
 
-	MemoryT bus;
-
+	/// @returns The current registers state.
 	const Registers &registers() const {
 		return registers_;
 	}
@@ -563,12 +562,14 @@ struct Executor {
 		return registers_.pc(0);
 	}
 
+	MemoryT bus;
+
 private:
 	Registers registers_;
 };
 
-/// Provides an analogue of the @c OperationMapper -affiliated @c dispatch that also updates the
-/// executor's program counter appropriately.
+/// Executes the instruction @c instruction which should have been fetched from @c executor.pc(),
+/// modifying @c executor.
 template <Model model, typename MemoryT>
 void execute(uint32_t instruction, Executor<model, MemoryT> &executor) {
 	executor.set_pc(executor.pc() + 4);

--- a/InstructionSets/ARM/OperationMapper.hpp
+++ b/InstructionSets/ARM/OperationMapper.hpp
@@ -232,7 +232,7 @@ struct SingleDataTransferFlags {
 		return flag_bit<20>(flags_) ? Operation::LDR : Operation::STR;
 	}
 
-	constexpr bool offset_is_immediate() const	{	return !flag_bit<25>(flags_);	}
+	constexpr bool offset_is_register() const	{	return flag_bit<25>(flags_);	}
 	constexpr bool pre_index() const			{	return flag_bit<24>(flags_);	}
 	constexpr bool add_offset() const			{	return flag_bit<23>(flags_);	}
 	constexpr bool transfer_byte() const		{	return flag_bit<22>(flags_);	}

--- a/InstructionSets/ARM/OperationMapper.hpp
+++ b/InstructionSets/ARM/OperationMapper.hpp
@@ -254,7 +254,7 @@ struct SingleDataTransfer: public WithShiftControlBits {
 	/// The base register index. i.e. 'Rn'.
 	int base() const					{	return (opcode_ >> 16) & 0xf;	}
 
-	/// The immediate offset, if @c offset_is_immediate() was @c true; meaningless otherwise.
+	/// The immediate offset, if @c offset_is_register() was @c false; meaningless otherwise.
 	int immediate() const				{	return opcode_ & 0xfff;			}
 };
 

--- a/InstructionSets/ARM/Registers.hpp
+++ b/InstructionSets/ARM/Registers.hpp
@@ -66,6 +66,7 @@ struct Registers {
 			overflow_flag_ = value;
 		}
 
+		/// @returns The current status bits, separate from the PC — mode, NVCZ and the two interrupt flags.
 		uint32_t status() const {
 			return
 				uint32_t(mode_) |
@@ -100,6 +101,7 @@ struct Registers {
 			}
 		}
 
+		/// @returns The current mode.
 		Mode mode() const {
 			return mode_;
 		}
@@ -109,6 +111,7 @@ struct Registers {
 			active[15] = value & ConditionCode::Address;
 		}
 
+		/// @returns The stored PC plus @c offset limited to 26 bits.
 		uint32_t pc(uint32_t offset) const {
 			return (active[15] + offset) & ConditionCode::Address;
 		}
@@ -136,6 +139,7 @@ struct Registers {
 			FIQ = 0x1c,
 		};
 
+		/// Updates the program counter, interupt flags and link register if applicable to begin @c exception.
 		template <Exception exception>
 		void exception() {
 			interrupt_flags_ |= ConditionCode::IRQDisable;
@@ -163,6 +167,7 @@ struct Registers {
 
 		// MARK: - Condition tests.
 
+		/// @returns @c true if @c condition tests as true; @c false otherwise.
 		bool test(Condition condition) {
 			const auto ne = [&]() -> bool {
 				return zero_result_;
@@ -208,8 +213,7 @@ struct Registers {
 			}
 		}
 
-		std::array<uint32_t, 16> active{};
-
+		/// Sets current execution mode.
 		void set_mode(Mode target_mode) {
 			if(mode_ == target_mode) {
 				return;
@@ -257,6 +261,10 @@ struct Registers {
 
 			mode_ = target_mode;
 		}
+
+		/// The active register set. TODO: switch to an implementation of operator[], hiding the
+		/// current implementation decision to maintain this as a linear block of memory.
+		std::array<uint32_t, 16> active{};
 
 	private:
 		Mode mode_ = Mode::Supervisor;

--- a/OSBindings/Mac/Clock SignalTests/ARMDecoderTests.mm
+++ b/OSBindings/Mac/Clock SignalTests/ARMDecoderTests.mm
@@ -30,7 +30,7 @@ struct Memory {
 
 	template <typename IntT>
 	bool read(uint32_t address, IntT &source, Mode mode, bool trans) {
-		if(address > 0x3800000) {
+		if(address >= 0x3800000) {
 			has_moved_rom_ = true;
 			source = *reinterpret_cast<const IntT *>(&rom[address - 0x3800000]);
 		} else if(!has_moved_rom_) {
@@ -202,7 +202,7 @@ struct Memory {
 }
 
 // TODO: turn the below into a trace-driven test case.
-/*- (void)testROM319 {
+- (void)testROM319 {
 	constexpr ROM::Name rom_name = ROM::Name::AcornRISCOS319;
 	ROM::Request request(rom_name);
 	const auto roms = CSROMFetcher()(request);
@@ -217,6 +217,6 @@ struct Memory {
 		printf("%08x: %08x\n", executor.pc(), instruction);
 		execute<Model::ARMv2>(instruction, executor);
 	}
-}*/
+}
 
 @end

--- a/OSBindings/Mac/Clock SignalTests/ARMDecoderTests.mm
+++ b/OSBindings/Mac/Clock SignalTests/ARMDecoderTests.mm
@@ -211,25 +211,25 @@ struct Memory {
 }
 
 // TODO: turn the below into a trace-driven test case.
-- (void)testROM319 {
-	constexpr ROM::Name rom_name = ROM::Name::AcornRISCOS319;
-	ROM::Request request(rom_name);
-	const auto roms = CSROMFetcher()(request);
-
-	auto executor = std::make_unique<Executor<Model::ARMv2, Memory>>();
-	executor->bus.rom = roms.find(rom_name)->second;
-
-	for(int c = 0; c < 1000; c++) {
-		uint32_t instruction;
-		executor->bus.read(executor->pc(), instruction, executor->registers().mode(), false);
-
-		printf("%08x: %08x [", executor->pc(), instruction);
-		for(int c = 0; c < 15; c++) {
-			printf("r%d:%08x ", c, executor->registers().active[c]);
-		}
-		printf("psr:%08x]\n", executor->registers().status());
-		execute<Model::ARMv2>(instruction, *executor);
-	}
-}
+//- (void)testROM319 {
+//	constexpr ROM::Name rom_name = ROM::Name::AcornRISCOS319;
+//	ROM::Request request(rom_name);
+//	const auto roms = CSROMFetcher()(request);
+//
+//	auto executor = std::make_unique<Executor<Model::ARMv2, Memory>>();
+//	executor->bus.rom = roms.find(rom_name)->second;
+//
+//	for(int c = 0; c < 1000; c++) {
+//		uint32_t instruction;
+//		executor->bus.read(executor->pc(), instruction, executor->registers().mode(), false);
+//
+//		printf("%08x: %08x [", executor->pc(), instruction);
+//		for(int c = 0; c < 15; c++) {
+//			printf("r%d:%08x ", c, executor->registers().active[c]);
+//		}
+//		printf("psr:%08x]\n", executor->registers().status());
+//		execute<Model::ARMv2>(instruction, *executor);
+//	}
+//}
 
 @end


### PR DESCRIPTION
Also tie down some of the undefined parts of the still-vague ARM execution test.

Off the record: a lot of the output of that test now looks like appropriate IOC/VIDC activity.