### PR TITLE
Slightly reduce processing heft of floppy accesses.

### DIFF
--- a/Machines/Acorn/Archimedes/FloppyDisc.hpp
+++ b/Machines/Acorn/Archimedes/FloppyDisc.hpp
@@ -16,7 +16,7 @@ template <typename InterruptObserverT>
 class FloppyDisc: public WD::WD1770, public WD::WD1770::Delegate {
 public:
 	FloppyDisc(InterruptObserverT &observer) : WD::WD1770(P1772), observer_(observer) {
-		emplace_drives(4, 8000000, 300, 2);
+		emplace_drives(1, 8000000, 300, 2);
 		set_delegate(this);
 	}
 
@@ -25,13 +25,12 @@ public:
 	}
 
 	void set_control(uint8_t value) {
-		// TODO:
 		//	b0, b1, b2, b3 = drive selects;
 		//	b4 = side select;
 		//	b5 = motor on/off
 		//	b6 = floppy in use (i.e. LED?);
 		//	b7 = disc eject/change reset.
-		set_drive((value & 0xf) ^ 0xf);
+		set_drive((value & 0x1) ^ 0x1);
 		get_drive().set_head(1 ^ ((value >> 4) & 1));
 		get_drive().set_motor_on(!(value & 0x20));
 	}

--- a/Storage/Disk/Drive.cpp
+++ b/Storage/Disk/Drive.cpp
@@ -203,8 +203,9 @@ void Drive::advance(const Cycles cycles) {
 }
 
 void Drive::run_for(const Cycles cycles) {
-	// Assumed: the index pulse pulses even if the drive has stopped spinning.
-	index_pulse_remaining_ = std::max(index_pulse_remaining_ - cycles, Cycles(0));
+	// Assumed: the index pulse will end even if the drive has stopped spinning.
+	// Also: because the count here is a 64-bit integer, the std::max can be ignored.
+	index_pulse_remaining_ -= cycles;// std::max(index_pulse_remaining_ - cycles, Cycles(0));
 
 	if(time_until_motor_transition > Cycles(0)) {
 		if(time_until_motor_transition > cycles) {


### PR DESCRIPTION
1. reduces the Archimedes to a single disk drive, to avoid paying any update costs on the invisible three; and
2. removes a single conditional in drive emulation which showed up as expensive in profiling.