### PR TITLE
Don't move cursor near disk to folder if not about to load something.

### DIFF
--- a/Machines/Acorn/Archimedes/Archimedes.cpp
+++ b/Machines/Acorn/Archimedes/Archimedes.cpp
@@ -243,7 +243,6 @@ class ConcreteMachine:
 							executor_.bus.read(address + 16, y2, false);
 
 							switch(autoload_phase_) {
-
 								default: break;
 
 								case AutoloadPhase::WaitingForDiskContents: {
@@ -266,15 +265,12 @@ class ConcreteMachine:
 											.click(0);
 
 										if(target_program_.empty()) {
-											builder.set_phase(AutoloadPhase::Ended);
+											autoload_phase_ = AutoloadPhase::Ended;
 										} else {
-											builder
-												.set_phase(AutoloadPhase::WaitingForDiskContents)
-												.move_to(IconBarDriveX, 80);	// Just a guess of 'close' to where the program to launch
+											autoload_phase_ = AutoloadPhase::WaitingForDiskContents;
+											builder.move_to(IconBarDriveX, 80);	// Just a guess of 'close' to where the program to launch
 																				// will probably be, to have the cursor broadly nearby.
 										}
-
-										autoload_phase_ = AutoloadPhase::OpeningDisk;
 									}
 								break;
 							}
@@ -623,7 +619,6 @@ class ConcreteMachine:
 
 		enum class AutoloadPhase {
 			WaitingForStartup,
-			OpeningDisk,
 			WaitingForDiskContents,
 			WaitingForTargetIcon,
 			OpeningProgram,

--- a/Machines/Acorn/Archimedes/Archimedes.cpp
+++ b/Machines/Acorn/Archimedes/Archimedes.cpp
@@ -261,15 +261,18 @@ class ConcreteMachine:
 										// Wait a further second, mouse down to (32, 240), left click.
 										// That'll trigger disk access. Then move up to the top left,
 										// in anticipation of the appearance of a window.
-										CursorActionBuilder(cursor_actions_)
-//											.wait(5 * 24'000'000)
+										auto &builder = CursorActionBuilder(cursor_actions_)
 											.move_to(IconBarDriveX, IconBarY)
-											.click(0)
-											.set_phase(
-												target_program_.empty() ? AutoloadPhase::Ended : AutoloadPhase::WaitingForDiskContents
-											)
-											.move_to(IconBarDriveX, 36);	// Just a guess of 'close' to where the program to launch
-																			// will probably be, to have the cursor already nearby.
+											.click(0);
+
+										if(target_program_.empty()) {
+											builder.set_phase(AutoloadPhase::Ended);
+										} else {
+											builder
+												.set_phase(AutoloadPhase::WaitingForDiskContents)
+												.move_to(IconBarDriveX, 80);	// Just a guess of 'close' to where the program to launch
+																				// will probably be, to have the cursor broadly nearby.
+										}
 
 										autoload_phase_ = AutoloadPhase::OpeningDisk;
 									}


### PR DESCRIPTION
This also implies I could probably remove both `wait` and `set_phase` actions, but I'll defer for now.