### PR TITLE
Redraft CRTC closer to raw logic.

### DIFF
--- a/Components/6845/CRTC6845.hpp
+++ b/Components/6845/CRTC6845.hpp
@@ -262,6 +262,8 @@ template <class BusHandlerT, Personality personality, CursorType cursor_type> cl
 					}
 
 					if(character_reset_history_ & 4 && eom_latched_) {
+						// TODO: I don't believe the "add 1 for interlaced" test here is accurate; others represent the extra scanline as
+						// additional state, presumably because adjust total might be reprogrammed at any time.
 						const auto adjust_length = layout_.vertical.adjust + (layout_.interlace_mode_ != InterlaceMode::Off && odd_field_ ? 1 : 0);
 						is_in_adjustment_period_ |= adjustment_counter_ != adjust_length;
 						eof_latched_ |= adjustment_counter_ == adjust_length;
@@ -315,10 +317,10 @@ template <class BusHandlerT, Personality personality, CursorType cursor_type> cl
 					// Vertical display enable.
 					if(is_first_scanline_) {
 						line_is_visible_ = true;
+						odd_field_ = bus_state_.field_count & 1;
 					} else if(line_is_visible_ && row_counter_ == layout_.vertical.displayed) {
 						line_is_visible_ = false;
 						++bus_state_.field_count;
-						odd_field_ ^= true;
 					}
 
 

--- a/Components/6845/CRTC6845.hpp
+++ b/Components/6845/CRTC6845.hpp
@@ -207,8 +207,9 @@ template <class BusHandlerT, Personality personality, CursorType cursor_type> cl
 					const bool character_total_hit = character_counter_ == layout_.horizontal.total;
 					const uint8_t lines_per_row = layout_.interlace_mode_ == InterlaceMode::InterlaceSyncAndVideo ? layout_.vertical.end_row & ~1 : layout_.vertical.end_row;
 					const bool row_end_hit = bus_state_.row_address == lines_per_row && !is_in_adjustment_period_;
+					const bool was_eof = eof_latched_;
 					const bool new_frame =
-						character_total_hit && eof_latched_ &&
+						character_total_hit && was_eof &&
 						(
 							layout_.interlace_mode_ == InterlaceMode::Off ||
 							!(bus_state_.field_count&1) ||
@@ -249,7 +250,7 @@ template <class BusHandlerT, Personality personality, CursorType cursor_type> cl
 				//
 
 					if(character_total_hit) {
-						if(eof_latched_) {
+						if(was_eof) {
 							eof_latched_ = eom_latched_ = is_in_adjustment_period_ = false;
 							adjustment_counter_ = 0;
 						} else if(is_in_adjustment_period_) {
@@ -290,7 +291,7 @@ template <class BusHandlerT, Personality personality, CursorType cursor_type> cl
 
 					// Row address.
 					if(character_total_hit) {
-						if(eof_latched_ ) {
+						if(was_eof) {
 							bus_state_.row_address = 0;
 							eof_latched_ = eom_latched_ = false;
 						} else if(row_end_hit) {

--- a/Components/6845/CRTC6845.hpp
+++ b/Components/6845/CRTC6845.hpp
@@ -225,11 +225,6 @@ template <class BusHandlerT, Personality personality, CursorType cursor_type> cl
 				// Horizontal.
 				//
 
-					// Check for end of visible characters.
-					if(character_counter_ == layout_.horizontal.displayed) {
-						character_is_visible_ = false;
-					}
-
 					// Update horizontal sync.
 					if(bus_state_.hsync) {
 						++hsync_counter_;
@@ -238,8 +233,6 @@ template <class BusHandlerT, Personality personality, CursorType cursor_type> cl
 					if(character_counter_ == layout_.horizontal.start_sync) {
 						hsync_counter_ = 0;
 						bus_state_.hsync = true;
-
-						printf("Row:%d line:%d refresh:%04x; eom:%d eof:%d newf:%d\n", bus_state_.row_address, row_counter_, bus_state_.refresh_address, eom_latched_, eof_latched_, new_frame);
 					}
 
 					// Check for end-of-line.
@@ -248,6 +241,11 @@ template <class BusHandlerT, Personality personality, CursorType cursor_type> cl
 						character_is_visible_ = true;
 					} else {
 						character_counter_++;
+					}
+
+					// Check for end of visible characters.
+					if(character_counter_ == layout_.horizontal.displayed) {
+						character_is_visible_ = false;
 					}
 
 				//
@@ -298,7 +296,6 @@ template <class BusHandlerT, Personality personality, CursorType cursor_type> cl
 						}
 
 						if(vsync_counter_ == layout_.vertical.sync_lines) {
-							printf("\n\n===\n");
 							bus_state_.vsync = false;
 						}
 					}
@@ -308,17 +305,17 @@ template <class BusHandlerT, Personality personality, CursorType cursor_type> cl
 				//
 
 					if(new_frame) {
-						line_address_ = layout_.start_address;
-					} else if(character_counter_ == layout_.horizontal.displayed && row_end_hit) {
-						line_address_ = bus_state_.refresh_address;
-					}
-
-					if(new_frame) {
 						bus_state_.refresh_address = layout_.start_address;
 					} else if(character_total_hit) {
 						bus_state_.refresh_address = line_address_;
 					} else {
 						bus_state_.refresh_address = (bus_state_.refresh_address + 1) & RefreshMask;
+					}
+
+					if(new_frame) {
+						line_address_ = layout_.start_address;
+					} else if(character_counter_ == layout_.horizontal.displayed && row_end_hit) {
+						line_address_ = bus_state_.refresh_address;
 					}
 			}
 		}

--- a/Components/6845/CRTC6845.hpp
+++ b/Components/6845/CRTC6845.hpp
@@ -221,6 +221,8 @@ template <class BusHandlerT, Personality personality, CursorType cursor_type> cl
 						extra_scanline_
 					);
 
+					// TODO: eof_latched_
+
 				//
 				// Horizontal.
 				//
@@ -272,7 +274,7 @@ template <class BusHandlerT, Personality personality, CursorType cursor_type> cl
 					if(new_frame) {
 						next_row_address_ = 0;
 					} else if(line_total_hit && character_total_hit) {
-						next_row_address_ = bus_state_.row_address + 1;
+						next_row_address_ = (bus_state_.row_address + 1) & 31;
 					} else {
 						next_row_address_ = bus_state_.row_address;
 					}
@@ -308,9 +310,9 @@ template <class BusHandlerT, Personality personality, CursorType cursor_type> cl
 					if(new_frame) {
 						bus_state_.refresh_address = layout_.start_address;
 					} else if(character_total_hit) {
-						layout_.start_address = line_address_;
+						bus_state_.refresh_address = line_address_;
 					} else {
-						layout_.start_address = (layout_.start_address + 1) & RefreshMask;
+						bus_state_.refresh_address = (bus_state_.refresh_address + 1) & RefreshMask;
 					}
 			}
 		}

--- a/Components/6845/CRTC6845.hpp
+++ b/Components/6845/CRTC6845.hpp
@@ -271,14 +271,24 @@ template <class BusHandlerT, Personality personality, CursorType cursor_type> cl
 				//
 
 					if(new_frame) {
+						line_address_ = layout_.start_address;
+					} else if(character_counter_ == layout_.horizontal.displayed && line_total_hit) {
+						line_address_ = bus_state_.refresh_address;
+					}
 
+					if(new_frame) {
+						bus_state_.refresh_address = layout_.start_address;
+					} else if(character_total_hit) {
+						layout_.start_address = line_address_;
+					} else {
+						layout_.start_address = (layout_.start_address + 1) & RefreshMask;
 					}
 
 				// Do bus work.
-//				bus_state_.refresh_address = (bus_state_.refresh_address + 1) & RefreshMask;
-//
 //				bus_state_.cursor = is_cursor_line_ &&
 //					bus_state_.refresh_address == layout_.cursor_address;
+
+				bus_state_.display_enable = character_is_visible_;
 
 				perform_bus_cycle_phase1();
 				perform_bus_cycle_phase2();

--- a/Components/6845/CRTC6845.hpp
+++ b/Components/6845/CRTC6845.hpp
@@ -212,8 +212,7 @@ template <class BusHandlerT, Personality personality, CursorType cursor_type> cl
 						character_total_hit && was_eof &&
 						(
 							layout_.interlace_mode_ == InterlaceMode::Off ||
-							!(bus_state_.field_count&1) ||
-							extra_scanline_
+							!(bus_state_.field_count&1)
 						);
 
 				//
@@ -451,7 +450,6 @@ template <class BusHandlerT, Personality personality, CursorType cursor_type> cl
 
 		bool eof_latched_ = false;
 		bool eom_latched_ = false;
-		bool extra_scanline_ = false;
 		uint16_t next_row_address_ = 0;
 		bool odd_field_ = false;
 };

