### PR TITLE
Avoid `std::memory_order::memory_order_X` in favour of `std::memory_order_X`.

### DIFF
--- a/Analyser/Dynamic/MultiMachine/Implementation/MultiSpeaker.cpp
+++ b/Analyser/Dynamic/MultiMachine/Implementation/MultiSpeaker.cpp
@@ -61,7 +61,7 @@ void MultiSpeaker::set_output_volume(float volume) {
 }
 
 void MultiSpeaker::speaker_did_complete_samples(Speaker *speaker, const std::vector<int16_t> &buffer) {
-	auto delegate = delegate_.load(std::memory_order::memory_order_relaxed);
+	auto delegate = delegate_.load(std::memory_order_relaxed);
 	if(!delegate) return;
 	{
 		std::lock_guard lock_guard(front_speaker_mutex_);
@@ -71,7 +71,7 @@ void MultiSpeaker::speaker_did_complete_samples(Speaker *speaker, const std::vec
 }
 
 void MultiSpeaker::speaker_did_change_input_clock(Speaker *speaker) {
-	auto delegate = delegate_.load(std::memory_order::memory_order_relaxed);
+	auto delegate = delegate_.load(std::memory_order_relaxed);
 	if(!delegate) return;
 	{
 		std::lock_guard lock_guard(front_speaker_mutex_);
@@ -85,7 +85,7 @@ void MultiSpeaker::set_new_front_machine(::Machine::DynamicMachine *machine) {
 		std::lock_guard lock_guard(front_speaker_mutex_);
 		front_speaker_ = machine->audio_producer()->get_speaker();
 	}
-	auto delegate = delegate_.load(std::memory_order::memory_order_relaxed);
+	auto delegate = delegate_.load(std::memory_order_relaxed);
 	if(delegate) {
 		delegate->speaker_did_change_input_clock(this);
 	}

--- a/Machines/Amiga/Audio.cpp
+++ b/Machines/Amiga/Audio.cpp
@@ -20,7 +20,7 @@ Audio::Audio(Chipset &chipset, uint16_t *ram, size_t word_size, float output_rat
 
 	// Mark all buffers as available.
 	for(auto &flag: buffer_available_) {
-		flag.store(true, std::memory_order::memory_order_relaxed);
+		flag.store(true, std::memory_order_relaxed);
 	}
 
 	speaker_.set_input_rate(output_rate);
@@ -130,7 +130,7 @@ void Audio::output() {
 	// Spin until the next buffer is available if just entering it for the first time.
 	// Contention here should be essentially non-existent.
 	if(!sample_pointer_) {
-		while(!buffer_available_[buffer_pointer_].load(std::memory_order::memory_order_relaxed));
+		while(!buffer_available_[buffer_pointer_].load(std::memory_order_relaxed));
 	}
 
 	// Left.
@@ -155,10 +155,10 @@ void Audio::output() {
 		const auto &buffer = buffer_[buffer_pointer_];
 		auto &flag = buffer_available_[buffer_pointer_];
 
-		flag.store(false, std::memory_order::memory_order_release);
+		flag.store(false, std::memory_order_release);
 		queue_.enqueue([this, &buffer, &flag] {
 			speaker_.push(buffer.data(), buffer.size() >> 1);
-			flag.store(true, std::memory_order::memory_order_relaxed);
+			flag.store(true, std::memory_order_relaxed);
 		});
 
 		buffer_pointer_ = (buffer_pointer_ + 1) % BufferCount;

--- a/Machines/Apple/ADB/Mouse.cpp
+++ b/Machines/Apple/ADB/Mouse.cpp
@@ -25,15 +25,15 @@ void Mouse::perform_command(const Command &command) {
 		// There's some small chance of creating negative feedback here — taking too much off delta_x_ or delta_y_
 		// due to a change in the underlying value between the load and the arithmetic. But if that occurs it means
 		// the user moved the mouse again in the interim, so it'll just play out as very slight latency.
-		auto delta_x = delta_x_.load(std::memory_order::memory_order_relaxed);
-		auto delta_y = delta_y_.load(std::memory_order::memory_order_relaxed);
+		auto delta_x = delta_x_.load(std::memory_order_relaxed);
+		auto delta_y = delta_y_.load(std::memory_order_relaxed);
 		if(abs(delta_x) > max_delta || abs(delta_y) > max_delta) {
 			int max = std::max(abs(delta_x), abs(delta_y));
 			delta_x = delta_x * max_delta / max;
 			delta_y = delta_y * max_delta / max;
 		}
 
-		const int buttons = button_flags_.load(std::memory_order::memory_order_relaxed);
+		const int buttons = button_flags_.load(std::memory_order_relaxed);
 		delta_x_ -= delta_x;
 		delta_y_ -= delta_y;
 

--- a/Machines/Apple/AppleIIgs/Sound.cpp
+++ b/Machines/Apple/AppleIIgs/Sound.cpp
@@ -35,7 +35,7 @@ void GLU::set_data(uint8_t data) {
 		write.address = address_;
 		write.value = data;
 		write.time = pending_store_write_time_;
-		pending_stores_[pending_store_write_].store(write, std::memory_order::memory_order_release);
+		pending_stores_[pending_store_write_].store(write, std::memory_order_release);
 
 		pending_store_write_ = (pending_store_write_ + 1) % (StoreBufferSize - 1);
 	} else {
@@ -174,15 +174,15 @@ template void GLU::apply_samples<Outputs::Speaker::Action::Ignore>(std::size_t, 
 //	skip_audio(remote_, number_of_samples);
 //
 //	// Apply any pending stores.
-//	std::atomic_thread_fence(std::memory_order::memory_order_acquire);
+//	std::atomic_thread_fence(std::memory_order_acquire);
 //	const uint32_t final_time = pending_store_read_time_ + uint32_t(number_of_samples);
 //	while(true) {
-//		auto next_store = pending_stores_[pending_store_read_].load(std::memory_order::memory_order_acquire);
+//		auto next_store = pending_stores_[pending_store_read_].load(std::memory_order_acquire);
 //		if(!next_store.enabled) break;
 //		if(next_store.time >= final_time) break;
 //		remote_.ram_[next_store.address] = next_store.value;
 //		next_store.enabled = false;
-//		pending_stores_[pending_store_read_].store(next_store, std::memory_order::memory_order_relaxed);
+//		pending_stores_[pending_store_read_].store(next_store, std::memory_order_relaxed);
 //
 //		pending_store_read_ = (pending_store_read_ + 1) & (StoreBufferSize - 1);
 //	}
@@ -263,7 +263,7 @@ void GLU::skip_audio(EnsoniqState &state, size_t number_of_samples) {
 
 template <Outputs::Speaker::Action action>
 void GLU::generate_audio(size_t number_of_samples, Outputs::Speaker::MonoSample *target) {
-	auto next_store = pending_stores_[pending_store_read_].load(std::memory_order::memory_order_acquire);
+	auto next_store = pending_stores_[pending_store_read_].load(std::memory_order_acquire);
 	uint8_t next_amplitude = 255;
 	for(size_t sample = 0; sample < number_of_samples; sample++) {
 
@@ -344,7 +344,7 @@ void GLU::generate_audio(size_t number_of_samples, Outputs::Speaker::MonoSample 
 		if(next_store.time != pending_store_read_time_) continue;
 		remote_.ram_[next_store.address] = next_store.value;
 		next_store.enabled = false;
-		pending_stores_[pending_store_read_].store(next_store, std::memory_order::memory_order_relaxed);
+		pending_stores_[pending_store_read_].store(next_store, std::memory_order_relaxed);
 		pending_store_read_ = (pending_store_read_ + 1) & (StoreBufferSize - 1);
 	}
 }

--- a/Machines/Apple/Macintosh/Audio.cpp
+++ b/Machines/Apple/Macintosh/Audio.cpp
@@ -27,7 +27,7 @@ Audio::Audio(Concurrency::AsyncTaskQueue<false> &task_queue) : task_queue_(task_
 void Audio::post_sample(uint8_t sample) {
 	// Store sample directly indexed by current write pointer; this ensures that collected samples
 	// directly map to volume and enabled/disabled states.
-	sample_queue_.buffer[sample_queue_.write_pointer].store(sample, std::memory_order::memory_order_relaxed);
+	sample_queue_.buffer[sample_queue_.write_pointer].store(sample, std::memory_order_relaxed);
 	sample_queue_.write_pointer = (sample_queue_.write_pointer + 1) % sample_queue_.buffer.size();
 }
 
@@ -82,7 +82,7 @@ void Audio::apply_samples(std::size_t number_of_samples, Outputs::Speaker::MonoS
 		const auto cycles_left_in_sample = std::min(number_of_samples, sample_length - subcycle_offset_);
 
 		// Determine the output level, and output that many samples.
-		const int16_t output_level = volume_multiplier_ * (int16_t(sample_queue_.buffer[sample_queue_.read_pointer].load(std::memory_order::memory_order_relaxed)) - 128);
+		const int16_t output_level = volume_multiplier_ * (int16_t(sample_queue_.buffer[sample_queue_.read_pointer].load(std::memory_order_relaxed)) - 128);
 		Outputs::Speaker::fill<action>(target, target + cycles_left_in_sample, output_level);
 		target += cycles_left_in_sample;
 

--- a/OSBindings/SDL/main.cpp
+++ b/OSBindings/SDL/main.cpp
@@ -246,7 +246,7 @@ class ActivityObserver: public Activity::Observer {
 			const float right_x = 1.0f - 2.0f * width;
 			float y = 1.0f - 2.0f * height;
 			for(const auto &drive: drives_) {
-				lights_.emplace(std::make_pair(drive, std::make_unique<Outputs::Display::OpenGL::Rectangle>(right_x, y, width, height)));
+				lights_.emplace(drive, std::make_unique<Outputs::Display::OpenGL::Rectangle>(right_x, y, width, height));
 				y -= height * 2.0f;
 			}
 
@@ -257,7 +257,7 @@ class ActivityObserver: public Activity::Observer {
 				const float left_x = -1.0f + 2.0f * width;
 				y = 1.0f - 2.0f * height;
 				for(const auto &led: leds_) {
-					lights_.emplace(std::make_pair(led, std::make_unique<OpenGL::Rectangle>(left_x, y, width, height)));
+					lights_.emplace(led, std::make_unique<OpenGL::Rectangle>(left_x, y, width, height));
 					y -= height * 2.0f;
 				}
 			*/

--- a/Outputs/Speaker/Implementation/LowpassSpeaker.hpp
+++ b/Outputs/Speaker/Implementation/LowpassSpeaker.hpp
@@ -239,7 +239,7 @@ template <typename ConcreteT, bool is_stereo> class LowpassBase: public Speaker 
 
 	protected:
 		bool process(size_t length) {
-			const auto delegate = delegate_.load(std::memory_order::memory_order_relaxed);
+			const auto delegate = delegate_.load(std::memory_order_relaxed);
 			if(!delegate) return false;
 
 			const int scale = static_cast<ConcreteT *>(this)->get_scale();
@@ -301,7 +301,7 @@ template <bool is_stereo> class PushLowpass: public LowpassBase<PushLowpass<is_s
 
 		std::atomic<int> scale_ = 65536;
 		int get_scale() const {
-			return scale_.load(std::memory_order::memory_order_relaxed);
+			return scale_.load(std::memory_order_relaxed);
 		}
 
 		const int16_t *buffer_ = nullptr;

--- a/Outputs/Speaker/Speaker.hpp
+++ b/Outputs/Speaker/Speaker.hpp
@@ -91,7 +91,7 @@ class Speaker {
 		void copy_output_rate(const Speaker &rhs) {
 			output_cycles_per_second_ = rhs.output_cycles_per_second_;
 			output_buffer_size_ = rhs.output_buffer_size_;
-			stereo_output_.store(rhs.stereo_output_.load(std::memory_order::memory_order_relaxed), std::memory_order::memory_order_relaxed);
+			stereo_output_.store(rhs.stereo_output_.load(std::memory_order_relaxed), std::memory_order_relaxed);
 			compute_output_rate();
 		}
 
@@ -129,7 +129,7 @@ class Speaker {
 			virtual void speaker_did_change_input_clock([[maybe_unused]] Speaker *speaker) {}
 		};
 		virtual void set_delegate(Delegate *delegate) {
-			delegate_.store(delegate, std::memory_order::memory_order_relaxed);
+			delegate_.store(delegate, std::memory_order_relaxed);
 		}
 
 
@@ -139,7 +139,7 @@ class Speaker {
 	protected:
 		void did_complete_samples(Speaker *, const std::vector<int16_t> &buffer, bool is_stereo) {
 			// Test the delegate for existence again, as it may have changed.
-			const auto delegate = delegate_.load(std::memory_order::memory_order_relaxed);
+			const auto delegate = delegate_.load(std::memory_order_relaxed);
 			if(!delegate) return;
 
 			++completed_sample_sets_;

--- a/Processors/65816/Implementation/65816Storage.cpp
+++ b/Processors/65816/Implementation/65816Storage.cpp
@@ -153,7 +153,7 @@ struct CPU::WDC65816::ProcessorStorageConstructor {
 		}
 
 		// Insert into the map and return the resulting iterator.
-		return installed_patterns.insert(std::make_pair(key, std::make_pair(micro_op_location_8, micro_op_location_16))).first;
+		return installed_patterns.insert({key, {micro_op_location_8, micro_op_location_16}}).first;
 	}
 
 	public:

--- a/Reflection/Enum.hpp
+++ b/Reflection/Enum.hpp
@@ -72,8 +72,8 @@ class Enum {
 				result.emplace_back(std::string(start, size_t(d_ptr - start)));
 			}
 
-			members_by_type_.emplace(std::make_pair(std::type_index(typeid(Type)), result));
-			names_by_type_.emplace(std::make_pair(std::type_index(typeid(Type)), std::string(name)));
+			members_by_type_.emplace(std::type_index(typeid(Type)), result);
+			names_by_type_.emplace(std::type_index(typeid(Type)), std::string(name));
 		}
 
 		/*!

--- a/Reflection/Struct.hpp
+++ b/Reflection/Struct.hpp
@@ -294,7 +294,7 @@ template <typename Owner> class StructImpl: public Struct {
 			}
 			va_end(list);
 
-			permitted_enum_values_.emplace(std::make_pair(name, permitted_values));
+			permitted_enum_values_.emplace(name, permitted_values);
 		}
 
 		/*!

--- a/Storage/Disk/DiskImage/DiskImageImplementation.hpp
+++ b/Storage/Disk/DiskImage/DiskImageImplementation.hpp
@@ -25,7 +25,7 @@ template <typename T> void DiskImageHolder<T>::flush_tracks() {
 		using TrackMap = std::map<Track::Address, std::shared_ptr<Track>>;
 		std::shared_ptr<TrackMap> track_copies(new TrackMap);
 		for(const auto &address : unwritten_tracks_) {
-			track_copies->insert(std::make_pair(address, std::shared_ptr<Track>(cached_tracks_[address]->clone())));
+			track_copies->insert({address, std::shared_ptr<Track>(cached_tracks_[address]->clone())});
 		}
 		unwritten_tracks_.clear();
 

--- a/Storage/Disk/Encodings/AppleGCR/SegmentParser.cpp
+++ b/Storage/Disk/Encodings/AppleGCR/SegmentParser.cpp
@@ -317,14 +317,14 @@ std::map<std::size_t, Sector> Storage::Encodings::AppleGCR::sectors_from_segment
 					// Potentially this is a Macintosh sector.
 					auto macintosh_sector = decode_macintosh_sector(had_header ? &header : nullptr, sector);
 					if(macintosh_sector) {
-						result.insert(std::make_pair(sector_location, std::move(*macintosh_sector)));
+						result.insert({sector_location, std::move(*macintosh_sector)});
 						continue;
 					}
 
 					// Apple II then?
 					auto appleii_sector = decode_appleii_sector(had_header ? &header : nullptr, sector, is_five_and_three);
 					if(appleii_sector) {
-						result.insert(std::make_pair(sector_location, std::move(*appleii_sector)));
+						result.insert({sector_location, std::move(*appleii_sector)});
 					}
 				} else {
 					new_sector->data.push_back(value);

--- a/Storage/Disk/Encodings/MFM/SegmentParser.cpp
+++ b/Storage/Disk/Encodings/MFM/SegmentParser.cpp
@@ -72,7 +72,7 @@ std::map<std::size_t, Storage::Encodings::MFM::Sector> Storage::Encodings::MFM::
 							new_sector->samples[0].push_back(shifter.get_byte());
 							++position;
 							if(position == size + 4) {
-								result.insert(std::make_pair(start_location, std::move(*new_sector)));
+								result.insert({start_location, std::move(*new_sector)});
 								is_reading = false;
 								shifter.set_should_obey_syncs(true);
 								new_sector.reset();


### PR DESCRIPTION
... as this form is compatible with both C++17 and C++20 onwards.