### PR TITLE
Resolve two immediate warnings in a C++20 test build.

### DIFF
--- a/Analyser/Dynamic/MultiMachine/Implementation/MultiProducer.cpp
+++ b/Analyser/Dynamic/MultiMachine/Implementation/MultiProducer.cpp
@@ -19,7 +19,7 @@ template <typename MachineType>
 void MultiInterface<MachineType>::perform_parallel(const std::function<void(MachineType *)> &function) {
 	// Apply a blunt force parallelisation of the machines; each run_for is dispatched
 	// to a separate queue and this queue will block until all are done.
-	volatile std::size_t outstanding_machines;
+	std::size_t outstanding_machines;
 	std::condition_variable condition;
 	std::mutex mutex;
 	{
@@ -33,7 +33,7 @@ void MultiInterface<MachineType>::perform_parallel(const std::function<void(Mach
 				if(machine) function(machine);
 
 				std::lock_guard lock(mutex);
-				outstanding_machines--;
+				--outstanding_machines;
 				condition.notify_all();
 			});
 		}

--- a/Outputs/ScanTargets/BufferingScanTarget.cpp
+++ b/Outputs/ScanTargets/BufferingScanTarget.cpp
@@ -297,7 +297,7 @@ size_t BufferingScanTarget::write_area_data_size() const {
 }
 
 void BufferingScanTarget::set_modals(Modals modals) {
-	perform([=] {
+	perform([&] {
 		modals_ = modals;
 		modals_are_dirty_.store(true, std::memory_order_relaxed);
 	});


### PR DESCRIPTION
With C++20 I'd be empowered to use concepts, which I think could better document a lot of the otherwise mildly-opaque template requirements.

But I'm just dipping my toe in for now.