### PR TITLE
macOS: Reinsert media and/or restart machines upon underlying file changes.

### DIFF
--- a/Machines/AmstradCPC/FDC.hpp
+++ b/Machines/AmstradCPC/FDC.hpp
@@ -40,6 +40,10 @@ public:
 		get_drive().set_disk(disk);
 	}
 
+	const Storage::Disk::Disk *disk() const {
+		return get_drive().disk();
+	}
+
 	void set_activity_observer(Activity::Observer *observer) {
 		get_drive().set_activity_observer(observer, "Drive 1", true);
 	}

--- a/Machines/MediaTarget.hpp
+++ b/Machines/MediaTarget.hpp
@@ -33,15 +33,25 @@ struct MediaTarget {
 	};
 	/*!
 		Queries what action an observed on-disk change in the file with name `file_name`,
-		which is guaranteed lexically to match one used earlier for the creation of media that
-		was either inserted or provided at machine construction, should be performed by the
-		machine's owner.
+		which is guaranteed lexically to match one used earlier with this machine, should be
+		performed by the machine's owner.
+
+		It is guaranteed by the caller that the underlying bytes of the file have changed; the caller
+		is not required to differentiate changes made by Clock Signal itself from those made
+		external to it.
 
 		@c ChangeEffect::None means that no specific action will be taken;
 		@c ChangeEffect::ReinsertMedia requests that the owner construct the applicable
 			`Analyser::Static::Media` and call `insert_media`;
 		@c ChangeEffect::RestartMachine requests that the owner reconsult the static analyer
 			and construct a new machine to replace this one.
+
+		In general:
+			* if the machine itself has recently modified the file, `::None` is appropriate;
+			* if the machine has not recently modified the file, quite often obviously so because the
+			file is a ROM or something else that is never modified, then ::ReinsertMedia or ::RestartMachine
+			might be appropriate depending on whether it is more likely that execution will continue correctly
+			with a simple media swap or whether this implies that previous state should be completely discarded.
 	*/
 	virtual ChangeEffect effect_for_file_did_change([[maybe_unused]] const std::string &file_name) {
 		return ChangeEffect::None;

--- a/Machines/MediaTarget.hpp
+++ b/Machines/MediaTarget.hpp
@@ -25,6 +25,27 @@ struct MediaTarget {
 		@returns @c true if any media was inserted; @c false otherwise.
 	*/
 	virtual bool insert_media(const Analyser::Static::Media &) = 0;
+
+	enum class ChangeEffect {
+		None,
+		ReinsertMedia,
+		RestartMachine
+	};
+	/*!
+		Queries what action an observed on-disk change in the file with name `file_name`,
+		which is guaranteed lexically to match one used earlier for the creation of media that
+		was either inserted or provided at machine construction, should be performed by the
+		machine's owner.
+
+		@c ChangeEffect::None means that no specific action will be taken;
+		@c ChangeEffect::ReinsertMedia requests that the owner construct the applicable
+			`Analyser::Static::Media` and call `insert_media`;
+		@c ChangeEffect::RestartMachine requests that the owner reconsult the static analyer
+			and construct a new machine to replace this one.
+	*/
+	virtual ChangeEffect effect_for_file_did_change([[maybe_unused]] const std::string &file_name) {
+		return ChangeEffect::None;
+	}
 };
 
 }

--- a/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
+++ b/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
@@ -696,6 +696,12 @@ template<Model model> class ConcreteMachine:
 			return !media.tapes.empty() || (!media.disks.empty() && model == Model::Plus3);
 		}
 
+		ChangeEffect effect_for_file_did_change(const std::string &file_name) override {
+			fdc_->disk();
+
+			return ChangeEffect::None;
+		}
+
 		// MARK: - ClockingHint::Observer.
 
 		void set_component_prefers_clocking(ClockingHint::Source *, ClockingHint::Preference) override {

--- a/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
+++ b/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
@@ -697,9 +697,9 @@ template<Model model> class ConcreteMachine:
 		}
 
 		ChangeEffect effect_for_file_did_change(const std::string &file_name) override {
-			fdc_->disk();
-
-			return ChangeEffect::None;
+			const auto disk = fdc_->disk();
+			return disk && disk->represents(file_name) && disk->has_written() ?
+				ChangeEffect::None : ChangeEffect::RestartMachine;
 		}
 
 		// MARK: - ClockingHint::Observer.

--- a/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
@@ -236,6 +236,7 @@
 		4B0ACC3223775819008902D0 /* Atari2600.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0ACC2223775819008902D0 /* Atari2600.cpp */; };
 		4B0ACC3323775819008902D0 /* Atari2600.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0ACC2223775819008902D0 /* Atari2600.cpp */; };
 		4B0B23A12D6826DE00153879 /* NumericTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4B0B23A02D6826DE00153879 /* NumericTests.mm */; };
+		4B0B23A62D6AC53B00153879 /* CSFileContentChangeObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B0B23A42D6AC53B00153879 /* CSFileContentChangeObserver.m */; };
 		4B0CCC451C62D0B3001CAC5F /* CRT.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0CCC421C62D0B3001CAC5F /* CRT.cpp */; };
 		4B0DA67B282DCDF100C12F17 /* Instruction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0DA67A282DCC4200C12F17 /* Instruction.cpp */; };
 		4B0DA67C282DCDF300C12F17 /* Instruction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0DA67A282DCC4200C12F17 /* Instruction.cpp */; };
@@ -1374,6 +1375,8 @@
 		4B0ACC2523775819008902D0 /* TIA.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = TIA.hpp; sourceTree = "<group>"; };
 		4B0B239F2D658C9400153879 /* BitStream.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = BitStream.hpp; sourceTree = "<group>"; };
 		4B0B23A02D6826DE00153879 /* NumericTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = NumericTests.mm; sourceTree = "<group>"; };
+		4B0B23A42D6AC53B00153879 /* CSFileContentChangeObserver.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CSFileContentChangeObserver.m; sourceTree = "<group>"; };
+		4B0B23A72D6AC56400153879 /* CSFileContentChangeObserver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CSFileContentChangeObserver.h; sourceTree = "<group>"; };
 		4B0CCC421C62D0B3001CAC5F /* CRT.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CRT.cpp; sourceTree = "<group>"; };
 		4B0CCC431C62D0B3001CAC5F /* CRT.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = CRT.hpp; sourceTree = "<group>"; };
 		4B0DA67A282DCC4200C12F17 /* Instruction.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Instruction.cpp; sourceTree = "<group>"; };
@@ -2724,6 +2727,15 @@
 				4B0ACC1C23775819008902D0 /* CommaVid.hpp */,
 			);
 			path = Cartridges;