--- a/Components/6845/CRTC6845.hpp
+++ b/Components/6845/CRTC6845.hpp
@@ -262,8 +262,9 @@ template <class BusHandlerT, Personality personality, CursorType cursor_type> cl
 					}
 
 					if(character_reset_history_ & 4 && eom_latched_) {
-						is_in_adjustment_period_ |= adjustment_counter_ != (layout_.vertical.adjust + (odd_field_ ? 1 : 0));
-						eof_latched_ |= adjustment_counter_ == layout_.vertical.adjust;
+						const auto adjust_length = layout_.vertical.adjust + (layout_.interlace_mode_ != InterlaceMode::Off && odd_field_ ? 1 : 0);
+						is_in_adjustment_period_ |= adjustment_counter_ != adjust_length;
+						eof_latched_ |= adjustment_counter_ == adjust_length;
 					}
 
 				//

--- a/Components/6845/CRTC6845.hpp
+++ b/Components/6845/CRTC6845.hpp
@@ -203,7 +203,7 @@ template <class BusHandlerT, Personality personality, CursorType cursor_type> cl
 //				bus_state_.cursor = is_cursor_line_ &&
 //					bus_state_.refresh_address == layout_.cursor_address;
 
-				bus_state_.display_enable = character_is_visible_; // TODO: && row_visible_ or somesuch
+				bus_state_.display_enable = character_is_visible_ && line_is_visible_;
 
 				// TODO: considate the two below.
 				perform_bus_cycle_phase1();
