### PR TITLE
Resolve GCC/Ubuntu CI warnings.

### DIFF
--- a/Machines/Apple/Macintosh/Macintosh.cpp
+++ b/Machines/Apple/Macintosh/Macintosh.cpp
@@ -91,8 +91,8 @@ template <Analyser::Static::Macintosh::Target::Model model> class ConcreteMachin
 			mc68000_(*this),
 			iwm_(CLOCK_RATE),
 			video_(audio_, drive_speed_accumulator_),
-			via_(via_port_handler_),
 			via_port_handler_(*this, clock_, keyboard_, audio_, iwm_, mouse_),
+			via_(via_port_handler_),
 			scsi_bus_(CLOCK_RATE * 2),
 			scsi_(scsi_bus_, CLOCK_RATE * 2),
 			hard_drive_(scsi_bus_, 6 /* SCSI ID */),
@@ -760,8 +760,8 @@ template <Analyser::Static::Macintosh::Target::Model model> class ConcreteMachin
 		Apple::Clock::SerialClock clock_;
 		Keyboard keyboard_;
 
-		MOS::MOS6522::MOS6522<VIAPortHandler> via_;
 		VIAPortHandler via_port_handler_;
+		MOS::MOS6522::MOS6522<VIAPortHandler> via_;
 
 		Zilog::SCC::z8530 scc_;
 		SCSI::Bus scsi_bus_;

--- a/Machines/Commodore/Vic-20/Vic20.cpp
+++ b/Machines/Commodore/Vic-20/Vic20.cpp
@@ -233,8 +233,8 @@ class Vic6560BusHandler {
 		}
 
 		// It is assumed that these pointers have been filled in by the machine.
-		uint8_t *video_memory_map[16];	// Segments video memory into 1kb portions.
-		uint8_t *colour_memory;			// Colour memory must be contiguous.
+		uint8_t *video_memory_map[16]{};	// Segments video memory into 1kb portions.
+		uint8_t *colour_memory{};			// Colour memory must be contiguous.
 };
 
 /*!

--- a/Machines/MSX/MSX.cpp
+++ b/Machines/MSX/MSX.cpp
@@ -198,10 +198,10 @@ class ConcreteMachine:
 	public:
 		ConcreteMachine(const Target &target, const ROMMachine::ROMFetcher &rom_fetcher):
 			z80_(*this),
-			i8255_(i8255_port_handler_),
 			tape_player_(3579545 * 2),
 			i8255_port_handler_(*this, speaker_.audio_toggle, tape_player_),
 			ay_port_handler_(tape_player_),
+			i8255_(i8255_port_handler_),
 			memory_slots_{{*this}, {*this}, {*this}, {*this}},
 			clock_(ClockRate) {
 			set_clock_rate(ClockRate);
@@ -913,7 +913,6 @@ class ConcreteMachine:
 
 		CPU::Z80::Processor<ConcreteMachine, false, false> z80_;
 		JustInTimeActor<TI::TMS::TMS9918<vdp_model()>> vdp_;
-		Intel::i8255::i8255<i8255PortHandler> i8255_;
 
 		Storage::Tape::BinaryTapePlayer tape_player_;
 		bool tape_player_is_sleeping_ = false;
@@ -931,6 +930,8 @@ class ConcreteMachine:
 		i8255PortHandler i8255_port_handler_;
 		Speaker<has_opll> speaker_;
 		AYPortHandler ay_port_handler_;
+
+		Intel::i8255::i8255<i8255PortHandler> i8255_;
 
 		/// The current primary and secondary slot selections; the former retains whatever was written
 		/// last to the 8255 PPI via port A8 and the latter — if enabled — captures 0xffff on a per-slot basis.

--- a/Machines/Oric/Oric.cpp
+++ b/Machines/Oric/Oric.cpp
@@ -285,7 +285,7 @@ template <Analyser::Static::Oric::Target::DiskInterface disk_interface, CPU::MOS
 	public:
 		ConcreteMachine(const Analyser::Static::Oric::Target &target, const ROMMachine::ROMFetcher &rom_fetcher) :
 				m6502_(*this),
-				video_(ram_),
+				video_(ram_.data()),
 				ay8910_(GI::AY38910::Personality::AY38910, audio_queue_),
 				speaker_(ay8910_),
 				via_port_handler_(audio_queue_, ay8910_, speaker_, tape_player_, keyboard_),
@@ -302,9 +302,9 @@ template <Analyser::Static::Oric::Target::DiskInterface disk_interface, CPU::MOS
 			// sort of assumes it, but also the BD-500 never explicitly sets PAL mode
 			// so I can't have any switch-to-NTSC bytes in the display area. Hence:
 			// disallow all atributes.
-			Memory::Fuzz(ram_, sizeof(ram_));
-			for(size_t c = 0; c < sizeof(ram_); ++c) {
-				ram_[c] |= 0x40;
+			Memory::Fuzz(ram_);
+			for(auto &c: ram_) {
+				c |= 0x40;
 			}
 
 			::ROM::Request request = ::ROM::Request(::ROM::Name::OricColourROM, true);

--- a/Machines/Oric/Oric.cpp
+++ b/Machines/Oric/Oric.cpp
@@ -36,6 +36,7 @@
 
 #include "../../ClockReceiver/JustInTime.hpp"
 
+#include <array>
 #include <cstdint>
 #include <memory>
 #include <vector>
@@ -715,7 +716,7 @@ template <Analyser::Static::Oric::Target::DiskInterface disk_interface, CPU::MOS
 
 		// RAM and ROM
 		std::vector<uint8_t> rom_, disk_rom_;
-		uint8_t ram_[65536];
+		std::array<uint8_t, 65536> ram_{};
 
 		// ROM bookkeeping
 		uint16_t tape_get_byte_address_ = 0, tape_speed_address_ = 0;

--- a/OSBindings/SDL/main.cpp
+++ b/OSBindings/SDL/main.cpp
@@ -446,7 +446,7 @@ std::string final_path_component(const std::string &path) {
 std::string system_get(const char *command) {
 	struct pcloser {
 		void operator()(FILE *file) {
-			pclose(dir);
+			pclose(file);
 		}
 	};
 	std::unique_ptr<FILE, pcloser> pipe(popen(command, "r"));

--- a/OSBindings/SDL/main.cpp
+++ b/OSBindings/SDL/main.cpp
@@ -444,7 +444,12 @@ std::string final_path_component(const std::string &path) {
 	Executes @c command and returns its STDOUT.
 */
 std::string system_get(const char *command) {
-	std::unique_ptr<FILE, decltype((pclose))> pipe(popen(command, "r"), pclose);
+	struct pcloser {
+		void operator()(FILE *file) {
+			pclose(dir);
+		}
+	};
+	std::unique_ptr<FILE, pcloser> pipe(popen(command, "r"));
 	if(!pipe) return "";
 
 	std::string result;


### PR DESCRIPTION
Primarily exposing the identities of objects prior to their initialisation, but also to tighten the type used for a `popen`/`FILE *` `unique_ptr`.