+			sourceTree = "<group>";
+		};
+		4B0B23A52D6AC53B00153879 /* File Observer */ = {
+			isa = PBXGroup;
+			children = (
+				4B0B23A72D6AC56400153879 /* CSFileContentChangeObserver.h */,
+				4B0B23A42D6AC53B00153879 /* CSFileContentChangeObserver.m */,
+			);
+			path = "File Observer";
 			sourceTree = "<group>";
 		};
 		4B0CCC411C62D0B3001CAC5F /* CRT */ = {
@@ -4651,6 +4663,7 @@
 				4B2A538F1D117D36003C6002 /* Audio */,
 				4B643F3D1D77B88000D431D6 /* Document Controller */,
 				4B55CE551C3B7D360093A61B /* Documents */,
+				4B0B23A52D6AC53B00153879 /* File Observer */,
 				4B2BF19323E10F0000C3AD60 /* High Precision Timer */,
 				4BBFE83B21015D9C00BF1C40 /* Joystick Manager */,
 				4B2A53921D117D36003C6002 /* Machine */,
@@ -6354,6 +6367,7 @@
 				4BEDA3BA25B25563000C2DBD /* Decoder.cpp in Sources */,
 				4BFEA2EF2682A7B900EBF94C /* Dave.cpp in Sources */,
 				4B4518A21F75FD1C00926311 /* G64.cpp in Sources */,
+				4B0B23A62D6AC53B00153879 /* CSFileContentChangeObserver.m in Sources */,
 				4B89452C201967B4007DE474 /* Tape.cpp in Sources */,
 				4B448E811F1C45A00009ABD6 /* TZX.cpp in Sources */,
 				4BBFE83D21015D9C00BF1C40 /* CSJoystickManager.m in Sources */,

--- a/OSBindings/Mac/Clock Signal/ClockSignal-Bridging-Header.h
+++ b/OSBindings/Mac/Clock Signal/ClockSignal-Bridging-Header.h
@@ -7,6 +7,7 @@
 #import "CSAtari2600.h"
 #import "CSZX8081.h"
 
+#import "CSFileContentChangeObserver.h"
 #import "CSStaticAnalyser.h"
 
 #import "CSAudioQueue.h"

--- a/OSBindings/Mac/Clock Signal/Document Controller/DocumentController.swift
+++ b/OSBindings/Mac/Clock Signal/Document Controller/DocumentController.swift
@@ -10,9 +10,4 @@ import Cocoa
 
 class DocumentController: NSDocumentController {
 	let joystickManager = CSJoystickManager()
-
-	override func document(for url: URL) -> NSDocument? {
-		Swift.print("Document for?")
-		return super.document(for: url)
-	}
 }

--- a/OSBindings/Mac/Clock Signal/Document Controller/DocumentController.swift
+++ b/OSBindings/Mac/Clock Signal/Document Controller/DocumentController.swift
@@ -10,4 +10,9 @@ import Cocoa
 
 class DocumentController: NSDocumentController {
 	let joystickManager = CSJoystickManager()
+
+	override func document(for url: URL) -> NSDocument? {
+		Swift.print("Document for?")
+		return super.document(for: url)
+	}
 }

--- a/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
+++ b/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
@@ -72,23 +72,17 @@ class MachineDocument:
 			self.configureAs(analyser)
 			self.fileObserver = CSFileContentChangeObserver.init(url: url, handler: {
 				DispatchQueue.main.async {
-//					self.actionLock.lock()
-//					self.drawLock.lock()
-
 					switch(self.machine.effectForFile(atURLDidChange: url)) {
 						case .reinsertMedia:	self.insertFile(url)
 						case .restartMachine:
 							let target = CSStaticAnalyser(fileAt: url)
 							if let target = target {
-//								self.configureAs(target)
+								self.machine.substitute(target)
 							}
 
 						case .none:				fallthrough
 						@unknown default:		break
 					}
-
-//					self.actionLock.unlock()
-//					self.drawLock.unlock()
 				}
 			})
 		} else {

--- a/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
+++ b/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
@@ -78,6 +78,7 @@ class MachineDocument:
 							let target = CSStaticAnalyser(fileAt: url)
 							if let target = target {
 								self.machine.substitute(target)
+								self.optionsController?.establishStoredOptions()
 							}
 
 						case .none:				fallthrough

--- a/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
+++ b/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
@@ -71,16 +71,24 @@ class MachineDocument:
 			self.displayName = analyser.displayName
 			self.configureAs(analyser)
 			self.fileObserver = CSFileContentChangeObserver.init(url: url, handler: {
-				switch(self.machine.effectForFile(atURLDidChange: url)) {
-					case .reinsertMedia:	self.insertFile(url)
-					case .restartMachine:
-						let target = CSStaticAnalyser(fileAt: url)
-						if let target = target {
-							self.configureAs(target)
-						}
+				DispatchQueue.main.async {
+//					self.actionLock.lock()
+//					self.drawLock.lock()
 
-					case .none:				fallthrough
-					@unknown default:		break
+					switch(self.machine.effectForFile(atURLDidChange: url)) {
+						case .reinsertMedia:	self.insertFile(url)
+						case .restartMachine:
+							let target = CSStaticAnalyser(fileAt: url)
+							if let target = target {
+//								self.configureAs(target)
+							}
+
+						case .none:				fallthrough
+						@unknown default:		break
+					}
+
+//					self.actionLock.unlock()
+//					self.drawLock.unlock()
 				}
 			})
 		} else {

--- a/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
+++ b/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
@@ -82,11 +82,6 @@ class MachineDocument:
 					case .none:				fallthrough
 					@unknown default:		break
 				}
-
-				Swift.print("Content changed")
-
-				// TODO: tell machine content has changed. Machine will need to indicate
-				// whether it's the one that changed it. If not, restart the machine.
 			})
 		} else {
 			throw NSError(domain: "MachineDocument", code: -1, userInfo: nil)

--- a/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
+++ b/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
@@ -71,18 +71,21 @@ class MachineDocument:
 			self.displayName = analyser.displayName
 			self.configureAs(analyser)
 			self.fileObserver = CSFileContentChangeObserver.init(url: url, handler: {
-				DispatchQueue.main.async {
-					switch(self.machine.effectForFile(atURLDidChange: url)) {
-						case .reinsertMedia:	self.insertFile(url)
-						case .restartMachine:
-							let target = CSStaticAnalyser(fileAt: url)
-							if let target = target {
-								self.machine.substitute(target)
-								self.optionsController?.establishStoredOptions()
-							}
+				if let machine = self.machine {
+					DispatchQueue.main.async {
+						switch(machine.effectForFile(atURLDidChange: url)) {
+							case .reinsertMedia:	self.insertFile(url)
+							case .restartMachine:
+								let target = CSStaticAnalyser(fileAt: url)
+								if let target = target {
+									self.audioQueue = nil
+									machine.substitute(target)
+									self.optionsController?.establishStoredOptions()
+								}
 
-						case .none:				fallthrough
-						@unknown default:		break
+							case .none:				fallthrough
+							@unknown default:		break
+						}
 					}
 				}
 			})

--- a/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
+++ b/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
@@ -72,6 +72,9 @@ class MachineDocument:
 			self.configureAs(analyser)
 			self.fileObserver = CSFileContentChangeObserver.init(url: url, handler: {
 				Swift.print("Content changed")
+
+				// TODO: tell machine content has changed. Machine will need to indicate
+				// whether it's the one that changed it. If not, restart the machine.
 			})
 		} else {
 			throw NSError(domain: "MachineDocument", code: -1, userInfo: nil)

--- a/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
+++ b/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
@@ -9,6 +9,8 @@
 import AudioToolbox
 import Cocoa
 import QuartzCore
+import System
+
 
 class MachineDocument:
 	NSDocument,
@@ -63,10 +65,14 @@ class MachineDocument:
 		return "MachineDocument"
 	}
 
+	var fileObserver: CSFileContentChangeObserver?
 	override func read(from url: URL, ofType typeName: String) throws {
 		if let analyser = CSStaticAnalyser(fileAt: url) {
 			self.displayName = analyser.displayName
 			self.configureAs(analyser)
+			self.fileObserver = CSFileContentChangeObserver.init(url: url, handler: {
+				Swift.print("Content changed")
+			})
 		} else {
 			throw NSError(domain: "MachineDocument", code: -1, userInfo: nil)
 		}
@@ -135,20 +141,6 @@ class MachineDocument:
 
 		actionLock.unlock()
 		drawLock.unlock()
-	}
-
-	override func presentedItemDidChange() {
-		// Indicates that _something_ about the file changed.
-		//
-		// It could be only metadata.
-		//
-		// It could be content, but it might have been this application that did it.
-		//
-		// However, if:
-		//	(i) content changed; and
-		//	(ii) it was another application that did it;
-		// then it makes sense to restart the machine.
-		Swift.print("Did change?")
 	}
 
 	enum InteractionMode {

--- a/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
+++ b/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
@@ -137,6 +137,20 @@ class MachineDocument:
 		drawLock.unlock()
 	}
 
+	override func presentedItemDidChange() {
+		// Indicates that _something_ about the file changed.
+		//
+		// It could be only metadata.
+		//
+		// It could be content, but it might have been this application that did it.
+		//
+		// However, if:
+		//	(i) content changed; and
+		//	(ii) it was another application that did it;
+		// then it makes sense to restart the machine.
+		Swift.print("Did change?")
+	}
+
 	enum InteractionMode {
 		case notStarted, showingMachinePicker, showingROMRequester, showingMachine
 	}

--- a/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
+++ b/OSBindings/Mac/Clock Signal/Documents/MachineDocument.swift
@@ -71,6 +71,18 @@ class MachineDocument:
 			self.displayName = analyser.displayName
 			self.configureAs(analyser)
 			self.fileObserver = CSFileContentChangeObserver.init(url: url, handler: {
+				switch(self.machine.effectForFile(atURLDidChange: url)) {
+					case .reinsertMedia:	self.insertFile(url)
+					case .restartMachine:
+						let target = CSStaticAnalyser(fileAt: url)
+						if let target = target {
+							self.configureAs(target)
+						}
+
+					case .none:				fallthrough
+					@unknown default:		break
+				}
+
 				Swift.print("Content changed")
 
 				// TODO: tell machine content has changed. Machine will need to indicate

--- a/OSBindings/Mac/Clock Signal/File Observer/CSFileContentChangeObserver.h
+++ b/OSBindings/Mac/Clock Signal/File Observer/CSFileContentChangeObserver.h
@@ -1,0 +1,15 @@
+//
+//  CSFileObserver.h
+//  Clock Signal
+//
+//  Created by Thomas Harte on 22/02/2025.
+//  Copyright © 2025 Thomas Harte. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface CSFileContentChangeObserver: NSObject
+
+- (nullable instancetype)initWithURL:(nonnull NSURL *)url handler:(nonnull dispatch_block_t)handler;
+
+@end

--- a/OSBindings/Mac/Clock Signal/File Observer/CSFileContentChangeObserver.m
+++ b/OSBindings/Mac/Clock Signal/File Observer/CSFileContentChangeObserver.m
@@ -1,0 +1,47 @@
+//
+//  CSFileObserver.m
+//  Clock Signal
+//
+//  Created by Thomas Harte on 22/02/2025.
+//  Copyright © 2025 Thomas Harte. All rights reserved.
+//
+
+#import "CSFileContentChangeObserver.h"
+
+@implementation CSFileContentChangeObserver {
+	int _fileDescriptor;
+	dispatch_source_t _source;
+}
+
+- (nullable instancetype)initWithURL:(nonnull NSURL *)url handler:(nonnull dispatch_block_t)handler {
+	if(!url.isFileURL) {
+		return nil;
+	}
+
+	self = [super init];
+	if(self) {
+		_fileDescriptor = open(url.fileSystemRepresentation, O_EVTONLY);
+		if(_fileDescriptor <= 0) {
+			return nil;
+		}
+
+		_source = dispatch_source_create(
+			DISPATCH_SOURCE_TYPE_VNODE,
+			(uintptr_t)_fileDescriptor,
+			DISPATCH_VNODE_WRITE,
+			dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0)
+		);
+		dispatch_source_set_event_handler(_source, handler);
+		dispatch_resume(_source);
+	}
+	return self;
+}
+
+- (void)dealloc {
+	if(_fileDescriptor) {
+		close(_fileDescriptor);
+		dispatch_source_cancel(_source);
+	}
+}
+
+@end

--- a/OSBindings/Mac/Clock Signal/Machine/CSMachine.h
+++ b/OSBindings/Mac/Clock Signal/Machine/CSMachine.h
@@ -33,6 +33,12 @@ typedef NS_ENUM(NSInteger, CSMachineKeyboardInputMode) {
 	CSMachineKeyboardInputModeJoystick,
 };
 
+typedef NS_ENUM(NSInteger, CSMachineChangeEffect) {
+	CSMachineChangeEffectNone,
+	CSMachineChangeEffectReinsertMedia,
+	CSMachineChangeEffectRestartMachine,
+};
+
 @interface CSMachineLED: NSObject
 @property(nonatomic, nonnull, readonly) NSString *name;
 @property(nonatomic, readonly) BOOL isPersisent;
@@ -87,11 +93,13 @@ typedef NS_ENUM(NSInteger, CSMachineKeyboardInputMode) {
 @property (nonatomic, assign) BOOL useAutomaticTapeMotorControl;
 @property (nonatomic, assign) BOOL useQuickBootingHack;
 
-@property (nonatomic, readonly) BOOL canInsertMedia;
-
 - (BOOL)supportsVideoSignal:(CSMachineVideoSignal)videoSignal;
 
-// Volume contorl.
+// Public media functions; use a CSMediaSet to insert.
+@property (nonatomic, readonly) BOOL canInsertMedia;
+- (CSMachineChangeEffect)effectForFileAtURLDidChange:(nonnull NSURL *)url;
+
+// Volume control.
 - (void)setVolume:(float)volume;
 @property (nonatomic, readonly) BOOL hasAudioOutput;
 

--- a/OSBindings/Mac/Clock Signal/Machine/CSMachine.h
+++ b/OSBindings/Mac/Clock Signal/Machine/CSMachine.h
@@ -79,6 +79,8 @@ typedef NS_ENUM(NSInteger, CSMachineChangeEffect) {
 - (void)setMouseButton:(int)button isPressed:(BOOL)isPressed;
 - (void)addMouseMotionX:(CGFloat)deltaX y:(CGFloat)deltaY;
 
+- (void)substitute:(nonnull CSStaticAnalyser *)machine;
+
 @property (nonatomic, strong, nullable) CSAudioQueue *audioQueue;
 @property (nonatomic, readonly, nonnull) CSScanTargetView *view;
 @property (nonatomic, weak, nullable) id<CSMachineDelegate> delegate;

--- a/OSBindings/Mac/Clock Signal/Machine/CSMachine.mm
+++ b/OSBindings/Mac/Clock Signal/Machine/CSMachine.mm
@@ -350,6 +350,30 @@ struct ActivityObserver: public Activity::Observer {
 	}
 }
 
+- (CSMachineChangeEffect)effectForFileAtURLDidChange:(nonnull NSURL *)url {
+	@synchronized(self) {
+		const auto mediaTarget = _machine->media_target();
+		if(!mediaTarget) {
+			return CSMachineChangeEffectNone;
+		}
+		const auto effect = mediaTarget->effect_for_file_did_change([url fileSystemRepresentation]);
+		using ChangeEffect = MachineTypes::MediaTarget::ChangeEffect;
+		switch(effect) {
+			case ChangeEffect::None:
+				return CSMachineChangeEffectNone;
+			case ChangeEffect::ReinsertMedia:
+				return CSMachineChangeEffectReinsertMedia;
+			case ChangeEffect::RestartMachine:
+				return CSMachineChangeEffectRestartMachine;
+
+			default:
+				NSLog(@"Unmapped change effect %d", int(effect));
+				return CSMachineChangeEffectNone;
+		}
+	}
+}
+
+
 - (void)setInputMode:(CSMachineKeyboardInputMode)inputMode {
 	_inputMode = inputMode;
 

--- a/OSBindings/Mac/Clock SignalTests/NumericTests.mm
+++ b/OSBindings/Mac/Clock SignalTests/NumericTests.mm
@@ -1,0 +1,82 @@
+//
+//  NumericTests.m
+//  Clock SignalTests
+//
+//  Created by Thomas Harte on 20/02/2025.
+//  Copyright © 2025 Thomas Harte. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#include "BitStream.hpp"
+
+@interface NumericTests : XCTestCase
+@end
+
+@implementation NumericTests {
+}
+
+- (void)testBitStreamLSBFirst {
+	constexpr uint8_t testData[] = {
+		0xa3, 0xf4
+	};
+
+	auto it = std::begin(testData);
+	Numeric::BitStream<2, true> stream([&]() -> uint8_t {
+		if(it == std::end(testData)) return 0xff;
+		return *it++;
+	});
+
+	XCTAssertEqual(stream.next<2>(), 0b11);
+	XCTAssertEqual(stream.next<2>(), 0b00);
+	XCTAssertEqual(stream.next<2>(), 0b01);
+	XCTAssertEqual(stream.next<1>(), 0b0);
+	XCTAssertEqual(stream.next<2>(), 0b10);
+	XCTAssertEqual(stream.next<2>(), 0b01);
+	XCTAssertEqual(stream.next<1>(), 0b0);
+	XCTAssertEqual(stream.next<1>(), 0b1);
+	XCTAssertEqual(stream.next<2>(), 0b11);
+	XCTAssertEqual(stream.next<2>(), 0b11);
+}
+
+- (void)testBitStreamMSBFirst {
+	constexpr uint8_t testData[] = {
+		0xa3, 0xf4
+	};
+
+	auto it = std::begin(testData);
+	Numeric::BitStream<2, false> stream([&]() -> uint8_t {
+		if(it == std::end(testData)) return 0xff;
+		return *it++;
+	});
+
+	XCTAssertEqual(stream.next<2>(), 0b10);
+	XCTAssertEqual(stream.next<2>(), 0b10);
+	XCTAssertEqual(stream.next<2>(), 0b00);
+	XCTAssertEqual(stream.next<1>(), 0b1);
+	XCTAssertEqual(stream.next<2>(), 0b11);
+	XCTAssertEqual(stream.next<2>(), 0b11);
+	XCTAssertEqual(stream.next<1>(), 0b1);
+	XCTAssertEqual(stream.next<1>(), 0b0);
+	XCTAssertEqual(stream.next<2>(), 0b10);
+	XCTAssertEqual(stream.next<2>(), 0b01);
+}
+
+- (void)testBitStreamMultibyte {
+	constexpr uint8_t testData[] = {
+		0xa3, 0xf4, 0x11
+	};
+
+	auto it = std::begin(testData);
+	Numeric::BitStream<11, false> stream([&]() -> uint8_t {
+		if(it == std::end(testData)) return 0xff;
+		return *it++;
+	});
+
+	XCTAssertEqual(stream.next<2>(), 0b10);
+	XCTAssertEqual(stream.next<9>(), 0b100011111);
+	XCTAssertEqual(stream.next<11>(), 0b10100000100);
+	XCTAssertEqual(stream.next<3>(), 0b011);
+}
+
+@end

--- a/Storage/Disk/Disk.hpp
+++ b/Storage/Disk/Disk.hpp
@@ -32,18 +32,18 @@ public:
 		This is not necessarily a track count. There is no implicit guarantee that every position will
 		return a distinct track, or, e.g. if the media is holeless, will return any track at all.
 	*/
-	virtual HeadPosition get_maximum_head_position() = 0;
+	virtual HeadPosition get_maximum_head_position() const = 0;
 
 	/*!
 		@returns the number of heads (and, therefore, impliedly surfaces) available on this disk.
 	*/
-	virtual int get_head_count() = 0;
+	virtual int get_head_count() const = 0;
 
 	/*!
 		@returns the @c Track at @c position underneath @c head if there are any detectable events there;
 		returns @c nullptr otherwise.
 	*/
-	virtual Track *track_at_position(Track::Address) = 0;
+	virtual Track *track_at_position(Track::Address) const = 0;
 
 	/*!
 		Replaces the Track at position @c position underneath @c head with @c track. Ignored if this disk is read-only.
@@ -58,13 +58,23 @@ public:
 	/*!
 		@returns whether the disk image is read only. Defaults to @c true if not overridden.
 	*/
-	virtual bool get_is_read_only() = 0;
+	virtual bool get_is_read_only() const = 0;
 
 	/*!
 		@returns @c true if the tracks at the two addresses are different. @c false if they are the same track.
 			This can avoid some degree of work when disk images offer sub-head-position precision.
 	*/
-	virtual bool tracks_differ(Track::Address, Track::Address) = 0;
+	virtual bool tracks_differ(Track::Address, Track::Address) const = 0;
+
+	/*!
+		@returns @c true if the file named by the string is what underlies this disk image; @c false otherwise.
+	*/
+	virtual bool represents(const std::string &) const = 0;
+
+	/*!
+		@returns @c true if this disk has been written to at any point; @c false otherwise.
+	*/
+	virtual bool has_written() const = 0;
 };
 
 }

--- a/Storage/Disk/DiskImage/DiskImageImplementation.hpp
+++ b/Storage/Disk/DiskImage/DiskImageImplementation.hpp
@@ -23,8 +23,7 @@ bool DiskImageHolder<T>::get_is_read_only() const {
 
 template <typename T>
 bool DiskImageHolder<T>::represents(const std::string &file) const {
-	return false;	// TODO.
-//	return disk_image_.represents(file);
+	return disk_image_.represents(file);
 }
 
 template <typename T>

--- a/Storage/Disk/DiskImage/Formats/2MG.cpp
+++ b/Storage/Disk/DiskImage/Formats/2MG.cpp
@@ -78,7 +78,8 @@ Disk2MG::DiskOrMassStorageDevice Disk2MG::open(const std::string &file_name) {
 			// 'ProDOS order', which could still mean Macintosh-style (ie. not ProDOS, but whatever)
 			// or Apple II-style. Try them both.
 			try {
-				return new DiskImageHolder<Storage::Disk::MacintoshIMG>(file_name, MacintoshIMG::FixedType::GCR, data_start, data_size);
+				return new DiskImageHolder<Storage::Disk::MacintoshIMG>(
+					file_name, MacintoshIMG::FixedType::GCR, data_start, data_size);
 			} catch(...) {}
 
 			// TODO: Apple II-style.

--- a/Storage/Disk/DiskImage/Formats/AcornADF.cpp
+++ b/Storage/Disk/DiskImage/Formats/AcornADF.cpp
@@ -111,14 +111,14 @@ AcornADF::AcornADF(const std::string &file_name) : MFMSectorDump(file_name) {
 	set_geometry(sectors_per_track_, sector_size_, 0, density);
 }
 
-HeadPosition AcornADF::get_maximum_head_position() {
+HeadPosition AcornADF::get_maximum_head_position() const {
 	return HeadPosition(80);
 }
 
-int AcornADF::get_head_count() {
+int AcornADF::get_head_count() const {
 	return head_count_;
 }
 
-long AcornADF::get_file_offset_for_position(Track::Address address) {
+long AcornADF::get_file_offset_for_position(Track::Address address) const {
 	return (address.position.as_int() * head_count_ + address.head) * (128 << sector_size_) * sectors_per_track_;
 }

--- a/Storage/Disk/DiskImage/Formats/AcornADF.hpp
+++ b/Storage/Disk/DiskImage/Formats/AcornADF.hpp
@@ -27,11 +27,11 @@ public:
 	*/
 	AcornADF(const std::string &file_name);
 
-	HeadPosition get_maximum_head_position() final;
-	int get_head_count() final;
+	HeadPosition get_maximum_head_position() const final;
+	int get_head_count() const final;
 
 private:
-	long get_file_offset_for_position(Track::Address) final;
+	long get_file_offset_for_position(Track::Address) const final;
 	int head_count_ = 1;
 	uint8_t sector_size_ = 1;
 	int sectors_per_track_ = 16;

--- a/Storage/Disk/DiskImage/Formats/AmigaADF.cpp
+++ b/Storage/Disk/DiskImage/Formats/AmigaADF.cpp
@@ -185,3 +185,7 @@ std::unique_ptr<Track> AmigaADF::track_at_position(Track::Address address) const
 long AmigaADF::get_file_offset_for_position(Track::Address address) const {
 	return (address.position.as_int() * 2 + address.head) * 512 * 11;
 }
+
+bool AmigaADF::represents(const std::string &name) const {
+	return name == file_.name();
+}

--- a/Storage/Disk/DiskImage/Formats/AmigaADF.cpp
+++ b/Storage/Disk/DiskImage/Formats/AmigaADF.cpp
@@ -116,15 +116,15 @@ AmigaADF::AmigaADF(const std::string &file_name) :
 	if(file_.stats().st_size != 901120) throw Error::InvalidFormat;
 }
 
-HeadPosition AmigaADF::get_maximum_head_position() {
+HeadPosition AmigaADF::get_maximum_head_position() const {
 	return HeadPosition(80);
 }
 
-int AmigaADF::get_head_count() {
+int AmigaADF::get_head_count() const {
 	return 2;
 }
 
-std::unique_ptr<Track> AmigaADF::track_at_position(Track::Address address) {
+std::unique_ptr<Track> AmigaADF::track_at_position(Track::Address address) const {
 	using namespace Storage::Encodings;
 
 	// Create an MFM encoder.
@@ -182,6 +182,6 @@ std::unique_ptr<Track> AmigaADF::track_at_position(Track::Address address) {
 	return std::make_unique<Storage::Disk::PCMTrack>(std::move(encoded_segment));
 }
 
-long AmigaADF::get_file_offset_for_position(Track::Address address) {
+long AmigaADF::get_file_offset_for_position(Track::Address address) const {
 	return (address.position.as_int() * 2 + address.head) * 512 * 11;
 }

--- a/Storage/Disk/DiskImage/Formats/AmigaADF.hpp
+++ b/Storage/Disk/DiskImage/Formats/AmigaADF.hpp
@@ -29,13 +29,13 @@ public:
 	AmigaADF(const std::string &file_name);
 
 	// implemented to satisfy @c Disk
-	HeadPosition get_maximum_head_position() final;
-	int get_head_count() final;
-	std::unique_ptr<Track> track_at_position(Track::Address) final;
+	HeadPosition get_maximum_head_position() const;
+	int get_head_count() const;
+	std::unique_ptr<Track> track_at_position(Track::Address) const;
 
 private:
-	Storage::FileHolder file_;
-	long get_file_offset_for_position(Track::Address);
+	mutable Storage::FileHolder file_;
+	long get_file_offset_for_position(Track::Address) const;
 
 };
 

--- a/Storage/Disk/DiskImage/Formats/AmigaADF.hpp
+++ b/Storage/Disk/DiskImage/Formats/AmigaADF.hpp
@@ -32,6 +32,7 @@ public:
 	HeadPosition get_maximum_head_position() const;
 	int get_head_count() const;
 	std::unique_ptr<Track> track_at_position(Track::Address) const;
+	bool represents(const std::string &) const;
 
 private:
 	mutable Storage::FileHolder file_;

--- a/Storage/Disk/DiskImage/Formats/AppleDSK.cpp
+++ b/Storage/Disk/DiskImage/Formats/AppleDSK.cpp
@@ -42,26 +42,26 @@ AppleDSK::AppleDSK(const std::string &file_name) :
 	}
 }
 
-HeadPosition AppleDSK::get_maximum_head_position() {
+HeadPosition AppleDSK::get_maximum_head_position() const {
 	return HeadPosition(number_of_tracks);
 }
 
-bool AppleDSK::get_is_read_only() {
+bool AppleDSK::get_is_read_only() const {
 	return file_.get_is_known_read_only();
 }
 
-long AppleDSK::file_offset(Track::Address address) {
+long AppleDSK::file_offset(Track::Address address) const {
 	return address.position.as_int() * bytes_per_sector * sectors_per_track_;
 }
 
-size_t AppleDSK::logical_sector_for_physical_sector(size_t physical) {
+size_t AppleDSK::logical_sector_for_physical_sector(size_t physical) const {
 	// DOS and Pro DOS interleave sectors on disk, and they're represented in a disk
 	// image in physical order rather than logical.
 	if(physical == 15) return 15;
 	return (physical * (is_prodos_ ? 8 : 7)) % 15;
 }
 
-std::unique_ptr<Track> AppleDSK::track_at_position(Track::Address address) {
+std::unique_ptr<Track> AppleDSK::track_at_position(Track::Address address) const {
 	std::vector<uint8_t> track_data;
 	{
 		std::lock_guard lock_guard(file_.get_file_access_mutex());

--- a/Storage/Disk/DiskImage/Formats/AppleDSK.cpp
+++ b/Storage/Disk/DiskImage/Formats/AppleDSK.cpp
@@ -121,3 +121,7 @@ void AppleDSK::set_tracks(const std::map<Track::Address, std::unique_ptr<Track>>
 		file_.write(pair.second);
 	}
 }
+
+bool AppleDSK::represents(const std::string &name) const {
+	return name == file_.name();
+}

--- a/Storage/Disk/DiskImage/Formats/AppleDSK.hpp
+++ b/Storage/Disk/DiskImage/Formats/AppleDSK.hpp
@@ -30,18 +30,18 @@ public:
 	AppleDSK(const std::string &file_name);
 
 	// Implemented to satisfy @c DiskImage.
-	HeadPosition get_maximum_head_position() final;
-	std::unique_ptr<Track> track_at_position(Track::Address) final;
-	void set_tracks(const std::map<Track::Address, std::unique_ptr<Track>> &) final;
-	bool get_is_read_only() final;
+	HeadPosition get_maximum_head_position() const;
+	std::unique_ptr<Track> track_at_position(Track::Address) const;
+	void set_tracks(const std::map<Track::Address, std::unique_ptr<Track>> &);
+	bool get_is_read_only() const;
 
 private:
-	Storage::FileHolder file_;
+	mutable Storage::FileHolder file_;
 	int sectors_per_track_ = 16;
 	bool is_prodos_ = false;
 
-	long file_offset(Track::Address);
-	size_t logical_sector_for_physical_sector(size_t physical);
+	long file_offset(Track::Address) const;
+	size_t logical_sector_for_physical_sector(size_t physical) const;
 };
 
 }

--- a/Storage/Disk/DiskImage/Formats/AppleDSK.hpp
+++ b/Storage/Disk/DiskImage/Formats/AppleDSK.hpp
@@ -34,6 +34,7 @@ public:
 	std::unique_ptr<Track> track_at_position(Track::Address) const;
 	void set_tracks(const std::map<Track::Address, std::unique_ptr<Track>> &);
 	bool get_is_read_only() const;
+	bool represents(const std::string &) const;
 
 private:
 	mutable Storage::FileHolder file_;

--- a/Storage/Disk/DiskImage/Formats/CPCDSK.cpp
+++ b/Storage/Disk/DiskImage/Formats/CPCDSK.cpp
@@ -388,3 +388,7 @@ void CPCDSK::set_tracks(const std::map<::Storage::Disk::Track::Address, std::uni
 bool CPCDSK::get_is_read_only() const {
 	return is_read_only_;
 }
+
+bool CPCDSK::represents(const std::string &name) const {
+	return name == file_name_;
+}

--- a/Storage/Disk/DiskImage/Formats/CPCDSK.cpp
+++ b/Storage/Disk/DiskImage/Formats/CPCDSK.cpp
@@ -186,19 +186,19 @@ CPCDSK::CPCDSK(const std::string &file_name) :
 	}
 }
 
-HeadPosition CPCDSK::get_maximum_head_position() {
+HeadPosition CPCDSK::get_maximum_head_position() const {
 	return HeadPosition(head_position_count_);
 }
 
-int CPCDSK::get_head_count() {
+int CPCDSK::get_head_count() const {
 	return head_count_;
 }
 
-std::size_t CPCDSK::index_for_track(::Storage::Disk::Track::Address address) {
+std::size_t CPCDSK::index_for_track(::Storage::Disk::Track::Address address) const {
 	return size_t((address.position.as_int() * head_count_) + address.head);
 }
 
-std::unique_ptr<Track> CPCDSK::track_at_position(::Storage::Disk::Track::Address address) {
+std::unique_ptr<Track> CPCDSK::track_at_position(::Storage::Disk::Track::Address address) const {
 	// Given that thesea are interleaved images, determine which track, chronologically, is being requested.
 	const std::size_t chronological_track = index_for_track(address);
 
@@ -385,6 +385,6 @@ void CPCDSK::set_tracks(const std::map<::Storage::Disk::Track::Address, std::uni
 	}
 }
 
-bool CPCDSK::get_is_read_only() {
+bool CPCDSK::get_is_read_only() const {
 	return is_read_only_;
 }

--- a/Storage/Disk/DiskImage/Formats/CPCDSK.hpp
+++ b/Storage/Disk/DiskImage/Formats/CPCDSK.hpp
@@ -31,11 +31,11 @@ public:
 	CPCDSK(const std::string &file_name);
 
 	// DiskImage interface.
-	HeadPosition get_maximum_head_position() final;
-	int get_head_count() final;
-	bool get_is_read_only() final;
-	void set_tracks(const std::map<Track::Address, std::unique_ptr<Track>> &) final;
-	std::unique_ptr<::Storage::Disk::Track> track_at_position(::Storage::Disk::Track::Address) final;
+	HeadPosition get_maximum_head_position() const;
+	int get_head_count() const;
+	bool get_is_read_only() const;
+	void set_tracks(const std::map<Track::Address, std::unique_ptr<Track>> &);
+	std::unique_ptr<::Storage::Disk::Track> track_at_position(::Storage::Disk::Track::Address) const;
 
 private:
 	struct Track {
@@ -60,7 +60,7 @@ private:
 	};
 	std::string file_name_;
 	std::vector<std::unique_ptr<Track>> tracks_;
-	std::size_t index_for_track(::Storage::Disk::Track::Address address);
+	std::size_t index_for_track(::Storage::Disk::Track::Address address) const;
 
 	int head_count_;
 	int head_position_count_;

--- a/Storage/Disk/DiskImage/Formats/CPCDSK.hpp
+++ b/Storage/Disk/DiskImage/Formats/CPCDSK.hpp
@@ -34,6 +34,7 @@ public:
 	HeadPosition get_maximum_head_position() const;
 	int get_head_count() const;
 	bool get_is_read_only() const;
+	bool represents(const std::string &) const;
 	void set_tracks(const std::map<Track::Address, std::unique_ptr<Track>> &);
 	std::unique_ptr<::Storage::Disk::Track> track_at_position(::Storage::Disk::Track::Address) const;
 

--- a/Storage/Disk/DiskImage/Formats/D64.cpp
+++ b/Storage/Disk/DiskImage/Formats/D64.cpp
@@ -34,11 +34,11 @@ D64::D64(const std::string &file_name) :
 	}
 }
 
-HeadPosition D64::get_maximum_head_position() {
+HeadPosition D64::get_maximum_head_position() const {
 	return HeadPosition(number_of_tracks_);
 }
 
-std::unique_ptr<Track> D64::track_at_position(const Track::Address address) {
+std::unique_ptr<Track> D64::track_at_position(const Track::Address address) const {
 	// Figure out where this track starts on the disk.
 	int offset_to_track = 0;
 	int tracks_to_traverse = address.position.as_int();

--- a/Storage/Disk/DiskImage/Formats/D64.cpp
+++ b/Storage/Disk/DiskImage/Formats/D64.cpp
@@ -137,3 +137,7 @@ std::unique_ptr<Track> D64::track_at_position(const Track::Address address) cons
 
 	return std::make_unique<PCMTrack>(PCMSegment(data));
 }
+
+bool D64::represents(const std::string &name) const {
+	return name == file_.name();
+}

--- a/Storage/Disk/DiskImage/Formats/D64.hpp
+++ b/Storage/Disk/DiskImage/Formats/D64.hpp
@@ -26,11 +26,11 @@ public:
 	*/
 	D64(const std::string &file_name);
 
-	HeadPosition get_maximum_head_position() final;
-	std::unique_ptr<Track> track_at_position(Track::Address) final;
+	HeadPosition get_maximum_head_position() const;
+	std::unique_ptr<Track> track_at_position(Track::Address) const;
 
 private:
-	Storage::FileHolder file_;
+	mutable Storage::FileHolder file_;
 	int number_of_tracks_;
 	uint16_t disk_id_;
 };

--- a/Storage/Disk/DiskImage/Formats/D64.hpp
+++ b/Storage/Disk/DiskImage/Formats/D64.hpp
@@ -28,6 +28,7 @@ public:
 
 	HeadPosition get_maximum_head_position() const;
 	std::unique_ptr<Track> track_at_position(Track::Address) const;
+	bool represents(const std::string &) const;
 
 private:
 	mutable Storage::FileHolder file_;

--- a/Storage/Disk/DiskImage/Formats/DMK.cpp
+++ b/Storage/Disk/DiskImage/Formats/DMK.cpp
@@ -181,3 +181,7 @@ std::unique_ptr<::Storage::Disk::Track> DMK::track_at_position(const ::Storage::
 
 	return std::make_unique<PCMTrack>(segments);
 }
+
+bool DMK::represents(const std::string &name) const {
+	return name == file_.name();
+}

--- a/Storage/Disk/DiskImage/Formats/DMK.cpp
+++ b/Storage/Disk/DiskImage/Formats/DMK.cpp
@@ -61,25 +61,25 @@ DMK::DMK(const std::string &file_name) :
 	if(format) throw Error::InvalidFormat;
 }
 
-HeadPosition DMK::get_maximum_head_position() {
+HeadPosition DMK::get_maximum_head_position() const {
 	return HeadPosition(head_position_count_);
 }
 
-int DMK::get_head_count() {
+int DMK::get_head_count() const {
 	return head_count_;
 }
 
-bool DMK::get_is_read_only() {
+bool DMK::get_is_read_only() const {
 	return true;
 	// Given that track serialisation is not yet implemented, treat all DMKs as read-only.
 //	return is_read_only_;
 }
 
-long DMK::get_file_offset_for_position(Track::Address address) {
+long DMK::get_file_offset_for_position(const Track::Address address) const {
 	return (address.head*head_count_ + address.position.as_int()) * track_length_ + 16;
 }
 
-std::unique_ptr<::Storage::Disk::Track> DMK::track_at_position(::Storage::Disk::Track::Address address) {
+std::unique_ptr<::Storage::Disk::Track> DMK::track_at_position(const ::Storage::Disk::Track::Address address) const {
 	file_.seek(get_file_offset_for_position(address), SEEK_SET);
 
 	// Read the IDAM table.

--- a/Storage/Disk/DiskImage/Formats/DMK.hpp
+++ b/Storage/Disk/DiskImage/Formats/DMK.hpp
@@ -28,16 +28,15 @@ public:
 	*/
 	DMK(const std::string &file_name);
 
-	// implemented to satisfy @c Disk
-	HeadPosition get_maximum_head_position() final;
-	int get_head_count() final;
-	bool get_is_read_only() final;
+	HeadPosition get_maximum_head_position() const;
+	int get_head_count() const;
+	bool get_is_read_only() const;
 
-	std::unique_ptr<Track> track_at_position(Track::Address) final;
+	std::unique_ptr<Track> track_at_position(Track::Address) const;
 
 private:
-	FileHolder file_;
-	long get_file_offset_for_position(Track::Address address);
+	mutable FileHolder file_;
+	long get_file_offset_for_position(Track::Address address) const;
 
 	bool is_read_only_;
 	int head_position_count_;

--- a/Storage/Disk/DiskImage/Formats/DMK.hpp
+++ b/Storage/Disk/DiskImage/Formats/DMK.hpp
@@ -31,6 +31,7 @@ public:
 	HeadPosition get_maximum_head_position() const;
 	int get_head_count() const;
 	bool get_is_read_only() const;
+	bool represents(const std::string &) const;
 
 	std::unique_ptr<Track> track_at_position(Track::Address) const;
 

--- a/Storage/Disk/DiskImage/Formats/FAT12.cpp
+++ b/Storage/Disk/DiskImage/Formats/FAT12.cpp
@@ -49,14 +49,14 @@ FAT12::FAT12(const std::string &file_name) :
 	);
 }
 
-HeadPosition FAT12::get_maximum_head_position() {
+HeadPosition FAT12::get_maximum_head_position() const {
 	return HeadPosition(track_count_);
 }
 
-int FAT12::get_head_count() {
+int FAT12::get_head_count() const {
 	return head_count_;
 }
 
-long FAT12::get_file_offset_for_position(Track::Address address) {
+long FAT12::get_file_offset_for_position(Track::Address address) const {
 	return (address.position.as_int() * head_count_ + address.head) * sector_size_ * sector_count_;
 }

--- a/Storage/Disk/DiskImage/Formats/FAT12.hpp
+++ b/Storage/Disk/DiskImage/Formats/FAT12.hpp
@@ -21,11 +21,11 @@ namespace Storage::Disk {
 class FAT12: public MFMSectorDump {
 public:
 	FAT12(const std::string &file_name);
-	HeadPosition get_maximum_head_position() final;
-	int get_head_count() final;
+	HeadPosition get_maximum_head_position() const final;
+	int get_head_count() const final;
 
 private:
-	long get_file_offset_for_position(Track::Address address) final;
+	long get_file_offset_for_position(Track::Address address) const;
 
 	int head_count_;
 	int track_count_;

--- a/Storage/Disk/DiskImage/Formats/G64.cpp
+++ b/Storage/Disk/DiskImage/Formats/G64.cpp
@@ -105,3 +105,7 @@ std::unique_ptr<Track> G64::track_at_position(const Track::Address address) cons
 	// TODO: find out whether it's possible for a G64 to supply only a partial track. I don't think it is, which
 	// would make the above correct but supposing I'm wrong, the above would produce some incorrectly clocked tracks.
 }
+
+bool G64::represents(const std::string &name) const {
+	return name == file_.name();
+}

--- a/Storage/Disk/DiskImage/Formats/G64.cpp
+++ b/Storage/Disk/DiskImage/Formats/G64.cpp
@@ -30,13 +30,13 @@ G64::G64(const std::string &file_name) :
 	maximum_track_size_ = file_.get_le<uint16_t>();
 }
 
-HeadPosition G64::get_maximum_head_position() {
+HeadPosition G64::get_maximum_head_position() const {
 	// give at least 84 tracks, to yield the normal geometry but,
 	// if there are more, shove them in
 	return HeadPosition(number_of_tracks_ > 84 ? number_of_tracks_ : 84, 2);
 }
 
-std::unique_ptr<Track> G64::track_at_position(Track::Address address) {
+std::unique_ptr<Track> G64::track_at_position(const Track::Address address) const {
 	// seek to this track's entry in the track table
 	file_.seek(long((address.position.as_half() * 4) + 0xc), SEEK_SET);
 

--- a/Storage/Disk/DiskImage/Formats/G64.hpp
+++ b/Storage/Disk/DiskImage/Formats/G64.hpp
@@ -33,6 +33,7 @@ public:
 	HeadPosition get_maximum_head_position() const;
 	std::unique_ptr<Track> track_at_position(Track::Address) const;
 	using DiskImage::get_is_read_only;
+	bool represents(const std::string &) const;
 
 private:
 	mutable Storage::FileHolder file_;

--- a/Storage/Disk/DiskImage/Formats/G64.hpp
+++ b/Storage/Disk/DiskImage/Formats/G64.hpp
@@ -30,12 +30,12 @@ public:
 	G64(const std::string &file_name);
 
 	// implemented to satisfy @c Disk
-	HeadPosition get_maximum_head_position() final;
-	std::unique_ptr<Track> track_at_position(Track::Address) final;
+	HeadPosition get_maximum_head_position() const;
+	std::unique_ptr<Track> track_at_position(Track::Address) const;
 	using DiskImage::get_is_read_only;
 
 private:
-	Storage::FileHolder file_;
+	mutable Storage::FileHolder file_;
 	uint8_t number_of_tracks_;
 	uint16_t maximum_track_size_;
 };

--- a/Storage/Disk/DiskImage/Formats/HFE.cpp
+++ b/Storage/Disk/DiskImage/Formats/HFE.cpp
@@ -128,3 +128,7 @@ void HFE::set_tracks(const std::map<Track::Address, std::unique_ptr<Track>> &tra
 bool HFE::get_is_read_only() const {
 	return file_.get_is_known_read_only();
 }
+
+bool HFE::represents(const std::string &name) const {
+	return name == file_.name();
+}

--- a/Storage/Disk/DiskImage/Formats/HFE.cpp
+++ b/Storage/Disk/DiskImage/Formats/HFE.cpp
@@ -25,11 +25,11 @@ HFE::HFE(const std::string &file_name) :
 	track_list_offset_ = long(file_.get_le<uint16_t>()) << 9;
 }
 
-HeadPosition HFE::get_maximum_head_position() {
+HeadPosition HFE::get_maximum_head_position() const {
 	return HeadPosition(track_count_);
 }
 
-int HFE::get_head_count() {
+int HFE::get_head_count() const {
 	return head_count_;
 }
 
@@ -40,7 +40,7 @@ int HFE::get_head_count() {
 	To read the track, start from the current file position, read 256 bytes,
 	skip 256 bytes, read 256 bytes, skip 256 bytes, etc.
 */
-uint16_t HFE::seek_track(Track::Address address) {
+uint16_t HFE::seek_track(const Track::Address address) const {
 	// Get track position and length from the lookup table; data is then always interleaved
 	// based on an assumption of two heads.
 	file_.seek(track_list_offset_ + address.position.as_int() * 4, SEEK_SET);
@@ -54,7 +54,7 @@ uint16_t HFE::seek_track(Track::Address address) {
 	return track_length / 2;	// Divide by two to give the track length for a single side.
 }
 
-std::unique_ptr<Track> HFE::track_at_position(Track::Address address) {
+std::unique_ptr<Track> HFE::track_at_position(const Track::Address address) const {
 	PCMSegment segment;
 	{
 		std::lock_guard lock_guard(file_.get_file_access_mutex());
@@ -125,6 +125,6 @@ void HFE::set_tracks(const std::map<Track::Address, std::unique_ptr<Track>> &tra
 	}
 }
 
-bool HFE::get_is_read_only() {
+bool HFE::get_is_read_only() const {
 	return file_.get_is_known_read_only();
 }

--- a/Storage/Disk/DiskImage/Formats/HFE.hpp
+++ b/Storage/Disk/DiskImage/Formats/HFE.hpp
@@ -30,15 +30,15 @@ public:
 	HFE(const std::string &file_name);
 
 	// implemented to satisfy @c Disk
-	HeadPosition get_maximum_head_position() final;
-	int get_head_count() final;
-	bool get_is_read_only() final;
-	void set_tracks(const std::map<Track::Address, std::unique_ptr<Track>> &tracks) final;
-	std::unique_ptr<Track> track_at_position(Track::Address) final;
+	HeadPosition get_maximum_head_position() const;
+	int get_head_count() const;
+	bool get_is_read_only() const;
+	void set_tracks(const std::map<Track::Address, std::unique_ptr<Track>> &tracks);
+	std::unique_ptr<Track> track_at_position(Track::Address) const;
 
 private:
-	Storage::FileHolder file_;
-	uint16_t seek_track(Track::Address address);
+	mutable Storage::FileHolder file_;
+	uint16_t seek_track(Track::Address address) const;
 
 	int head_count_;
 	int track_count_;

--- a/Storage/Disk/DiskImage/Formats/HFE.hpp
+++ b/Storage/Disk/DiskImage/Formats/HFE.hpp
@@ -33,6 +33,7 @@ public:
 	HeadPosition get_maximum_head_position() const;
 	int get_head_count() const;
 	bool get_is_read_only() const;
+	bool represents(const std::string &) const;
 	void set_tracks(const std::map<Track::Address, std::unique_ptr<Track>> &tracks);
 	std::unique_ptr<Track> track_at_position(Track::Address) const;
 

--- a/Storage/Disk/DiskImage/Formats/IMD.cpp
+++ b/Storage/Disk/DiskImage/Formats/IMD.cpp
@@ -98,6 +98,10 @@ int IMD::get_head_count() const {
 	return heads_ + 1;
 }
 
+bool IMD::represents(const std::string &name) const {
+	return name == file_.name();
+}
+
 std::unique_ptr<Track> IMD::track_at_position(const Track::Address address) const {
 	auto location = track_locations_.find(address);
 	if(location == track_locations_.end()) {

--- a/Storage/Disk/DiskImage/Formats/IMD.cpp
+++ b/Storage/Disk/DiskImage/Formats/IMD.cpp
@@ -90,15 +90,15 @@ IMD::IMD(const std::string &file_name) : file_(file_name) {
 	++ heads_;
 }
 
-HeadPosition IMD::get_maximum_head_position() {
+HeadPosition IMD::get_maximum_head_position() const {
 	return HeadPosition(cylinders_);
 }
 
-int IMD::get_head_count() {
+int IMD::get_head_count() const {
 	return heads_ + 1;
 }
 
-std::unique_ptr<Track> IMD::track_at_position(Track::Address address) {
+std::unique_ptr<Track> IMD::track_at_position(const Track::Address address) const {
 	auto location = track_locations_.find(address);
 	if(location == track_locations_.end()) {
 		return nullptr;

--- a/Storage/Disk/DiskImage/Formats/IMD.hpp
+++ b/Storage/Disk/DiskImage/Formats/IMD.hpp
@@ -29,12 +29,12 @@ public:
 	IMD(const std::string &file_name);
 
 	// DiskImage interface.
-	HeadPosition get_maximum_head_position() final;
-	int get_head_count() final;
-	std::unique_ptr<Track> track_at_position(Track::Address) final;
+	HeadPosition get_maximum_head_position() const;
+	int get_head_count() const;
+	std::unique_ptr<Track> track_at_position(Track::Address) const;
 
 private:
-	FileHolder file_;
+	mutable FileHolder file_;
 	std::map<Storage::Disk::Track::Address, long> track_locations_;
 	uint8_t cylinders_ = 0, heads_ = 0;
 };

--- a/Storage/Disk/DiskImage/Formats/IMD.hpp
+++ b/Storage/Disk/DiskImage/Formats/IMD.hpp
@@ -31,6 +31,7 @@ public:
 	// DiskImage interface.
 	HeadPosition get_maximum_head_position() const;
 	int get_head_count() const;
+	bool represents(const std::string &) const;
 	std::unique_ptr<Track> track_at_position(Track::Address) const;
 
 private:

--- a/Storage/Disk/DiskImage/Formats/IPF.cpp
+++ b/Storage/Disk/DiskImage/Formats/IPF.cpp
@@ -109,7 +109,7 @@ IPF::IPF(const std::string &file_name) : file_(file_name) {
 
 				// If the file didn't declare anything, default to supporting everything.
 				if(!platform_type_) {
-					platform_type_ = ~0;
+					platform_type_ = ~TargetPlatform::IntType(0);
 				}
 
 				// Ignore: disk number, creator ID, reserved area.
@@ -178,15 +178,15 @@ IPF::IPF(const std::string &file_name) : file_(file_name) {
 	}
 }
 
-HeadPosition IPF::get_maximum_head_position() {
+HeadPosition IPF::get_maximum_head_position() const {
 	return HeadPosition(track_count_);
 }
 
-int IPF::get_head_count() {
+int IPF::get_head_count() const {
 	return head_count_;
 }
 
-std::unique_ptr<Track> IPF::track_at_position([[maybe_unused]] Track::Address address) {
+std::unique_ptr<Track> IPF::track_at_position(const Track::Address address) const {
 	// Get the track description, if it exists, and check either that the file has contents for the track.
 	auto pair = tracks_.find(address);
 	if(pair == tracks_.end()) {
@@ -322,7 +322,7 @@ std::unique_ptr<Track> IPF::track_at_position([[maybe_unused]] Track::Address ad
 /// densities (or, equivalently, lengths) in the file, densities are named according to their protection scheme and the decoder
 /// is required to know all named protection schemes. Which makes IPF unable to handle arbitrary disks (or, indeed, disks
 /// with multiple protection schemes on a single track).
-Storage::Time IPF::bit_length(TrackDescription::Density density, int block) {
+Storage::Time IPF::bit_length(TrackDescription::Density density, int block) const {
 	constexpr unsigned int us = 100'000'000;
 	static constexpr auto us170 = Storage::Time::simplified(170, us);
 	static constexpr auto us180 = Storage::Time::simplified(180, us);
@@ -378,7 +378,7 @@ Storage::Time IPF::bit_length(TrackDescription::Density density, int block) {
 	return us200;	// i.e. default to 2µs.
 }
 
-void IPF::add_gap(std::vector<Storage::Disk::PCMSegment> &track, Time bit_length, size_t num_bits, uint32_t value) {
+void IPF::add_gap(std::vector<Storage::Disk::PCMSegment> &track, Time bit_length, size_t num_bits, uint32_t value) const {
 	auto &segment = track.emplace_back();
 	segment.length_of_a_bit = bit_length;
 
@@ -396,7 +396,7 @@ void IPF::add_gap(std::vector<Storage::Disk::PCMSegment> &track, Time bit_length
 	segment.data.resize(num_bits);
 }
 
-void IPF::add_unencoded_data(std::vector<Storage::Disk::PCMSegment> &track, Time bit_length, size_t num_bits) {
+void IPF::add_unencoded_data(std::vector<Storage::Disk::PCMSegment> &track, Time bit_length, size_t num_bits) const {
 	auto &segment = track.emplace_back();
 	segment.length_of_a_bit = bit_length;
 
@@ -415,7 +415,7 @@ void IPF::add_unencoded_data(std::vector<Storage::Disk::PCMSegment> &track, Time
 	segment.data.resize(num_bits * 2);
 }
 
-void IPF::add_raw_data(std::vector<Storage::Disk::PCMSegment> &track, Time bit_length, size_t num_bits) {
+void IPF::add_raw_data(std::vector<Storage::Disk::PCMSegment> &track, Time bit_length, size_t num_bits) const {
 	auto &segment = track.emplace_back();
 	segment.length_of_a_bit = bit_length;
 

--- a/Storage/Disk/DiskImage/Formats/IPF.cpp
+++ b/Storage/Disk/DiskImage/Formats/IPF.cpp
@@ -437,3 +437,7 @@ void IPF::add_raw_data(std::vector<Storage::Disk::PCMSegment> &track, Time bit_l
 	assert(segment.data.size() <= num_bits_ceiling);
 	segment.data.resize(num_bits);
 }
+
+bool IPF::represents(const std::string &name) const {
+	return name == file_.name();
+}

--- a/Storage/Disk/DiskImage/Formats/IPF.hpp
+++ b/Storage/Disk/DiskImage/Formats/IPF.hpp
@@ -39,6 +39,7 @@ public:
 	HeadPosition get_maximum_head_position() const;
 	int get_head_count() const;
 	std::unique_ptr<Track> track_at_position(Track::Address) const;
+	bool represents(const std::string &) const;
 
 private:
 	mutable Storage::FileHolder file_;

--- a/Storage/Disk/DiskImage/Formats/IPF.hpp
+++ b/Storage/Disk/DiskImage/Formats/IPF.hpp
@@ -36,12 +36,12 @@ public:
 	IPF(const std::string &file_name);
 
 	// implemented to satisfy @c Disk
-	HeadPosition get_maximum_head_position() final;
-	int get_head_count() final;
-	std::unique_ptr<Track> track_at_position(Track::Address) final;
+	HeadPosition get_maximum_head_position() const;
+	int get_head_count() const;
+	std::unique_ptr<Track> track_at_position(Track::Address) const;
 
 private:
-	Storage::FileHolder file_;
+	mutable Storage::FileHolder file_;
 	uint16_t seek_track(Track::Address address);
 
 	struct TrackDescription {
@@ -77,10 +77,10 @@ private:
 	}
 	TargetPlatform::IntType platform_type_ = TargetPlatform::Amiga;
 
-	Time bit_length(TrackDescription::Density, int block);
-	void add_gap(std::vector<Storage::Disk::PCMSegment> &, Time bit_length, size_t num_bits, uint32_t value);
-	void add_unencoded_data(std::vector<Storage::Disk::PCMSegment> &, Time bit_length, size_t num_bits);
-	void add_raw_data(std::vector<Storage::Disk::PCMSegment> &, Time bit_length, size_t num_bits);
+	Time bit_length(TrackDescription::Density, int block) const;
+	void add_gap(std::vector<Storage::Disk::PCMSegment> &, Time bit_length, size_t num_bits, uint32_t value) const;
+	void add_unencoded_data(std::vector<Storage::Disk::PCMSegment> &, Time bit_length, size_t num_bits) const;
+	void add_raw_data(std::vector<Storage::Disk::PCMSegment> &, Time bit_length, size_t num_bits) const;
 };
 
 }

--- a/Storage/Disk/DiskImage/Formats/MFMSectorDump.cpp
+++ b/Storage/Disk/DiskImage/Formats/MFMSectorDump.cpp
@@ -71,3 +71,7 @@ void MFMSectorDump::set_tracks(const std::map<Track::Address, std::unique_ptr<Tr
 bool MFMSectorDump::get_is_read_only() const {
 	return file_.get_is_known_read_only();
 }
+
+bool MFMSectorDump::represents(const std::string &name) const {
+	return name == file_.name();
+}

--- a/Storage/Disk/DiskImage/Formats/MFMSectorDump.cpp
+++ b/Storage/Disk/DiskImage/Formats/MFMSectorDump.cpp
@@ -21,7 +21,7 @@ void MFMSectorDump::set_geometry(int sectors_per_track, uint8_t sector_size, uin
 	first_sector_ = first_sector;
 }
 
-std::unique_ptr<Track> MFMSectorDump::track_at_position(Track::Address address) {
+std::unique_ptr<Track> MFMSectorDump::track_at_position(Track::Address address) const {
 	if(address.head >= get_head_count()) return nullptr;
 	if(address.position.as_largest() >= get_maximum_head_position().as_largest()) return nullptr;
 
@@ -68,6 +68,6 @@ void MFMSectorDump::set_tracks(const std::map<Track::Address, std::unique_ptr<Tr
 	file_.flush();
 }
 
-bool MFMSectorDump::get_is_read_only() {
+bool MFMSectorDump::get_is_read_only() const {
 	return file_.get_is_known_read_only();
 }

--- a/Storage/Disk/DiskImage/Formats/MFMSectorDump.hpp
+++ b/Storage/Disk/DiskImage/Formats/MFMSectorDump.hpp
@@ -23,16 +23,18 @@ class MFMSectorDump: public DiskImage {
 public:
 	MFMSectorDump(const std::string &file_name);
 
-	bool get_is_read_only() final;
-	void set_tracks(const std::map<Track::Address, std::unique_ptr<Track>> &tracks) final;
-	std::unique_ptr<Track> track_at_position(Track::Address) final;
+	bool get_is_read_only() const;
+	void set_tracks(const std::map<Track::Address, std::unique_ptr<Track>> &tracks);
+	std::unique_ptr<Track> track_at_position(Track::Address) const;
 
 protected:
-	Storage::FileHolder file_;
-	void set_geometry(int sectors_per_track, uint8_t sector_size, uint8_t first_sector, Encodings::MFM::Density density);
+	mutable Storage::FileHolder file_;
+	void set_geometry(int sectors_per_track, uint8_t sector_size, uint8_t first_sector, Encodings::MFM::Density);
 
 private:
-	virtual long get_file_offset_for_position(Track::Address address) = 0;
+	virtual int get_head_count() const = 0;
+	virtual HeadPosition get_maximum_head_position() const = 0;
+	virtual long get_file_offset_for_position(Track::Address) const = 0;
 
 	int sectors_per_track_ = 0;
 	uint8_t sector_size_ = 0;

--- a/Storage/Disk/DiskImage/Formats/MFMSectorDump.hpp
+++ b/Storage/Disk/DiskImage/Formats/MFMSectorDump.hpp
@@ -24,6 +24,7 @@ public:
 	MFMSectorDump(const std::string &file_name);
 
 	bool get_is_read_only() const;
+	bool represents(const std::string &) const;
 	void set_tracks(const std::map<Track::Address, std::unique_ptr<Track>> &tracks);
 	std::unique_ptr<Track> track_at_position(Track::Address) const;
 

--- a/Storage/Disk/DiskImage/Formats/MSA.cpp
+++ b/Storage/Disk/DiskImage/Formats/MSA.cpp
@@ -94,3 +94,7 @@ HeadPosition MSA::get_maximum_head_position() const {
 int MSA::get_head_count() const {
 	return sides_;
 }
+
+bool MSA::represents(const std::string &name) const {
+	return name == file_.name();
+}

--- a/Storage/Disk/DiskImage/Formats/MSA.cpp
+++ b/Storage/Disk/DiskImage/Formats/MSA.cpp
@@ -75,7 +75,7 @@ MSA::MSA(const std::string &file_name) :
 		throw Error::InvalidFormat;
 }
 
-std::unique_ptr<Track> MSA::track_at_position(Track::Address address) {
+std::unique_ptr<Track> MSA::track_at_position(Track::Address address) const {
 	if(address.head >= sides_) return nullptr;
 
 	const auto position = address.position.as_int();
@@ -87,10 +87,10 @@ std::unique_ptr<Track> MSA::track_at_position(Track::Address address) {
 	return track_for_sectors(track.data(), sectors_per_track_, uint8_t(position), uint8_t(address.head), 1, 2, Storage::Encodings::MFM::Density::Double);
 }
 
-HeadPosition MSA::get_maximum_head_position() {
+HeadPosition MSA::get_maximum_head_position() const {
 	return HeadPosition(ending_track_ + 1);
 }
 
-int MSA::get_head_count() {
+int MSA::get_head_count() const {
 	return sides_;
 }

--- a/Storage/Disk/DiskImage/Formats/MSA.hpp
+++ b/Storage/Disk/DiskImage/Formats/MSA.hpp
@@ -24,13 +24,13 @@ public:
 	MSA(const std::string &file_name);
 
 	// Implemented to satisfy @c DiskImage.
-	HeadPosition get_maximum_head_position() final;
-	int get_head_count() final;
-	std::unique_ptr<Track> track_at_position(Track::Address) final;
-	bool get_is_read_only() final { return false; }
+	HeadPosition get_maximum_head_position() const;
+	int get_head_count() const;
+	std::unique_ptr<Track> track_at_position(Track::Address) const;
+	bool get_is_read_only() const { return false; }
 
 private:
-	FileHolder file_;
+	mutable FileHolder file_;
 	uint16_t sectors_per_track_;
 	uint16_t sides_;
 	uint16_t starting_track_;

--- a/Storage/Disk/DiskImage/Formats/MSA.hpp
+++ b/Storage/Disk/DiskImage/Formats/MSA.hpp
@@ -28,6 +28,7 @@ public:
 	int get_head_count() const;
 	std::unique_ptr<Track> track_at_position(Track::Address) const;
 	bool get_is_read_only() const { return false; }
+	bool represents(const std::string &) const;
 
 private:
 	mutable FileHolder file_;

--- a/Storage/Disk/DiskImage/Formats/MacintoshIMG.cpp
+++ b/Storage/Disk/DiskImage/Formats/MacintoshIMG.cpp
@@ -143,7 +143,7 @@ void MacintoshIMG::construct_raw_gcr(size_t offset, size_t size) {
 	}
 }
 
-uint32_t MacintoshIMG::checksum(const std::vector<uint8_t> &data, size_t bytes_to_skip) {
+uint32_t MacintoshIMG::checksum(const std::vector<uint8_t> &data, size_t bytes_to_skip) const {
 	uint32_t result = 0;
 
 	// Checksum algorithm is: take each two bytes as a big-endian word; add that to a
@@ -157,21 +157,21 @@ uint32_t MacintoshIMG::checksum(const std::vector<uint8_t> &data, size_t bytes_t
 	return result;
 }
 
-HeadPosition MacintoshIMG::get_maximum_head_position() {
+HeadPosition MacintoshIMG::get_maximum_head_position() const {
 	return HeadPosition(80);
 }
 
-int MacintoshIMG::get_head_count() {
+int MacintoshIMG::get_head_count() const {
 	// Bit 5 in the format field indicates whether this disk is double
 	// sided, regardless of whether it is GCR or MFM.
 	return 1 + ((format_ & 0x20) >> 5);
 }
 
-bool MacintoshIMG::get_is_read_only() {
+bool MacintoshIMG::get_is_read_only() const {
 	return file_.get_is_known_read_only();
 }
 
-std::unique_ptr<Track> MacintoshIMG::track_at_position(Track::Address address) {
+std::unique_ptr<Track> MacintoshIMG::track_at_position(Track::Address address) const {
 	/*
 		The format_ byte has the following meanings:
 
@@ -197,8 +197,8 @@ std::unique_ptr<Track> MacintoshIMG::track_at_position(Track::Address address) {
 
 		if(start_sector*512 >= data_.size()) return nullptr;
 
-		uint8_t *const sector = &data_[512 * start_sector];
-		uint8_t *const tags = tags_.size() ? &tags_[12 * start_sector] : nullptr;
+		const uint8_t *const sector = &data_[512 * start_sector];
+		const uint8_t *const tags = tags_.size() ? &tags_[12 * start_sector] : nullptr;
 
 		Storage::Disk::PCMSegment segment;
 		segment += Encodings::AppleGCR::six_and_two_sync(24);

--- a/Storage/Disk/DiskImage/Formats/MacintoshIMG.cpp
+++ b/Storage/Disk/DiskImage/Formats/MacintoshIMG.cpp
@@ -171,6 +171,11 @@ bool MacintoshIMG::get_is_read_only() const {
 	return file_.get_is_known_read_only();
 }
 
+bool MacintoshIMG::represents(const std::string &name) const {
+	return name == file_.name();
+}
+
+
 std::unique_ptr<Track> MacintoshIMG::track_at_position(Track::Address address) const {
 	/*
 		The format_ byte has the following meanings:

--- a/Storage/Disk/DiskImage/Formats/MacintoshIMG.hpp
+++ b/Storage/Disk/DiskImage/Formats/MacintoshIMG.hpp
@@ -43,15 +43,15 @@ public:
 	MacintoshIMG(const std::string &file_name, FixedType type, size_t offset = 0, size_t length = 0);
 
 	// implemented to satisfy @c Disk
-	HeadPosition get_maximum_head_position() final;
-	int get_head_count() final;
-	bool get_is_read_only() final;
+	HeadPosition get_maximum_head_position() const;
+	int get_head_count() const;
+	bool get_is_read_only() const;
 
-	std::unique_ptr<Track> track_at_position(Track::Address) final;
-	void set_tracks(const std::map<Track::Address, std::unique_ptr<Track>> &tracks) final;
+	std::unique_ptr<Track> track_at_position(Track::Address) const;
+	void set_tracks(const std::map<Track::Address, std::unique_ptr<Track>> &tracks);
 
 private:
-	Storage::FileHolder file_;
+	mutable Storage::FileHolder file_;
 
 	enum class Encoding {
 		GCR400,
@@ -64,9 +64,9 @@ private:
 	std::vector<uint8_t> data_;
 	std::vector<uint8_t> tags_;
 	bool is_diskCopy_file_ = false;
-	std::mutex buffer_mutex_;
+	mutable std::mutex buffer_mutex_;
 
-	uint32_t checksum(const std::vector<uint8_t> &, size_t bytes_to_skip = 0);
+	uint32_t checksum(const std::vector<uint8_t> &, size_t bytes_to_skip = 0) const;
 	void construct_raw_gcr(size_t offset, size_t length = 0);
 	long raw_offset_ = 0;
 };

--- a/Storage/Disk/DiskImage/Formats/MacintoshIMG.hpp
+++ b/Storage/Disk/DiskImage/Formats/MacintoshIMG.hpp
@@ -46,6 +46,7 @@ public:
 	HeadPosition get_maximum_head_position() const;
 	int get_head_count() const;
 	bool get_is_read_only() const;
+	bool represents(const std::string &) const;
 
 	std::unique_ptr<Track> track_at_position(Track::Address) const;
 	void set_tracks(const std::map<Track::Address, std::unique_ptr<Track>> &tracks);

--- a/Storage/Disk/DiskImage/Formats/NIB.cpp
+++ b/Storage/Disk/DiskImage/Formats/NIB.cpp
@@ -50,6 +50,10 @@ bool NIB::get_is_read_only() const {
 	return file_.get_is_known_read_only();
 }
 
+bool NIB::represents(const std::string &name) const {
+	return name == file_.name();
+}
+
 long NIB::file_offset(const Track::Address address) const {
 	return long(address.position.as_int()) * track_length;
 }
@@ -189,3 +193,4 @@ void NIB::set_tracks(const std::map<Track::Address, std::unique_ptr<Track>> &tra
 		file_.write(track.second);
 	}
 }
+

--- a/Storage/Disk/DiskImage/Formats/NIB.cpp
+++ b/Storage/Disk/DiskImage/Formats/NIB.cpp
@@ -42,26 +42,26 @@ NIB::NIB(const std::string &file_name) :
 	}
 }
 
-HeadPosition NIB::get_maximum_head_position() {
+HeadPosition NIB::get_maximum_head_position() const {
 	return HeadPosition(number_of_tracks);
 }
 
-bool NIB::get_is_read_only() {
+bool NIB::get_is_read_only() const {
 	return file_.get_is_known_read_only();
 }
 
-long NIB::file_offset(Track::Address address) {
+long NIB::file_offset(const Track::Address address) const {
 	return long(address.position.as_int()) * track_length;
 }
 
-Track::Address NIB::canonical_address(Track::Address address) {
+Track::Address NIB::canonical_address(const Track::Address address) const {
 	return Track::Address(
 		address.head,
 		HeadPosition(address.position.as_int())
 	);
 }
 
-std::unique_ptr<Track> NIB::track_at_position(Track::Address address) {
+std::unique_ptr<Track> NIB::track_at_position(const Track::Address address) const {
 	static constexpr size_t MinimumSyncByteCount = 4;
 
 	// NIBs contain data for a fixed quantity of integer-position tracks underneath a single head only.

--- a/Storage/Disk/DiskImage/Formats/NIB.hpp
+++ b/Storage/Disk/DiskImage/Formats/NIB.hpp
@@ -26,16 +26,16 @@ public:
 	NIB(const std::string &file_name);
 
 	// Implemented to satisfy @c DiskImage.
-	HeadPosition get_maximum_head_position() final;
-	Track::Address canonical_address(Track::Address) final;
-	std::unique_ptr<Track> track_at_position(Track::Address) final;
-	void set_tracks(const std::map<Track::Address, std::unique_ptr<Track>> &tracks) final;
-	bool get_is_read_only() final;
+	HeadPosition get_maximum_head_position() const;
+	Track::Address canonical_address(Track::Address) const;
+	std::unique_ptr<Track> track_at_position(Track::Address) const;
+	void set_tracks(const std::map<Track::Address, std::unique_ptr<Track>> &tracks);
+	bool get_is_read_only() const;
 
 private:
-	FileHolder file_;
-	long get_file_offset_for_position(Track::Address address);
-	long file_offset(Track::Address address);
+	mutable FileHolder file_;
+	long get_file_offset_for_position(Track::Address address) const;
+	long file_offset(Track::Address address) const;
 };
 
 }

--- a/Storage/Disk/DiskImage/Formats/NIB.hpp
+++ b/Storage/Disk/DiskImage/Formats/NIB.hpp
@@ -31,6 +31,7 @@ public:
 	std::unique_ptr<Track> track_at_position(Track::Address) const;
 	void set_tracks(const std::map<Track::Address, std::unique_ptr<Track>> &tracks);
 	bool get_is_read_only() const;
+	bool represents(const std::string &) const;
 
 private:
 	mutable FileHolder file_;

--- a/Storage/Disk/DiskImage/Formats/OricMFMDSK.cpp
+++ b/Storage/Disk/DiskImage/Formats/OricMFMDSK.cpp
@@ -167,3 +167,7 @@ void OricMFMDSK::set_tracks(const std::map<Track::Address, std::unique_ptr<Track
 bool OricMFMDSK::get_is_read_only() const {
 	return file_.get_is_known_read_only();
 }
+
+bool OricMFMDSK::represents(const std::string &name) const {
+	return name == file_.name();
+}

--- a/Storage/Disk/DiskImage/Formats/OricMFMDSK.cpp
+++ b/Storage/Disk/DiskImage/Formats/OricMFMDSK.cpp
@@ -29,15 +29,15 @@ OricMFMDSK::OricMFMDSK(const std::string &file_name) :
 		throw Error::InvalidFormat;
 }
 
-HeadPosition OricMFMDSK::get_maximum_head_position() {
+HeadPosition OricMFMDSK::get_maximum_head_position() const {
 	return HeadPosition(int(track_count_));
 }
 
-int OricMFMDSK::get_head_count() {
+int OricMFMDSK::get_head_count() const {
 	return int(head_count_);
 }
 
-long OricMFMDSK::get_file_offset_for_position(Track::Address address) {
+long OricMFMDSK::get_file_offset_for_position(Track::Address address) const {
 	int seek_offset = 0;
 	switch(geometry_type_) {
 		case 1:
@@ -50,7 +50,7 @@ long OricMFMDSK::get_file_offset_for_position(Track::Address address) {
 	return long(seek_offset) * 6400 + 256;
 }
 
-std::unique_ptr<Track> OricMFMDSK::track_at_position(Track::Address address) {
+std::unique_ptr<Track> OricMFMDSK::track_at_position(const Track::Address address) const {
 	PCMSegment segment;
 	{
 		std::lock_guard lock_guard(file_.get_file_access_mutex());
@@ -164,6 +164,6 @@ void OricMFMDSK::set_tracks(const std::map<Track::Address, std::unique_ptr<Track
 	}
 }
 
-bool OricMFMDSK::get_is_read_only() {
+bool OricMFMDSK::get_is_read_only() const {
 	return file_.get_is_known_read_only();
 }

--- a/Storage/Disk/DiskImage/Formats/OricMFMDSK.hpp
+++ b/Storage/Disk/DiskImage/Formats/OricMFMDSK.hpp
@@ -31,6 +31,7 @@ public:
 	HeadPosition get_maximum_head_position() const;
 	int get_head_count() const;
 	bool get_is_read_only() const;
+	bool represents(const std::string &) const;
 
 	void set_tracks(const std::map<Track::Address, std::unique_ptr<Track>> &tracks);
 	std::unique_ptr<Track> track_at_position(Track::Address) const;

--- a/Storage/Disk/DiskImage/Formats/OricMFMDSK.hpp
+++ b/Storage/Disk/DiskImage/Formats/OricMFMDSK.hpp
@@ -28,16 +28,16 @@ public:
 	OricMFMDSK(const std::string &file_name);
 
 	// implemented to satisfy @c DiskImage
-	HeadPosition get_maximum_head_position() final;
-	int get_head_count() final;
-	bool get_is_read_only() final;
+	HeadPosition get_maximum_head_position() const;
+	int get_head_count() const;
+	bool get_is_read_only() const;
 
-	void set_tracks(const std::map<Track::Address, std::unique_ptr<Track>> &tracks) final;
-	std::unique_ptr<Track> track_at_position(Track::Address) final;
+	void set_tracks(const std::map<Track::Address, std::unique_ptr<Track>> &tracks);
+	std::unique_ptr<Track> track_at_position(Track::Address) const;
 
 private:
-	Storage::FileHolder file_;
-	long get_file_offset_for_position(Track::Address address);
+	mutable Storage::FileHolder file_;
+	long get_file_offset_for_position(Track::Address address) const;
 
 	uint32_t head_count_;
 	uint32_t track_count_;

--- a/Storage/Disk/DiskImage/Formats/PCBooter.cpp
+++ b/Storage/Disk/DiskImage/Formats/PCBooter.cpp
@@ -55,14 +55,14 @@ PCBooter::PCBooter(const std::string &file_name) :
 	// as it can also be used to disambiguate FAT12 disks.
 }
 
-HeadPosition PCBooter::get_maximum_head_position() {
+HeadPosition PCBooter::get_maximum_head_position() const {
 	return HeadPosition(track_count_);
 }
 
-int PCBooter::get_head_count() {
+int PCBooter::get_head_count() const {
 	return head_count_;
 }
 
-long PCBooter::get_file_offset_for_position(Track::Address address) {
+long PCBooter::get_file_offset_for_position(Track::Address address) const {
 	return (address.position.as_int() * head_count_ + address.head) * 512 * sector_count_;
 }

--- a/Storage/Disk/DiskImage/Formats/PCBooter.hpp
+++ b/Storage/Disk/DiskImage/Formats/PCBooter.hpp
@@ -21,11 +21,11 @@ namespace Storage::Disk {
 class PCBooter: public MFMSectorDump {
 public:
 	PCBooter(const std::string &file_name);
-	HeadPosition get_maximum_head_position() final;
-	int get_head_count() final;
+	HeadPosition get_maximum_head_position() const final;
+	int get_head_count() const final;
 
 private:
-	long get_file_offset_for_position(Track::Address address) final;
+	long get_file_offset_for_position(Track::Address address) const final;
 
 	int head_count_;
 	int track_count_;

--- a/Storage/Disk/DiskImage/Formats/SSD.cpp
+++ b/Storage/Disk/DiskImage/Formats/SSD.cpp
@@ -32,14 +32,14 @@ SSD::SSD(const std::string &file_name) : MFMSectorDump(file_name) {
 	set_geometry(sectors_per_track, sector_size, 0, Encodings::MFM::Density::Single);
 }
 
-HeadPosition SSD::get_maximum_head_position() {
+HeadPosition SSD::get_maximum_head_position() const {
 	return HeadPosition(track_count_);
 }
 
-int SSD::get_head_count() {
+int SSD::get_head_count() const {
 	return head_count_;
 }
 
-long SSD::get_file_offset_for_position(Track::Address address) {
+long SSD::get_file_offset_for_position(const Track::Address address) const {
 	return (address.position.as_int() * head_count_ + address.head) * 256 * 10;
 }

--- a/Storage/Disk/DiskImage/Formats/SSD.hpp
+++ b/Storage/Disk/DiskImage/Formats/SSD.hpp
@@ -25,11 +25,11 @@ public:
 	*/
 	SSD(const std::string &file_name);
 
-	HeadPosition get_maximum_head_position() final;
-	int get_head_count() final;
+	HeadPosition get_maximum_head_position() const final;
+	int get_head_count() const final;
 
 private:
-	long get_file_offset_for_position(Track::Address address) final;
+	long get_file_offset_for_position(Track::Address address) const final;
 
 	int head_count_;
 	int track_count_;

--- a/Storage/Disk/DiskImage/Formats/STX.cpp
+++ b/Storage/Disk/DiskImage/Formats/STX.cpp
@@ -440,15 +440,15 @@ STX::STX(const std::string &file_name) : file_(file_name) {
 	}
 }
 
-HeadPosition STX::get_maximum_head_position() {
+HeadPosition STX::get_maximum_head_position() const {
 	return HeadPosition(track_count_ + 1);	// Same issue as MSA; must fix!
 }
 
-int STX::get_head_count() {
+int STX::get_head_count() const {
 	return head_count_;
 }
 
-std::unique_ptr<Track> STX::track_at_position(Track::Address address) {
+std::unique_ptr<Track> STX::track_at_position(const Track::Address address) const {
 	// These images have two sides, at most.
 	if(address.head > 1) return nullptr;
 

--- a/Storage/Disk/DiskImage/Formats/STX.cpp
+++ b/Storage/Disk/DiskImage/Formats/STX.cpp
@@ -593,3 +593,7 @@ std::unique_ptr<Track> STX::track_at_position(const Track::Address address) cons
 	TrackConstructor constructor(track_data, sectors, track_length, first_sync);
 	return constructor.get_track();
 }
+
+bool STX::represents(const std::string &name) const {
+	return name == file_.name();
+}

--- a/Storage/Disk/DiskImage/Formats/STX.hpp
+++ b/Storage/Disk/DiskImage/Formats/STX.hpp
@@ -29,6 +29,7 @@ public:
 
 	HeadPosition get_maximum_head_position() const;
 	int get_head_count() const;
+	bool represents(const std::string &) const;
 
 	std::unique_ptr<Track> track_at_position(Track::Address) const;
 

--- a/Storage/Disk/DiskImage/Formats/STX.hpp
+++ b/Storage/Disk/DiskImage/Formats/STX.hpp
@@ -27,13 +27,13 @@ public:
 	*/
 	STX(const std::string &file_name);
 
-	HeadPosition get_maximum_head_position() final;
-	int get_head_count() final;
+	HeadPosition get_maximum_head_position() const;
+	int get_head_count() const;
 
-	std::unique_ptr<Track> track_at_position(Track::Address) final;
+	std::unique_ptr<Track> track_at_position(Track::Address) const;
 
 private:
-	FileHolder file_;
+	mutable FileHolder file_;
 
 	int track_count_;
 	int head_count_;

--- a/Storage/Disk/DiskImage/Formats/WOZ.cpp
+++ b/Storage/Disk/DiskImage/Formats/WOZ.cpp
@@ -228,3 +228,7 @@ bool WOZ::get_is_read_only() const {
 	return true;
 //	return file_.get_is_known_read_only() || is_read_only_ || type_ == Type::WOZ2;	// WOZ 2 disks are currently read only.
 }
+
+bool WOZ::represents(const std::string &name) const {
+	return name == file_.name();
+}

--- a/Storage/Disk/DiskImage/Formats/WOZ.cpp
+++ b/Storage/Disk/DiskImage/Formats/WOZ.cpp
@@ -107,15 +107,15 @@ WOZ::WOZ(const std::string &file_name) :
 	if(tracks_offset_ == -1 || !has_tmap) throw Error::InvalidFormat;
 }
 
-HeadPosition WOZ::get_maximum_head_position() {
+HeadPosition WOZ::get_maximum_head_position() const {
 	return is_3_5_disk_ ? HeadPosition(80) : HeadPosition(160, 4);
 }
 
-int WOZ::get_head_count() {
+int WOZ::get_head_count() const {
 	return is_3_5_disk_ ? 2 : 1;
 }
 
-long WOZ::file_offset(Track::Address address) {
+long WOZ::file_offset(Track::Address address) const {
 	// Calculate table position.
 	int table_position;
 	if(!is_3_5_disk_) {
@@ -141,13 +141,13 @@ long WOZ::file_offset(Track::Address address) {
 	}
 }
 
-bool WOZ::tracks_differ(Track::Address lhs, Track::Address rhs) {
+bool WOZ::tracks_differ(Track::Address lhs, Track::Address rhs) const {
 	const long offset1 = file_offset(lhs);
 	const long offset2 = file_offset(rhs);
 	return offset1 != offset2;
 }
 
-std::unique_ptr<Track> WOZ::track_at_position(Track::Address address) {
+std::unique_ptr<Track> WOZ::track_at_position(Track::Address address) const {
 	const long offset = file_offset(address);
 	if(offset == NoSuchTrack) {
 		return nullptr;
@@ -218,7 +218,7 @@ void WOZ::set_tracks(const std::map<Track::Address, std::unique_ptr<Track>> &tra
 	file_.write(post_crc_contents_);
 }
 
-bool WOZ::get_is_read_only() {
+bool WOZ::get_is_read_only() const {
 	/*
 		There is an unintended issue with the disk code that sits above here: it doesn't understand the idea
 		of multiple addresses mapping to the same track, yet it maintains a cache of track contents. Therefore

--- a/Storage/Disk/DiskImage/Formats/WOZ.hpp
+++ b/Storage/Disk/DiskImage/Formats/WOZ.hpp
@@ -24,15 +24,15 @@ public:
 	WOZ(const std::string &file_name);
 
 	// Implemented to satisfy @c DiskImage.
-	HeadPosition get_maximum_head_position() final;
-	int get_head_count() final;
-	std::unique_ptr<Track> track_at_position(Track::Address) final;
-	void set_tracks(const std::map<Track::Address, std::unique_ptr<Track>> &tracks) final;
-	bool get_is_read_only() final;
-	bool tracks_differ(Track::Address, Track::Address) final;
+	HeadPosition get_maximum_head_position() const;
+	int get_head_count() const;
+	std::unique_ptr<Track> track_at_position(Track::Address) const;
+	void set_tracks(const std::map<Track::Address, std::unique_ptr<Track>> &tracks);
+	bool get_is_read_only() const;
+	bool tracks_differ(Track::Address, Track::Address) const;
 
 private:
-	Storage::FileHolder file_;
+	mutable Storage::FileHolder file_;
 	enum class Type {
 		WOZ1, WOZ2
 	} type_ = Type::WOZ1;
@@ -49,7 +49,7 @@ private:
 		@returns The offset within the file of the track at @c address or @c NoSuchTrack if
 			the track does not exit.
 	*/
-	long file_offset(Track::Address address);
+	long file_offset(Track::Address address) const;
 	constexpr static long NoSuchTrack = 0;	// This is an offset a track definitely can't lie at.
 };
 

--- a/Storage/Disk/DiskImage/Formats/WOZ.hpp
+++ b/Storage/Disk/DiskImage/Formats/WOZ.hpp
@@ -30,6 +30,7 @@ public:
 	void set_tracks(const std::map<Track::Address, std::unique_ptr<Track>> &tracks);
 	bool get_is_read_only() const;
 	bool tracks_differ(Track::Address, Track::Address) const;
+	bool represents(const std::string &) const;
 
 private:
 	mutable Storage::FileHolder file_;

--- a/Storage/Disk/Drive.cpp
+++ b/Storage/Disk/Drive.cpp
@@ -66,6 +66,10 @@ void Drive::set_disk(const std::shared_ptr<Disk> &disk) {
 	update_clocking_observer();
 }
 
+const Disk *Drive::disk() const {
+	return disk_.get();
+}
+
 bool Drive::has_disk() const {
 	return has_disk_;
 }

--- a/Storage/Disk/Drive.hpp
+++ b/Storage/Disk/Drive.hpp
@@ -51,6 +51,11 @@ public:
 	void set_disk(const std::shared_ptr<Disk> &disk);
 
 	/*!
+		@returns The attached disk, if any.
+	*/
+	const Disk *disk() const;
+
+	/*!
 		@returns @c true if a disk is currently inserted; @c false otherwise.
 	*/
 	bool has_disk() const;

--- a/Storage/FileHolder.cpp
+++ b/Storage/FileHolder.cpp
@@ -107,6 +107,10 @@ std::string FileHolder::extension() const {
 	return extension;
 }
 
+const std::string &FileHolder::name() const {
+	return name_;
+}
+
 void FileHolder::ensure_is_at_least_length(long length) {
 	std::fseek(file_, 0, SEEK_END);
 	long bytes_to_write = length - ftell(file_);

--- a/Storage/FileHolder.hpp
+++ b/Storage/FileHolder.hpp
@@ -162,6 +162,11 @@ public:
 	std::string extension() const;
 
 	/*!
+		Returns the underlying file name.
+	*/
+	const std::string &name() const;
+
+	/*!
 		Ensures the file is at least @c length bytes long, appending 0s until it is
 		if necessary.
 	*/

--- a/Storage/TargetPlatforms.hpp
+++ b/Storage/TargetPlatforms.hpp
@@ -8,9 +8,11 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace TargetPlatform {
 
-using IntType = int;
+using IntType = uint32_t;
 
 constexpr IntType bit(int index) {
 	return 1 << index;
@@ -56,7 +58,7 @@ enum Type: IntType {
 	AllDisk			=	Acorn | Commodore | AmstradCPC | C64 | Oric | MSX | ZXSpectrum | Macintosh | AtariST | DiskII | PCCompatible | FAT12,
 	AllTape			=	Acorn | AmstradCPC | Commodore8bit | Oric | ZX8081 | MSX | ZXSpectrum,
 
-	All 			= ~0,
+	All 			=	~IntType(0),
 };
 
 class Distinguisher {


### PR DESCRIPTION
This also ran into a lack of `const` correctness in the disk image interface, which has been altered.

I think I want to take a quick step back and review that whole area, along with my failure so far to adopt `filesystem` despite having switched to C++17 some years ago. So this currently runs only as far as the ZX Spectrum, owing to its inspiration by #1416