### PR TITLE
Correct status unset-bit masks.

### DIFF
--- a/Machines/Commodore/Plus4/Interrupts.hpp
+++ b/Machines/Commodore/Plus4/Interrupts.hpp
@@ -32,7 +32,7 @@ public:
 	};
 
 	uint8_t status() const {
-		return status_ | ((status_ & mask_) ? 0x80 : 0x00) | 0x21;
+		return status_ | ((status_ & mask_) ? 0x80 : 0x00) | 0x25;
 	}
 
 	uint8_t mask() const {

--- a/Machines/Commodore/Plus4/Plus4.cpp
+++ b/Machines/Commodore/Plus4/Plus4.cpp
@@ -378,7 +378,7 @@ public:
 					} break;
 					case 0xff09:	*value = interrupts_.status();	break;
 					case 0xff0a:
-						*value = interrupts_.mask() | video_.read<0xff0a>() | 0x60;
+						*value = interrupts_.mask() | video_.read<0xff0a>() | 0xa0;
 					break;
 					case 0xff0b:	*value = video_.read<0xff0b>();	break;
 					case 0xff0c:	*value = video_.read<0xff0c>();	break;


### PR DESCRIPTION
This fixes tape input. Or, at least, restores it to its previous high watermark.