### PR TITLE
Eliminate macros from 6502 bus operation actions.

### DIFF
--- a/Machines/Acorn/Electron/Electron.cpp
+++ b/Machines/Acorn/Electron/Electron.cpp
@@ -250,7 +250,7 @@ public:
 		}
 
 		if(address < 0x8000) {
-			if(isReadOperation(operation)) {
+			if(is_read(operation)) {
 				*value = ram_[address];
 			} else {
 				ram_[address] = *value;
@@ -258,7 +258,7 @@ public:
 		} else {
 			switch(address & 0xff0f) {
 				case 0xfe00:
-					if(isReadOperation(operation)) {
+					if(is_read(operation)) {
 						*value = interrupt_status_;
 						interrupt_status_ &= ~PowerOnReset;
 					} else {
@@ -267,7 +267,7 @@ public:
 					}
 				break;
 				case 0xfe07:
-					if(!isReadOperation(operation)) {
+					if(!is_read(operation)) {
 						// update speaker mode
 						bool new_speaker_is_enabled = (*value & 6) == 2;
 						if(new_speaker_is_enabled != speaker_is_enabled_) {
@@ -291,12 +291,12 @@ public:
 				case 0xfe02: case 0xfe03:
 				case 0xfe08: case 0xfe09: case 0xfe0a: case 0xfe0b:
 				case 0xfe0c: case 0xfe0d: case 0xfe0e: case 0xfe0f:
-					if(!isReadOperation(operation)) {
+					if(!is_read(operation)) {
 						video_.write(address, *value);
 					}
 				break;
 				case 0xfe04:
-					if(isReadOperation(operation)) {
+					if(is_read(operation)) {
 						*value = tape_.get_data_register();
 						tape_.clear_interrupts(Interrupt::ReceiveDataFull);
 					} else {
@@ -305,7 +305,7 @@ public:
 					}
 				break;
 				case 0xfe05:
-					if(!isReadOperation(operation)) {
+					if(!is_read(operation)) {
 						const uint8_t interruptDisable = (*value)&0xf0;
 						if( interruptDisable ) {
 							if( interruptDisable&0x10 ) interrupt_status_ &= ~Interrupt::DisplayEnd;
@@ -332,7 +332,7 @@ public:
 					}
 				break;
 				case 0xfe06:
-					if(!isReadOperation(operation)) {
+					if(!is_read(operation)) {
 						update_audio();
 						sound_generator_.set_divider(*value);
 						tape_.set_counter(*value);
@@ -345,7 +345,7 @@ public:
 							is_holding_shift_ = false;
 							set_key_state(KeyShift, false);
 						}
-						if(isReadOperation(operation))
+						if(is_read(operation))
 							*value = plus3_->read(address);
 						else
 							plus3_->write(address, *value);
@@ -353,14 +353,14 @@ public:
 				break;
 				case 0xfc00:
 					if(plus3_ && (address&0x00f0) == 0x00c0) {
-						if(!isReadOperation(operation)) {
+						if(!is_read(operation)) {
 							plus3_->set_control_register(*value);
 						} else *value = 1;
 					}
 
 					if(has_scsi_bus && (address&0x00f0) == 0x0040) {
 						scsi_acknowledge_ = true;
-						if(!isReadOperation(operation)) {
+						if(!is_read(operation)) {
 							scsi_data_ = *value;
 							push_scsi_output();
 						} else {
@@ -377,7 +377,7 @@ public:
 					}
 				break;
 				case 0xfc01:
-					if(has_scsi_bus && (address&0x00f0) == 0x0040 && isReadOperation(operation)) {
+					if(has_scsi_bus && (address&0x00f0) == 0x0040 && is_read(operation)) {
 						// Status byte is:
 						//
 						//	b7:	SCSI C/D
@@ -427,7 +427,7 @@ public:
 
 				default:
 					if(address >= 0xc000) {
-						if(isReadOperation(operation)) {
+						if(is_read(operation)) {
 							if(
 								use_fast_tape_hack_ &&
 								(operation == CPU::MOS6502::BusOperation::ReadOpcode) &&
@@ -479,7 +479,7 @@ public:
 							}
 						}
 					} else {
-						if(isReadOperation(operation)) {
+						if(is_read(operation)) {
 							*value = roms_[active_rom_][address & 16383];
 							if(keyboard_is_active_) {
 								*value &= 0xf0;

--- a/Machines/Apple/AppleIIgs/AppleIIgs.cpp
+++ b/Machines/Apple/AppleIIgs/AppleIIgs.cpp
@@ -284,7 +284,7 @@ public:
 			*value = rom_[rom_.size() - 65536 + address];
 		} else if(region.flags & MemoryMap::Region::IsIO) {
 			// Ensure classic auxiliary and language card accesses have effect.
-			const bool is_read = isReadOperation(operation);
+			const bool is_read = CPU::MOS6502Esque::is_read(operation);
 			memory_.access(uint16_t(address), is_read);
 
 			const auto address_suffix = address & 0xffff;
@@ -818,7 +818,7 @@ public:
 			assert(operation != CPU::WDC65816::BusOperation::ReadOpcode || region.read);
 			is_1Mhz = region.flags & MemoryMap::Region::Is1Mhz;
 
-			if(isReadOperation(operation)) {
+			if(is_read(operation)) {
 				*value = memory_.read(region, address);
 			} else {
 				// Shadowed writes also occur "at 1Mhz".

--- a/Machines/Atari/2600/Cartridges/ActivisionStack.hpp
+++ b/Machines/Atari/2600/Cartridges/ActivisionStack.hpp
@@ -35,7 +35,7 @@ public:
 			}
 		}
 
-		if(isReadOperation(operation)) {
+		if(is_read(operation)) {
 			*value = rom_ptr_[address & 4095];
 		}
 

--- a/Machines/Atari/2600/Cartridges/Atari16k.hpp
+++ b/Machines/Atari/2600/Cartridges/Atari16k.hpp
@@ -28,7 +28,7 @@ public:
 
 		if(address >= 0x1ff6 && address <= 0x1ff9) rom_ptr_ = rom_base_ + (address - 0x1ff6) * 4096;
 
-		if(isReadOperation(operation)) {
+		if(is_read(operation)) {
 			*value = rom_ptr_[address & 4095];
 		}
 	}
@@ -53,12 +53,12 @@ public:
 
 		if(address >= 0x1ff6 && address <= 0x1ff9) rom_ptr_ = rom_base_ + (address - 0x1ff6) * 4096;
 
-		if(isReadOperation(operation)) {
+		if(is_read(operation)) {
 			*value = rom_ptr_[address & 4095];
 		}
 
 		if(address < 0x1080) ram_[address & 0x7f] = *value;
-		else if(address < 0x1100 && isReadOperation(operation)) *value = ram_[address & 0x7f];
+		else if(address < 0x1100 && is_read(operation)) *value = ram_[address & 0x7f];
 	}
 
 private:

--- a/Machines/Atari/2600/Cartridges/Atari32k.hpp
+++ b/Machines/Atari/2600/Cartridges/Atari32k.hpp
@@ -27,7 +27,7 @@ public:
 
 		if(address >= 0x1ff4 && address <= 0x1ffb) rom_ptr_ = rom_base_ + (address - 0x1ff4) * 4096;
 
-		if(isReadOperation(operation)) {
+		if(is_read(operation)) {
 			*value = rom_ptr_[address & 4095];
 		}
 	}
@@ -51,12 +51,12 @@ public:
 
 		if(address >= 0x1ff4 && address <= 0x1ffb) rom_ptr_ = rom_base_ + (address - 0x1ff4) * 4096;
 
-		if(isReadOperation(operation)) {
+		if(is_read(operation)) {
 			*value = rom_ptr_[address & 4095];
 		}
 
 		if(address < 0x1080) ram_[address & 0x7f] = *value;
-		else if(address < 0x1100 && isReadOperation(operation)) *value = ram_[address & 0x7f];
+		else if(address < 0x1100 && is_read(operation)) *value = ram_[address & 0x7f];
 	}
 
 private:

--- a/Machines/Atari/2600/Cartridges/Atari8k.hpp
+++ b/Machines/Atari/2600/Cartridges/Atari8k.hpp
@@ -28,7 +28,7 @@ public:
 		if(address == 0x1ff8) rom_ptr_ = rom_base_;
 		else if(address == 0x1ff9) rom_ptr_ = rom_base_ + 4096;
 
-		if(isReadOperation(operation)) {
+		if(is_read(operation)) {
 			*value = rom_ptr_[address & 4095];
 		}
 	}
@@ -53,12 +53,12 @@ public:
 		if(address == 0x1ff8) rom_ptr_ = rom_base_;
 		if(address == 0x1ff9) rom_ptr_ = rom_base_ + 4096;
 
-		if(isReadOperation(operation)) {
+		if(is_read(operation)) {
 			*value = rom_ptr_[address & 4095];
 		}
 
 		if(address < 0x1080) ram_[address & 0x7f] = *value;
-		else if(address < 0x1100 && isReadOperation(operation)) *value = ram_[address & 0x7f];
+		else if(address < 0x1100 && is_read(operation)) *value = ram_[address & 0x7f];
 	}
 
 private:

--- a/Machines/Atari/2600/Cartridges/CBSRAMPlus.hpp
+++ b/Machines/Atari/2600/Cartridges/CBSRAMPlus.hpp
@@ -27,12 +27,12 @@ public:
 
 		if(address >= 0x1ff8 && address <= 0x1ffa) rom_ptr_ = rom_base_ + (address - 0x1ff8) * 4096;
 
-		if(isReadOperation(operation)) {
+		if(is_read(operation)) {
 			*value = rom_ptr_[address & 4095];
 		}
 
 		if(address < 0x1100) ram_[address & 0xff] = *value;
-		else if(address < 0x1200 && isReadOperation(operation)) *value = ram_[address & 0xff];
+		else if(address < 0x1200 && is_read(operation)) *value = ram_[address & 0xff];
 	}
 
 private:

--- a/Machines/Atari/2600/Cartridges/Cartridge.hpp
+++ b/Machines/Atari/2600/Cartridges/Cartridge.hpp
@@ -78,13 +78,13 @@ public:
 		cycles_since_6532_update_ += Cycles(cycles_run_for / 3);
 		bus_extender_.advance_cycles(cycles_run_for / 3);
 
-		if(isAccessOperation(operation)) {
+		if(is_access(operation)) {
 			// give the cartridge a chance to respond to the bus access
 			bus_extender_.perform_bus_operation(operation, address, value);
 
 			// check for a RIOT RAM access
 			if((address&0x1280) == 0x80) {
-				if(isReadOperation(operation)) {
+				if(is_read(operation)) {
 					returnValue &= mos6532_.get_ram(address);
 				} else {
 					mos6532_.set_ram(address, *value);
@@ -93,7 +93,7 @@ public:
 
 			// check for a TIA access
 			if(!(address&0x1080)) {
-				if(isReadOperation(operation)) {
+				if(is_read(operation)) {
 					const uint16_t decodedAddress = address & 0xf;
 					switch(decodedAddress) {
 						case 0x00:		// missile 0 / player collisions
@@ -183,14 +183,14 @@ public:
 			// check for a PIA access
 			if((address&0x1280) == 0x280) {
 				update_6532();
-				if(isReadOperation(operation)) {
+				if(is_read(operation)) {
 					returnValue &= mos6532_.read(address);
 				} else {
 					mos6532_.write(address, *value);
 				}
 			}
 
-			if(isReadOperation(operation)) {
+			if(is_read(operation)) {
 				*value &= returnValue;
 			}
 		}

--- a/Machines/Atari/2600/Cartridges/CommaVid.hpp
+++ b/Machines/Atari/2600/Cartridges/CommaVid.hpp
@@ -25,7 +25,7 @@ public:
 		address &= 0x1fff;
 
 		if(address < 0x1400) {
-			if(isReadOperation(operation)) *value = ram_[address & 1023];
+			if(is_read(operation)) *value = ram_[address & 1023];
 			return;
 		}
 
@@ -34,7 +34,7 @@ public:
 			return;
 		}
 
-		if(isReadOperation(operation)) *value = rom_base_[address & 2047];
+		if(is_read(operation)) *value = rom_base_[address & 2047];
 	}
 
 private:

--- a/Machines/Atari/2600/Cartridges/MNetwork.hpp
+++ b/Machines/Atari/2600/Cartridges/MNetwork.hpp
@@ -41,18 +41,18 @@ public:
 			if(address < 0x1900) {
 				high_ram_ptr_[address & 255] = *value;
 			} else if(address < 0x1a00) {
-				if(isReadOperation(operation)) *value = high_ram_ptr_[address & 255];
+				if(is_read(operation)) *value = high_ram_ptr_[address & 255];
 			} else {
-				if(isReadOperation(operation)) *value = rom_ptr_[1][address & 2047];
+				if(is_read(operation)) *value = rom_ptr_[1][address & 2047];
 			}
 		} else {
 			if(rom_ptr_[0]) {
-				if(isReadOperation(operation)) *value = rom_ptr_[0][address & 2047];
+				if(is_read(operation)) *value = rom_ptr_[0][address & 2047];
 			} else {
 				if(address < 0x1400) {
 					low_ram_[address & 1023] = *value;
 				} else {
-					if(isReadOperation(operation)) *value = low_ram_[address & 1023];
+					if(is_read(operation)) *value = low_ram_[address & 1023];
 				}
 			}
 		}

--- a/Machines/Atari/2600/Cartridges/MegaBoy.hpp
+++ b/Machines/Atari/2600/Cartridges/MegaBoy.hpp
@@ -30,7 +30,7 @@ public:
 			rom_ptr_ = rom_base_ + current_page_ * 4096;
 		}
 
-		if(isReadOperation(operation)) {
+		if(is_read(operation)) {
 			*value = rom_ptr_[address & 4095];
 		}
 	}

--- a/Machines/Atari/2600/Cartridges/ParkerBros.hpp
+++ b/Machines/Atari/2600/Cartridges/ParkerBros.hpp
@@ -36,7 +36,7 @@ public:
 			rom_ptr_[slot] = rom_base_ + ((address & 7) * 1024);
 		}
 
-		if(isReadOperation(operation)) {
+		if(is_read(operation)) {
 			*value = rom_ptr_[(address >> 10)&3][address & 1023];
 		}
 	}

--- a/Machines/Atari/2600/Cartridges/Pitfall2.hpp
+++ b/Machines/Atari/2600/Cartridges/Pitfall2.hpp
@@ -34,7 +34,7 @@ public:
 
 			// The random number generator
 			case 0x1000: case 0x1001: case 0x1002: case 0x1003: case 0x1004:
-				if(isReadOperation(operation)) {
+				if(is_read(operation)) {
 					*value = random_number_generator_;
 				}
 				random_number_generator_ = uint8_t(
@@ -85,7 +85,7 @@ public:
 // MARK: - Business as usual
 
 			default:
-				if(isReadOperation(operation)) {
+				if(is_read(operation)) {
 					*value = rom_ptr_[address & 4095];
 				}
 			break;

--- a/Machines/Atari/2600/Cartridges/Tigervision.hpp
+++ b/Machines/Atari/2600/Cartridges/Tigervision.hpp
@@ -28,7 +28,7 @@ public:
 			int offset = ((*value) * 2048) & (rom_size_ - 1);
 			rom_ptr_[0] = rom_base_ + offset;
 			return;
-		} else if((address&0x1000) && isReadOperation(operation)) {
+		} else if((address&0x1000) && is_read(operation)) {
 			*value = rom_ptr_[(address >> 11)&1][address & 2047];
 		}
 	}

--- a/Machines/Atari/2600/Cartridges/Unpaged.hpp
+++ b/Machines/Atari/2600/Cartridges/Unpaged.hpp
@@ -21,7 +21,7 @@ public:
 		const uint16_t address,
 		uint8_t *const value
 	) {
-		if(isReadOperation(operation) && (address & 0x1000)) {
+		if(is_read(operation) && (address & 0x1000)) {
 			*value = rom_base_[address & (rom_size_ - 1)];
 		}
 	}

--- a/Machines/Commodore/1540/Implementation/C1540.cpp
+++ b/Machines/Commodore/1540/Implementation/C1540.cpp
@@ -76,21 +76,21 @@ Cycles MachineBase::perform_bus_operation(CPU::MOS6502::BusOperation operation, 
 			0xc000-0xffff	ROM
 	*/
 	if(address < 0x800) {
-		if(isReadOperation(operation))
+		if(is_read(operation))
 			*value = ram_[address];
 		else
 			ram_[address] = *value;
 	} else if(address >= 0xc000) {
-		if(isReadOperation(operation)) {
+		if(is_read(operation)) {
 			*value = rom_[address & 0x3fff];
 		}
 	} else if(address >= 0x1800 && address <= 0x180f) {
-		if(isReadOperation(operation))
+		if(is_read(operation))
 			*value = serial_port_VIA_.read(address);
 		else
 			serial_port_VIA_.write(address, *value);
 	} else if(address >= 0x1c00 && address <= 0x1c0f) {
-		if(isReadOperation(operation))
+		if(is_read(operation))
 			*value = drive_VIA_.read(address);
 		else
 			drive_VIA_.write(address, *value);

--- a/Machines/Commodore/Plus4/Plus4.cpp
+++ b/Machines/Commodore/Plus4/Plus4.cpp
@@ -231,7 +231,7 @@ public:
 			//	b1 = serial clock out and cassette write;
 			//	b0 = serial data out.
 
-			if(isReadOperation(operation)) {
+			if(is_read(operation)) {
 				if(!address) {
 					*value = io_direction_;
 				} else {
@@ -257,14 +257,14 @@ public:
 				serial_port_.set_output(Serial::Line::Attention, Serial::LineLevel(~output & 0x04));
 			}
 		} else if(address < 0xfd00 || address >= 0xff40) {
-			if(isReadOperation(operation)) {
+			if(is_read(operation)) {
 				*value = map_.read(address);
 			} else {
 				map_.write(address) = *value;
 			}
 		} else if(address < 0xff00) {
 			// Miscellaneous hardware. All TODO.
-			if(isReadOperation(operation)) {
+			if(is_read(operation)) {
 //				printf("TODO: read @ %04x\n", address);
 				if((address & 0xfff0) == 0xfd10) {
 					// 6529 parallel port, about which I know only what I've found in kernel ROM disassemblies.
@@ -295,7 +295,7 @@ public:
 //				printf("TODO: write of %02x @ %04x\n", *value, address);
 			}
 		} else {
-			if(isReadOperation(operation)) {
+			if(is_read(operation)) {
 				switch(address) {
 					case 0xff00:	*value = timers_.read<0>();		break;
 					case 0xff01:	*value = timers_.read<1>();		break;

--- a/Machines/Commodore/Vic-20/Vic20.cpp
+++ b/Machines/Commodore/Vic-20/Vic20.cpp
@@ -504,7 +504,7 @@ public:
 		cycles_since_mos6560_update_++;
 
 		// run the phase-2 part of the cycle, which is whatever the 6502 said it should be
-		if(isReadOperation(operation)) {
+		if(is_read(operation)) {
 			uint8_t result = processor_read_memory_map_[address >> 10] ? processor_read_memory_map_[address >> 10][address & 0x3ff] : 0xff;
 			if((address&0xfc00) == 0x9000) {
 				if(!(address&0x100)) {

--- a/Machines/Oric/Oric.cpp
+++ b/Machines/Oric/Oric.cpp
@@ -460,7 +460,7 @@ template <Analyser::Static::Oric::Target::DiskInterface disk_interface, CPU::MOS
 		// to satisfy CPU::MOS6502::BusHandler
 		forceinline Cycles perform_bus_operation(CPU::MOS6502::BusOperation operation, uint16_t address, uint8_t *value) {
 			if(address > ram_top_) {
-				if(!isWriteOperation(operation)) *value = paged_rom_[address - ram_top_ - 1];
+				if(!is_write(operation)) *value = paged_rom_[address - ram_top_ - 1];
 
 				// 024D = 0 => fast; otherwise slow
 				// E6C9 = read byte: return byte in A
@@ -479,39 +479,39 @@ template <Analyser::Static::Oric::Target::DiskInterface disk_interface, CPU::MOS
 			} else {
 				if((address & 0xff00) == 0x0300) {
 					if(address < 0x0310 || (disk_interface == DiskInterface::None)) {
-						if(!isWriteOperation(operation)) *value = via_.read(address);
+						if(!is_write(operation)) *value = via_.read(address);
 						else via_.write(address, *value);
 					} else {
 						switch(disk_interface) {
 							default: break;
 							case DiskInterface::BD500:
-								if(!isWriteOperation(operation)) *value = bd500_.read(address);
+								if(!is_write(operation)) *value = bd500_.read(address);
 								else bd500_.write(address, *value);
 							break;
 							case DiskInterface::Jasmin:
 								if(address >= 0x3f4) {
-									if(!isWriteOperation(operation)) *value = jasmin_.read(address);
+									if(!is_write(operation)) *value = jasmin_.read(address);
 									else jasmin_.write(address, *value);
 								}
 							break;
 							case DiskInterface::Microdisc:
 								switch(address) {
 									case 0x0310: case 0x0311: case 0x0312: case 0x0313:
-										if(!isWriteOperation(operation)) *value = microdisc_.read(address);
+										if(!is_write(operation)) *value = microdisc_.read(address);
 										else microdisc_.write(address, *value);
 									break;
 									case 0x314: case 0x315: case 0x316: case 0x317:
-										if(!isWriteOperation(operation)) *value = microdisc_.get_interrupt_request_register();
+										if(!is_write(operation)) *value = microdisc_.get_interrupt_request_register();
 										else microdisc_.set_control_register(*value);
 									break;
 									case 0x318: case 0x319: case 0x31a: case 0x31b:
-										if(!isWriteOperation(operation)) *value = microdisc_.get_data_request_register();
+										if(!is_write(operation)) *value = microdisc_.get_data_request_register();
 									break;
 								}
 							break;
 							case DiskInterface::Pravetz:
 								if(address >= 0x0320) {
-									if(!isWriteOperation(operation)) *value = pravetz_rom_[pravetz_rom_base_pointer_ + (address & 0xff)];
+									if(!is_write(operation)) *value = pravetz_rom_[pravetz_rom_base_pointer_ + (address & 0xff)];
 									else {
 										switch(address) {
 											case 0x380:	case 0x381:	case 0x382:	case 0x383:
@@ -522,13 +522,13 @@ template <Analyser::Static::Oric::Target::DiskInterface disk_interface, CPU::MOS
 									}
 								} else {
 									const int disk_value = diskii_->read_address(address);
-									if(!isWriteOperation(operation) && disk_value != Apple::DiskII::DidNotLoad) *value = uint8_t(disk_value);
+									if(!is_write(operation) && disk_value != Apple::DiskII::DidNotLoad) *value = uint8_t(disk_value);
 								}
 							break;
 						}
 					}
 				} else {
-					if(!isWriteOperation(operation))
+					if(!is_write(operation))
 						*value = ram_[address];
 					else {
 						if(address >= 0x9800 && address <= 0xc000) video_.flush();

--- a/Processors/6502/AllRAM/6502AllRAM.cpp
+++ b/Processors/6502/AllRAM/6502AllRAM.cpp
@@ -47,7 +47,7 @@ public:
 			cia2_.run_for(HalfCycles(2));
 		}
 
-		if(isAccessOperation(operation)) {
+		if(is_access(operation)) {
 			if(operation == BusOperation::ReadOpcode) {
 				if constexpr (LogProgramCounter) {
 					printf("[%04x] %02x a:%04x x:%04x y:%04x p:%02x s:%02x\n", address, memory_[address],

--- a/Processors/6502/Implementation/6502Implementation.hpp
+++ b/Processors/6502/Implementation/6502Implementation.hpp
@@ -780,7 +780,7 @@ void Processor<personality, T, uses_ready_line>::run_for(const Cycles cycles) {
 				if(has_stpwai(personality) && (stop_is_active_ || wait_is_active_)) {
 					break;
 				}
-				if(uses_ready_line && ready_line_is_enabled_ && (is_65c02(personality) || isReadOperation(next_bus_operation_))) {
+				if(uses_ready_line && ready_line_is_enabled_ && (is_65c02(personality) || is_read(next_bus_operation_))) {
 					ready_is_active_ = true;
 					break;
 				}

--- a/Processors/6502Esque/6502Esque.hpp
+++ b/Processors/6502Esque/6502Esque.hpp
@@ -64,7 +64,7 @@ enum Flag: uint8_t {
 	Bus handlers will be given the task of performing bus operations, allowing them to provide whatever interface they like
 	between a 6502-esque chip and the rest of the system. @c BusOperation lists the types of bus operation that may be requested.
 */
-enum BusOperation {
+enum class BusOperation {
 	/// 6502: indicates that a read was signalled.
 	/// 65816: indicates that a read was signalled with VDA.
 	Read,
@@ -99,17 +99,17 @@ enum BusOperation {
 /*!
 	For a machine watching only the RWB line, evaluates to @c true if the operation should be treated as a read; @c false otherwise.
 */
-#define isReadOperation(v)		(v <= CPU::MOS6502Esque::InternalOperationRead)
+#define isReadOperation(v)		(v <= CPU::MOS6502Esque::BusOperation::InternalOperationRead)
 
 /*!
 	For a machine watching only the RWB line, evaluates to @c true if the operation is any sort of write; @c false otherwise.
 */
-#define isWriteOperation(v)		(v >= CPU::MOS6502Esque::Write)
+#define isWriteOperation(v)		(v >= CPU::MOS6502Esque::BusOperation::Write)
 
 /*!
 	Evaluates to @c true if the operation actually expects a response; @c false otherwise.
 */
-#define isAccessOperation(v)	((v <= CPU::MOS6502Esque::ReadVector) || (v == CPU::MOS6502Esque::Write))
+#define isAccessOperation(v)	((v <= CPU::MOS6502Esque::BusOperation::ReadVector) || (v == CPU::MOS6502Esque::BusOperation::Write))
 
 /*!
 	A class providing empty implementations of the methods a 6502 uses to access the bus. To wire the 6502 to a bus,

--- a/Processors/6502Esque/6502Esque.hpp
+++ b/Processors/6502Esque/6502Esque.hpp
@@ -99,17 +99,17 @@ enum class BusOperation {
 /*!
 	For a machine watching only the RWB line, evaluates to @c true if the operation should be treated as a read; @c false otherwise.
 */
-#define isReadOperation(v)		(v <= CPU::MOS6502Esque::BusOperation::InternalOperationRead)
+constexpr bool isReadOperation(BusOperation op) { return op <= BusOperation::InternalOperationRead; }
 
 /*!
 	For a machine watching only the RWB line, evaluates to @c true if the operation is any sort of write; @c false otherwise.
 */
-#define isWriteOperation(v)		(v >= CPU::MOS6502Esque::BusOperation::Write)
+constexpr bool isWriteOperation(BusOperation op) { return op >= BusOperation::Write; }
 
 /*!
 	Evaluates to @c true if the operation actually expects a response; @c false otherwise.
 */
-#define isAccessOperation(v)	((v <= CPU::MOS6502Esque::BusOperation::ReadVector) || (v == CPU::MOS6502Esque::BusOperation::Write))
+constexpr bool isAccessOperation(BusOperation op) { return op <= BusOperation::ReadVector || op == BusOperation::Write; }
 
 /*!
 	A class providing empty implementations of the methods a 6502 uses to access the bus. To wire the 6502 to a bus,
@@ -136,7 +136,11 @@ template <typename addr_t> class BusHandler {
 			during some periods; one way to simulate that is to have the bus handler return a number other than
 			Cycles(1) to describe lengthened bus cycles.
 		*/
-		Cycles perform_bus_operation([[maybe_unused]] BusOperation operation, [[maybe_unused]] addr_t address, [[maybe_unused]] uint8_t *value) {
+		Cycles perform_bus_operation(
+			[[maybe_unused]] BusOperation operation,
+			[[maybe_unused]] addr_t address,
+			[[maybe_unused]] uint8_t *value
+		) {
 			return Cycles(1);
 		}
 };

--- a/Processors/6502Esque/6502Esque.hpp
+++ b/Processors/6502Esque/6502Esque.hpp
@@ -99,17 +99,17 @@ enum class BusOperation {
 /*!
 	For a machine watching only the RWB line, evaluates to @c true if the operation should be treated as a read; @c false otherwise.
 */
-constexpr bool isReadOperation(BusOperation op) { return op <= BusOperation::InternalOperationRead; }
+constexpr bool is_read(BusOperation op) { return op <= BusOperation::InternalOperationRead; }
 
 /*!
 	For a machine watching only the RWB line, evaluates to @c true if the operation is any sort of write; @c false otherwise.
 */
-constexpr bool isWriteOperation(BusOperation op) { return op >= BusOperation::Write; }
+constexpr bool is_write(BusOperation op) { return op >= BusOperation::Write; }
 
 /*!
 	Evaluates to @c true if the operation actually expects a response; @c false otherwise.
 */
-constexpr bool isAccessOperation(BusOperation op) { return op <= BusOperation::ReadVector || op == BusOperation::Write; }
+constexpr bool is_access(BusOperation op) { return op <= BusOperation::ReadVector || op == BusOperation::Write; }
 
 /*!
 	A class providing empty implementations of the methods a 6502 uses to access the bus. To wire the 6502 to a bus,


### PR DESCRIPTION
This is possibly preparatory to supplying the bus operation as a template argument. We'll see.