@@ -279,8 +279,10 @@ template <class BusHandlerT, Personality personality, CursorType cursor_type> cl
 					row_counter_ = next_row_counter_;
 					if(new_frame) {
 						next_row_counter_ = 0;
+						is_first_scanline_ = true;
 					} else {
 						next_row_counter_ = row_end_hit && character_total_hit ? (next_row_counter_ + 1) : next_row_counter_;
+						is_first_scanline_ &= !row_end_hit;
 					}
 
 					// Sync.
@@ -298,6 +300,13 @@ template <class BusHandlerT, Personality personality, CursorType cursor_type> cl
 						if(vsync_counter_ == layout_.vertical.sync_lines) {
 							bus_state_.vsync = false;
 						}
+					}
+
+					if(is_first_scanline_) {
+						line_is_visible_ = true;
+					} else if(line_is_visible_ && row_counter_ == layout_.vertical.displayed) {
+						line_is_visible_ = false;
+//						++field_counter_;
 					}
 
 				//
@@ -482,7 +491,7 @@ template <class BusHandlerT, Personality personality, CursorType cursor_type> cl
 		uint8_t character_counter_ = 0;
 		uint8_t row_counter_ = 0, next_row_counter_ = 0;;
 
-		bool character_is_visible_ = false, line_is_visible_ = false;
+		bool character_is_visible_ = false, line_is_visible_ = false, is_first_scanline_ = false;
 
 		int hsync_counter_ = 0;
 		int vsync_counter_ = 0;

