### PR TITLE
Avoid taking an out-of-range pointer.

### DIFF
--- a/OSBindings/Mac/Clock SignalTests/CPCShakerTests.mm
+++ b/OSBindings/Mac/Clock SignalTests/CPCShakerTests.mm
@@ -76,7 +76,7 @@ struct ScanTarget: public Outputs::Display::ScanTarget {
 				x_ = 0;
 			} break;
 			case Event::EndVerticalRetrace:
-				std::fill(&raw_image_[line_ * ImageWidth], &raw_image_[ImageHeight * ImageWidth], 0);
+				std::fill(raw_image_.begin() + (line_ * ImageWidth), raw_image_.end(), 0);
 				line_ = 0;
 				x_ = 0;
 			break;


### PR DESCRIPTION
Even though it was safe, being used as part of a half-open range, it still trips up the sanitiser.