### PR TITLE
Correct 65c02 BBS/BBR bus activity.

### DIFF
--- a/Processors/6502/Implementation/6502Implementation.hpp
+++ b/Processors/6502/Implementation/6502Implementation.hpp
@@ -725,7 +725,7 @@ void Processor<personality, T, uses_ready_line>::run_for(const Cycles cycles) {
 						} else {
 							scheduled_program_counter_ = operations_[size_t(OperationsSlot::DoNotBBRBBS)];
 						}
-					} break;
+					} continue;
 
 // MARK: - Transfers
 

--- a/Processors/6502/Implementation/6502Storage.hpp
+++ b/Processors/6502/Implementation/6502Storage.hpp
@@ -186,7 +186,9 @@ class ProcessorStorage {
 
 			CycleFetchFromHalfUpdatedPC,		// performs a throwaway read from (PC + (signed)operand).l combined with PC.h
 			CycleAddSignedOperandToPC,			// sets next_address to PC + (signed)operand. If the high byte of next_address differs from the PC, schedules a throwaway read from the half-updated PC. 65C02 specific: if the top two bytes are the same, proceeds directly to fetch-decode-execute, ignoring any pending interrupts.
-			OperationAddSignedOperandToPC16,	// adds (signed)operand into the PC
+			OperationAddSignedOperandToPC16,	// adds (signed)operand into the PC, leaving old PC in next_address_ and skipping a program step if there was no carry from low to high byte
+
+			CycleFetchFromNextAddress, 			// performs a throwaway fetch from next_address_
 
 			OperationSetFlagsFromOperand,			// sets all flags based on operand_
 			OperationSetOperandFromFlagsWithBRKSet,	// sets operand_ to the value of all flags, with the break flag set


### PR DESCRIPTION
These should now last 5 cycles if the branch is untaken, 6 if it is taken within a page, 7 if it is taken crossing a page — and omit the erroneous mid-instruction write.