### PR TITLE
Eliminate majority of M50740 macros

### DIFF
--- a/InstructionSets/M50740/Executor.cpp
+++ b/InstructionSets/M50740/Executor.cpp
@@ -553,6 +553,16 @@ template <Operation operation> void Executor::perform(uint8_t *operand [[maybe_u
 		carry_flag_ = (~temp16 >> 8)&1;
 	};
 
+	const auto index = [&](auto op) {
+		if(index_mode_) {
+			uint8_t t = read(x_);
+			op(t);
+			write(x_, t);
+		} else {
+			op(a_);
+		}
+	};
+
 	switch(operation) {
 		case Operation::LDA:
 			if(index_mode_) {
@@ -684,35 +694,24 @@ template <Operation operation> void Executor::perform(uint8_t *operand [[maybe_u
 		Operations affected by the index mode flag: ADC, AND, CMP, EOR, LDA, ORA, and SBC.
 	*/
 
-#define index(op)					\
-		if(index_mode_) {			\
-			uint8_t t = read(x_);	\
-			op(t);					\
-			write(x_, t);			\
-		} else {					\
-			op(a_);					\
-		}
-
 		case Operation::ORA: {
-			const auto op_ora = [&](uint8_t x) {
+			const auto op_ora = [&](uint8_t &x) {
 				set_nz(x |= *operand);
 			};
 			index(op_ora);
 		} break;
 		case Operation::AND: {
-			const auto op_and = [&](uint8_t x) {
+			const auto op_and = [&](uint8_t &x) {
 				set_nz(x &= *operand);
 			};
 			index(op_and);
 		} break;
 		case Operation::EOR: {
-			const auto op_eor = [&](uint8_t x) {
+			const auto op_eor = [&](uint8_t &x) {
 				set_nz(x ^= *operand);
 			};
 			index(op_eor);
 		} break;
-
-#undef index
 
 		case Operation::CMP:
 			if(index_mode_) {

--- a/InstructionSets/M50740/Executor.cpp
+++ b/InstructionSets/M50740/Executor.cpp
@@ -724,15 +724,14 @@ template <Operation operation> void Executor::perform(uint8_t *operand [[maybe_u
 					uint16_t partials = 0;
 					int result = carry_flag_;
 
-#define nibble(mask, limit, adjustment, carry)		\
-	result += (a & mask) + (*operand & mask);		\
-	partials += result & mask;						\
-	if(result >= limit) result = ((result + (adjustment)) & (carry - 1)) + carry;
+					const auto nibble = [&](uint16_t mask, uint16_t limit, uint16_t adjustment, uint16_t carry) {
+						result += (a & mask) + (*operand & mask);
+						partials += result & mask;
+						if(result >= limit) result = ((result + (adjustment)) & (carry - 1)) + carry;
+					};
 
 					nibble(0x000f, 0x000a, 0x0006, 0x00010);
 					nibble(0x00f0, 0x00a0, 0x0060, 0x00100);
-
-#undef nibble
 
 					overflow_result_ = uint8_t((partials ^ a) & (partials ^ *operand));
 					set_nz(uint8_t(result));
@@ -742,16 +741,15 @@ template <Operation operation> void Executor::perform(uint8_t *operand [[maybe_u
 					unsigned int borrow = carry_flag_ ^ 1;
 					const uint16_t decimal_result = uint16_t(a - *operand - borrow);
 
-#define nibble(mask, adjustment, carry)					\
-	result += (a & mask) - (*operand & mask) - borrow;	\
-	if(result > mask) result -= adjustment;				\
-	borrow = (result > mask) ? carry : 0;				\
-	result &= (carry - 1);
+					const auto nibble = [&](uint16_t mask, uint16_t adjustment, uint16_t carry) {
+						result += (a & mask) - (*operand & mask) - borrow;
+						if(result > mask) result -= adjustment;
+						borrow = (result > mask) ? carry : 0;
+						result &= (carry - 1);
+					};
 
 					nibble(0x000f, 0x0006, 0x00010);
 					nibble(0x00f0, 0x0060, 0x00100);
-
-#undef nibble
 
 					overflow_result_ = uint8_t((decimal_result ^ a) & (~decimal_result ^ *operand));
 					set_nz(uint8_t(result));


### PR DESCRIPTION
Apropos of very little, since Apple IIgs emulation is still faulty.