--- a/Components/6845/CRTC6845.hpp
+++ b/Components/6845/CRTC6845.hpp
@@ -104,13 +104,15 @@ template <class BusHandlerT, Personality personality, CursorType cursor_type> cl
 		void set_register(uint8_t value) {
 			static constexpr bool is_ega = is_egavga(personality);
 
-			auto load_low = [value](uint16_t &target) {
+			const auto load_low = [value](uint16_t &target) {
 				target = (target & 0xff00) | value;
 			};
-			auto load_high = [value](uint16_t &target) {
+			const auto load_high = [value](uint16_t &target) {
 				constexpr uint8_t mask = RefreshMask >> 8;
 				target = uint16_t((target & 0x00ff) | ((value & mask) << 8));
 			};
+
+//			printf("%d/[%d/%d]: %d -> %02x\n", character_counter_, row_counter_, bus_state_.row_address, selected_register_, value);
 
 			switch(selected_register_) {
 				case 0:	layout_.horizontal.total = value;		break;

--- a/Machines/AmstradCPC/AmstradCPC.cpp
+++ b/Machines/AmstradCPC/AmstradCPC.cpp
@@ -585,7 +585,7 @@ class CRTCBusHandler {
 };
 using CRTC = Motorola::CRTC::CRTC6845<
 	CRTCBusHandler,
-	Motorola::CRTC::Personality::HD6845S,
+	Motorola::CRTC::Personality::UM6845R,
 	Motorola::CRTC::CursorType::None>;
 
 /*!

--- a/Machines/AmstradCPC/AmstradCPC.cpp
+++ b/Machines/AmstradCPC/AmstradCPC.cpp
@@ -189,7 +189,7 @@ class CRTCBusHandler {
 			The CRTC entry function for the main part of each clock cycle; takes the current
 			bus state and determines what output to produce based on the current palette and mode.
 		*/
-		forceinline void perform_bus_cycle_phase1(const Motorola::CRTC::BusState &state) {
+		forceinline void perform_bus_cycle(const Motorola::CRTC::BusState &state) {
 			// The gate array waits 2us to react to the CRTC's vsync signal, and then
 			// caps output at 4us. Since the clock rate is 1Mhz, that's 2 and 4 cycles,
 			// respectively.
@@ -299,13 +299,7 @@ class CRTCBusHandler {
 					}
 				}
 			}
-		}
 
-		/*!
-			The CRTC entry function for phase 2 of each bus cycle, in which the next sync line state becomes
-			visible early. The CPC uses changes in sync to clock the interrupt timer.
-		*/
-		void perform_bus_cycle_phase2(const Motorola::CRTC::BusState &state) {
 			// Notify a leading hsync edge to the interrupt timer.
 			// Per Interrupts in the CPC: "to be confirmed: does gate array count positive or negative edge transitions of HSYNC signal?";
 			// if you take it as given that display mode is latched as a result of hsync then Pipe Mania seems to imply that the count

--- a/Machines/PCCompatible/CGA.hpp
+++ b/Machines/PCCompatible/CGA.hpp
@@ -173,7 +173,7 @@ class CGA {
 				return new_state;
 			}
 
-			void perform_bus_cycle_phase1(const Motorola::CRTC::BusState &state) {
+			void perform_bus_cycle(const Motorola::CRTC::BusState &state) {
 				// Determine new output state.
 				update_hsync(state.hsync);
 				const OutputState new_state = implied_state(state);
@@ -246,7 +246,6 @@ class CGA {
 					count = 0;
 				}
 			}
-			void perform_bus_cycle_phase2(const Motorola::CRTC::BusState &) {}
 
 			void flush_pixels() {
 				crt.output_data(count * active_clock_divider, size_t((count * active_pixels_per_tick) / 8));

--- a/Machines/PCCompatible/MDA.hpp
+++ b/Machines/PCCompatible/MDA.hpp
@@ -104,7 +104,7 @@ class MDA {
 				return control_;
 			}
 
-			void perform_bus_cycle_phase1(const Motorola::CRTC::BusState &state) {
+			void perform_bus_cycle(const Motorola::CRTC::BusState &state) {
 				// Determine new output state.
 				const OutputState new_state =
 					(state.hsync | state.vsync) ? OutputState::Sync :
@@ -207,7 +207,6 @@ class MDA {
 					pixels = pixel_pointer = nullptr;
 				}
 			}
-			void perform_bus_cycle_phase2(const Motorola::CRTC::BusState &) {}
 
 			Outputs::CRT::CRT crt;
 

--- a/Machines/Utility/Typer.cpp
+++ b/Machines/Utility/Typer.cpp
@@ -59,7 +59,7 @@ void Typer::append(const std::string &string) {
 	// If the final character in the string is not Typer::EndString
 	// then this machine doesn't need Begin and End, so don't worry about it.
 	ssize_t insertion_position = ssize_t(string_.size());
-	if(string_.back() == Typer::EndString) --insertion_position;
+	if(!string_.empty() && string_.back() == Typer::EndString) --insertion_position;
 
 	string_.reserve(string_.size() + string.size());
 	for(const char c : string) {


### PR DESCRIPTION
Similar to the recent Electron ULA changes, but casting a wider net on implementations, this attempts to reframe my CRTC implementation in hardware-style logic.

It still doesn't satisfy #1019; believed owing to the way the 6845 is integrated into the CPC emulation. More work to do here. But it's definitely an accuracy improvement in other areas.