### PR TITLE
Reduce repetitive dynamic work in 6522 usages.

### DIFF
--- a/Components/6522/6522.hpp
+++ b/Components/6522/6522.hpp
@@ -131,7 +131,7 @@ private:
 	void access(int address);
 
 	template <Port> uint8_t get_port_input(uint8_t output_mask, uint8_t output, uint8_t timer_mask);
-	template <Port port, int shift> void update_pcr(const uint8_t);
+	template <Port port> void update_pcr(const uint8_t);
 	inline void reevaluate_interrupts();
 
 	/// Sets the current intended output value for the port and line;

--- a/Components/6522/6522.hpp
+++ b/Components/6522/6522.hpp
@@ -33,15 +33,18 @@ enum Line {
 class PortHandler {
 public:
 	/// Requests the current input value of the named port from the port handler.
-	uint8_t get_port_input(Port) {
+	template<Port port>
+	uint8_t get_port_input() const {
 		return 0xff;
 	}
 
 	/// Sets the current output value of the named oprt and provides @c direction_mask, indicating which pins are marked as output.
-	void set_port_output(Port, [[maybe_unused]] uint8_t value, [[maybe_unused]] uint8_t direction_mask) {}
+	template<Port port>
+	void set_port_output([[maybe_unused]] uint8_t value, [[maybe_unused]] uint8_t direction_mask) {}
 
 	/// Sets the current logical output level for the named line on the specified  port.
-	void set_control_line_output(Port, Line, [[maybe_unused]] bool value) {}
+	template<Port port, Line line>
+	void set_control_line_output([[maybe_unused]] bool value) {}
 
 	/// Sets the current logical value of the interrupt line.
 	void set_interrupt_status([[maybe_unused]] bool status) {}
@@ -101,7 +104,8 @@ public:
 	BusHandlerT &bus_handler();
 
 	/// Sets the input value of the named line and port.
-	void set_control_line_input(Port, Line, bool value);
+	template<Port, Line>
+	void set_control_line_input(bool value);
 
 	/// Runs for a specified number of half cycles.
 	void run_for(const HalfCycles);
@@ -126,12 +130,13 @@ private:
 
 	void access(int address);
 
-	uint8_t get_port_input(Port port, uint8_t output_mask, uint8_t output, uint8_t timer_mask);
+	template <Port> uint8_t get_port_input(uint8_t output_mask, uint8_t output, uint8_t timer_mask);
+	template <Port port, int shift> void update_pcr(const uint8_t);
 	inline void reevaluate_interrupts();
 
 	/// Sets the current intended output value for the port and line;
 	/// if this affects the visible output, it will be passed to the handler.
-	void set_control_line_output(Port port, Line line, LineState value);
+	template <Port, Line> void set_control_line_output(LineState);
 	void evaluate_cb2_output();
 	void evaluate_port_b_output();
 };

--- a/Components/6522/Implementation/6522Implementation.hpp
+++ b/Components/6522/Implementation/6522Implementation.hpp
@@ -132,13 +132,11 @@ template <typename T> void MOS6522<T>::write(int address, const uint8_t value) {
 			}
 			evaluate_port_b_output();
 		break;
-		case 0xc: {	// Peripheral control ('PCR').
-//			const auto old_peripheral_control = registers_.peripheral_control;
+		case 0xc:	// Peripheral control ('PCR').
 			registers_.peripheral_control = value;
-
-			update_pcr<Port::A, 0>(value);
-			update_pcr<Port::B, 4>(value);
-		} break;
+			update_pcr<Port::A>(value);
+			update_pcr<Port::B>(value >> 4);
+		break;
 
 		// Interrupt control
 		case 0xd:	// Interrupt flag regiser ('IFR').
@@ -156,10 +154,10 @@ template <typename T> void MOS6522<T>::write(int address, const uint8_t value) {
 }
 
 template <typename T>
-template <Port port, int shift>
+template <Port port>
 void MOS6522<T>::update_pcr(const uint8_t value) {
 	handshake_modes_[port] = HandshakeMode::None;
-	switch((value >> shift) & 0x0e) {
+	switch(value & 0x0e) {
 		default: break;
 
 		case 0x00:	// Negative interrupt input; set Cx2 interrupt on negative Cx2 transition, clear on access to Port x register.

--- a/Machines/Apple/AppleII/Mockingboard.hpp
+++ b/Machines/Apple/AppleII/Mockingboard.hpp
@@ -99,7 +99,8 @@ private:
 			card.did_change_interrupt_flags();
 		}
 
-		void set_port_output(MOS::MOS6522::Port port, uint8_t value, uint8_t) {
+		template <MOS::MOS6522::Port port>
+		void set_port_output(const uint8_t value, uint8_t) {
 			if(port) {
 				using ControlLines = GI::AY38910::ControlLines;
 				ay.set_control_lines(
@@ -116,7 +117,8 @@ private:
 			}
 		}
 
-		uint8_t get_port_input(MOS::MOS6522::Port port) {
+		template <MOS::MOS6522::Port port>
+		uint8_t get_port_input() const {
 			if(!port) {
 				return ay.get_data_output();
 			}

--- a/Machines/Commodore/1540/Implementation/C1540.cpp
+++ b/Machines/Commodore/1540/Implementation/C1540.cpp
@@ -280,7 +280,6 @@ void DriveVIA::set_activity_observer(Activity::Observer *observer) {
 // MARK: - SerialPort
 
 void SerialPort::set_input(Serial::Line line, Serial::LineLevel level) {
-	// TODO: add dynamic.
 	serial_port_via_->set_serial_line_state(line, bool(level), *via_);
 }
 

--- a/Machines/Commodore/1540/Implementation/C1540.cpp
+++ b/Machines/Commodore/1540/Implementation/C1540.cpp
@@ -162,12 +162,14 @@ void MachineBase::drive_via_did_set_data_density(void *, const int density) {
 
 // MARK: - SerialPortVIA
 
-uint8_t SerialPortVIA::get_port_input(MOS::MOS6522::Port port) {
+template <MOS::MOS6522::Port port>
+uint8_t SerialPortVIA::get_port_input() const {
 	if(port) return port_b_;
 	return 0xff;
 }
 
-void SerialPortVIA::set_port_output(MOS::MOS6522::Port port, uint8_t value, uint8_t) {
+template <MOS::MOS6522::Port port>
+void SerialPortVIA::set_port_output(const uint8_t value, uint8_t) {
 	if(port) {
 		attention_acknowledge_level_ = !(value&0x10);
 		data_level_output_ = (value&0x02);
@@ -178,8 +180,8 @@ void SerialPortVIA::set_port_output(MOS::MOS6522::Port port, uint8_t value, uint
 }
 
 void SerialPortVIA::set_serial_line_state(
-	::Commodore::Serial::Line line,
-	bool value,
+	const Commodore::Serial::Line line,
+	const bool value,
 	MOS::MOS6522::MOS6522<SerialPortVIA> &via
 ) {
 	switch(line) {
@@ -189,7 +191,7 @@ void SerialPortVIA::set_serial_line_state(
 		case ::Commodore::Serial::Line::Attention:
 			attention_level_input_ = !value;
 			port_b_ = (port_b_ & ~0x80) | (value ? 0x00 : 0x80);
-			via.set_control_line_input(MOS::MOS6522::Port::A, MOS::MOS6522::Line::One, !value);
+			via.set_control_line_input<MOS::MOS6522::Port::A, MOS::MOS6522::Line::One>(!value);
 			update_data_line();
 		break;
 	}
@@ -212,11 +214,12 @@ void DriveVIA::set_delegate(Delegate *delegate) {
 }
 
 // write protect tab uncovered
-uint8_t DriveVIA::get_port_input(MOS::MOS6522::Port port) {
+template <MOS::MOS6522::Port port>
+uint8_t DriveVIA::get_port_input() const {
 	return port ? port_b_ : port_a_;
 }
 
-void DriveVIA::set_sync_detected(bool sync_detected) {
+void DriveVIA::set_sync_detected(const bool sync_detected) {
 	port_b_ = (port_b_ & 0x7f) | (sync_detected ? 0x00 : 0x80);
 }
 
@@ -232,13 +235,15 @@ bool DriveVIA::get_motor_enabled() {
 	return drive_motor_;
 }
 
-void DriveVIA::set_control_line_output(MOS::MOS6522::Port port, MOS::MOS6522::Line line, bool value) {
+template <MOS::MOS6522::Port port, MOS::MOS6522::Line line>
+void DriveVIA::set_control_line_output(const bool value) {
 	if(port == MOS::MOS6522::Port::A && line == MOS::MOS6522::Line::Two) {
 		should_set_overflow_ = value;
 	}
 }
 
-void DriveVIA::set_port_output(MOS::MOS6522::Port port, uint8_t value, uint8_t) {
+template <MOS::MOS6522::Port port>
+void DriveVIA::set_port_output(const uint8_t value, uint8_t) {
 	if(port) {
 		if(previous_port_b_output_ != value) {
 			// Record drive motor state.
@@ -275,6 +280,7 @@ void DriveVIA::set_activity_observer(Activity::Observer *observer) {
 // MARK: - SerialPort
 
 void SerialPort::set_input(Serial::Line line, Serial::LineLevel level) {
+	// TODO: add dynamic.
 	serial_port_via_->set_serial_line_state(line, bool(level), *via_);
 }
 

--- a/Machines/Commodore/1540/Implementation/C1540Base.hpp
+++ b/Machines/Commodore/1540/Implementation/C1540Base.hpp
@@ -39,10 +39,13 @@ namespace Commodore::C1540 {
 */
 class SerialPortVIA: public MOS::MOS6522::IRQDelegatePortHandler {
 public:
-	uint8_t get_port_input(MOS::MOS6522::Port);
+	template <MOS::MOS6522::Port>
+	uint8_t get_port_input() const;
 
-	void set_port_output(MOS::MOS6522::Port, uint8_t value, uint8_t mask);
-	void set_serial_line_state(::Commodore::Serial::Line, bool, MOS::MOS6522::MOS6522<SerialPortVIA> &);
+	template <MOS::MOS6522::Port>
+	void set_port_output(uint8_t value, uint8_t mask);
+
+	void set_serial_line_state(Commodore::Serial::Line, bool, MOS::MOS6522::MOS6522<SerialPortVIA> &);
 
 	void set_serial_port(Commodore::Serial::Port &);
 
@@ -55,6 +58,13 @@ private:
 
 	void update_data_line();
 };
+
+//inline void set_serial_line_state(Commodore::Serial::Line line bool value, MOS::MOS6522::MOS6522<SerialPortVIA> &via) {
+//	switch(line){
+//		case Commodore::Serial::Line::One:
+//			via.set_serial_line_state<Commodore::Serial::Line::One>(value, via);
+//	}
+//}
 
 /*!
 	An implementation of the drive VIA in a Commodore 1540: the VIA that is used to interface with the disk.
@@ -81,16 +91,19 @@ public:
 	};
 	void set_delegate(Delegate *);
 
-	uint8_t get_port_input(MOS::MOS6522::Port);
+	template <MOS::MOS6522::Port>
+	uint8_t get_port_input() const;
 
 	void set_sync_detected(bool);
 	void set_data_input(uint8_t);
 	bool get_should_set_overflow();
 	bool get_motor_enabled();
 
-	void set_control_line_output(MOS::MOS6522::Port, MOS::MOS6522::Line, bool value);
+	template <MOS::MOS6522::Port, MOS::MOS6522::Line>
+	void set_control_line_output(bool value);
 
-	void set_port_output(MOS::MOS6522::Port, uint8_t value, uint8_t direction_mask);
+	template <MOS::MOS6522::Port>
+	void set_port_output(uint8_t value, uint8_t direction_mask);
 
 	void set_activity_observer(Activity::Observer *);
 

--- a/Machines/Commodore/1540/Implementation/C1540Base.hpp
+++ b/Machines/Commodore/1540/Implementation/C1540Base.hpp
@@ -59,13 +59,6 @@ private:
 	void update_data_line();
 };
 
-//inline void set_serial_line_state(Commodore::Serial::Line line bool value, MOS::MOS6522::MOS6522<SerialPortVIA> &via) {
-//	switch(line){
-//		case Commodore::Serial::Line::One:
-//			via.set_serial_line_state<Commodore::Serial::Line::One>(value, via);
-//	}
-//}
-
 /*!
 	An implementation of the drive VIA in a Commodore 1540: the VIA that is used to interface with the disk.
 

--- a/Machines/Commodore/SerialBus.hpp
+++ b/Machines/Commodore/SerialBus.hpp
@@ -104,7 +104,7 @@ public:
 	/*!
 		Called by the bus to signal a change in any input line level. Subclasses should implement this.
 	*/
-	virtual void set_input(Line line, LineLevel value) = 0;
+	virtual void set_input(Line, LineLevel) = 0;
 
 	/*!
 		Sets the supplied serial bus as that to which line levels will be communicated.


### PR DESCRIPTION
Just excising another demon; I don't imagine it makes a substantial difference — or necessarily any difference — at runtime as the constant nature of the port/line parameters should have been easy for the compiler to detect.