### PR TITLE
Tee up for an AT-class PC.

### DIFF
--- a/Analyser/Static/PCCompatible/Target.hpp
+++ b/Analyser/Static/PCCompatible/Target.hpp
@@ -19,10 +19,10 @@ struct Target: public Analyser::Static::Target, public Reflection::StructImpl<Ta
 		CGA);
 	VideoAdaptor adaptor = VideoAdaptor::CGA;
 
-	ReflectableEnum(Speed,
-		ApproximatelyOriginal,
-		Fast);
-	Speed speed = Speed::Fast;
+	ReflectableEnum(ModelApproximation,
+		XT,
+		TurboXT);
+	ModelApproximation model = ModelApproximation::TurboXT;
 
 	Target() : Analyser::Static::Target(Machine::PCCompatible) {}
 
@@ -30,9 +30,9 @@ private:
 	friend Reflection::StructImpl<Target>;
 	void declare_fields() {
 		AnnounceEnum(VideoAdaptor);
-		AnnounceEnum(Speed);
+		AnnounceEnum(ModelApproximation);
 		DeclareField(adaptor);
-		DeclareField(speed);
+		DeclareField(model);
 	}
 };
 

--- a/InstructionSets/x86/Decoder.cpp
+++ b/InstructionSets/x86/Decoder.cpp
@@ -1085,7 +1085,3 @@ template class InstructionSet::x86::Decoder<InstructionSet::x86::Model::i8086>;
 template class InstructionSet::x86::Decoder<InstructionSet::x86::Model::i80186>;
 template class InstructionSet::x86::Decoder<InstructionSet::x86::Model::i80286>;
 template class InstructionSet::x86::Decoder<InstructionSet::x86::Model::i80386>;
-
-std::pair<int, Instruction<false>> Decoder8086::decode(const uint8_t *const source, const std::size_t length) {
-	return decoder.decode(source, length);
-}

--- a/InstructionSets/x86/Decoder.cpp
+++ b/InstructionSets/x86/Decoder.cpp
@@ -1085,19 +1085,3 @@ template class InstructionSet::x86::Decoder<InstructionSet::x86::Model::i8086>;
 template class InstructionSet::x86::Decoder<InstructionSet::x86::Model::i80186>;
 template class InstructionSet::x86::Decoder<InstructionSet::x86::Model::i80286>;
 template class InstructionSet::x86::Decoder<InstructionSet::x86::Model::i80386>;
-
-// Workaround for GCC; despite explicit instantiations above, GCC will fail to
-// link without the function below.
-void InstructionSet::x86::_gcc_instantiation_workaround(const uint8_t v) {
-	InstructionSet::x86::Decoder<InstructionSet::x86::Model::i8086> decoder86;
-	decoder86.decode(&v, 1);
-
-	InstructionSet::x86::Decoder<InstructionSet::x86::Model::i80186> decoder186;
-	decoder186.decode(&v, 1);
-
-	InstructionSet::x86::Decoder<InstructionSet::x86::Model::i80286> decoder286;
-	decoder286.decode(&v, 1);
-
-	InstructionSet::x86::Decoder<InstructionSet::x86::Model::i80386> decoder386;
-	decoder386.decode(&v, 1);
-}

--- a/InstructionSets/x86/Decoder.cpp
+++ b/InstructionSets/x86/Decoder.cpp
@@ -1086,11 +1086,9 @@ template class InstructionSet::x86::Decoder<InstructionSet::x86::Model::i80186>;
 template class InstructionSet::x86::Decoder<InstructionSet::x86::Model::i80286>;
 template class InstructionSet::x86::Decoder<InstructionSet::x86::Model::i80386>;
 
-namespace {
-
 // Workaround for GCC; despite explicit instantiations above, GCC will fail to
 // link without the function below.
-void _gcc_nonsense() {
+void _gcc_instantion_workaround() {
 	InstructionSet::x86::Decoder<InstructionSet::x86::Model::i8086> decoder86;
 	decoder86.decode(nullptr, 0);
 
@@ -1102,6 +1100,4 @@ void _gcc_nonsense() {
 
 	InstructionSet::x86::Decoder<InstructionSet::x86::Model::i80386> decoder386;
 	decoder386.decode(nullptr, 0);
-}
-
 }

--- a/InstructionSets/x86/Decoder.cpp
+++ b/InstructionSets/x86/Decoder.cpp
@@ -1085,3 +1085,23 @@ template class InstructionSet::x86::Decoder<InstructionSet::x86::Model::i8086>;
 template class InstructionSet::x86::Decoder<InstructionSet::x86::Model::i80186>;
 template class InstructionSet::x86::Decoder<InstructionSet::x86::Model::i80286>;
 template class InstructionSet::x86::Decoder<InstructionSet::x86::Model::i80386>;
+
+namespace {
+
+// Workaround for GCC; despite explicit instantiations above, GCC will fail to
+// link without the function below.
+void _gcc_nonsense() {
+	InstructionSet::x86::Decoder<InstructionSet::x86::Model::i8086> decoder86;
+	decoder86.decode(nullptr, 0);
+
+	InstructionSet::x86::Decoder<InstructionSet::x86::Model::i80186> decoder186;
+	decoder186.decode(nullptr, 0);
+
+	InstructionSet::x86::Decoder<InstructionSet::x86::Model::i80286> decoder286;
+	decoder286.decode(nullptr, 0);
+
+	InstructionSet::x86::Decoder<InstructionSet::x86::Model::i80386> decoder386;
+	decoder386.decode(nullptr, 0);
+}
+
+}

--- a/InstructionSets/x86/Decoder.cpp
+++ b/InstructionSets/x86/Decoder.cpp
@@ -1088,16 +1088,16 @@ template class InstructionSet::x86::Decoder<InstructionSet::x86::Model::i80386>;
 
 // Workaround for GCC; despite explicit instantiations above, GCC will fail to
 // link without the function below.
-void InstructionSet::x86::_gcc_instantiation_workaround() {
+void InstructionSet::x86::_gcc_instantiation_workaround(const uint8_t v) {
 	InstructionSet::x86::Decoder<InstructionSet::x86::Model::i8086> decoder86;
-	decoder86.decode(nullptr, 0);
+	decoder86.decode(&v, 1);
 
 	InstructionSet::x86::Decoder<InstructionSet::x86::Model::i80186> decoder186;
-	decoder186.decode(nullptr, 0);
+	decoder186.decode(&v, 1);
 
 	InstructionSet::x86::Decoder<InstructionSet::x86::Model::i80286> decoder286;
-	decoder286.decode(nullptr, 0);
+	decoder286.decode(&v, 1);
 
 	InstructionSet::x86::Decoder<InstructionSet::x86::Model::i80386> decoder386;
-	decoder386.decode(nullptr, 0);
+	decoder386.decode(&v, 1);
 }

--- a/InstructionSets/x86/Decoder.cpp
+++ b/InstructionSets/x86/Decoder.cpp
@@ -1088,7 +1088,7 @@ template class InstructionSet::x86::Decoder<InstructionSet::x86::Model::i80386>;
 
 // Workaround for GCC; despite explicit instantiations above, GCC will fail to
 // link without the function below.
-void _gcc_instantion_workaround() {
+void InstructionSet::x86::_gcc_instantiation_workaround() {
 	InstructionSet::x86::Decoder<InstructionSet::x86::Model::i8086> decoder86;
 	decoder86.decode(nullptr, 0);
 

--- a/InstructionSets/x86/Decoder.hpp
+++ b/InstructionSets/x86/Decoder.hpp
@@ -369,4 +369,8 @@ private:
 	}
 };
 
+// As the name implies, this function exists purely to work around what appears
+// at my level of comprehension to be an issue with GCC and explicit instantiation.
+void _gcc_instantion_workaround();
+
 }

--- a/InstructionSets/x86/Decoder.hpp
+++ b/InstructionSets/x86/Decoder.hpp
@@ -371,6 +371,6 @@ private:
 
 // As the name implies, this function exists purely to work around what appears
 // at my level of comprehension to be an issue with GCC and explicit instantiation.
-void _gcc_instantion_workaround();
+void _gcc_instantiation_workaround();
 
 }

--- a/InstructionSets/x86/Decoder.hpp
+++ b/InstructionSets/x86/Decoder.hpp
@@ -369,17 +369,4 @@ private:
 	}
 };
 
-// This is a temporary measure; for reasons as-yet unknown, GCC isn't picking up the
-// explicit instantiations of the template above at link time, even though is is
-// unambiguously building and linking in Decoder.cpp.
-//
-// So here's a thin non-templated shim to unblock initial PC Compatible development.
-class Decoder8086 {
-public:
-	std::pair<int, Instruction<false>> decode(const uint8_t *source, std::size_t length);
-
-private:
-	Decoder<Model::i8086> decoder;
-};
-
 }

--- a/InstructionSets/x86/Decoder.hpp
+++ b/InstructionSets/x86/Decoder.hpp
@@ -369,6 +369,11 @@ private:
 	}
 };
 
+extern template class InstructionSet::x86::Decoder<InstructionSet::x86::Model::i8086>;
+extern template class InstructionSet::x86::Decoder<InstructionSet::x86::Model::i80186>;
+extern template class InstructionSet::x86::Decoder<InstructionSet::x86::Model::i80286>;
+extern template class InstructionSet::x86::Decoder<InstructionSet::x86::Model::i80386>;
+
 // As the name implies, this function exists purely to work around what appears
 // at my level of comprehension to be an issue with GCC and explicit instantiation.
 

--- a/InstructionSets/x86/Decoder.hpp
+++ b/InstructionSets/x86/Decoder.hpp
@@ -371,6 +371,7 @@ private:
 
 // As the name implies, this function exists purely to work around what appears
 // at my level of comprehension to be an issue with GCC and explicit instantiation.
-void _gcc_instantiation_workaround();
+
+void _gcc_instantiation_workaround(uint8_t v = 0xff);
 
 }

--- a/InstructionSets/x86/Decoder.hpp
+++ b/InstructionSets/x86/Decoder.hpp
@@ -374,9 +374,4 @@ extern template class InstructionSet::x86::Decoder<InstructionSet::x86::Model::i
 extern template class InstructionSet::x86::Decoder<InstructionSet::x86::Model::i80286>;
 extern template class InstructionSet::x86::Decoder<InstructionSet::x86::Model::i80386>;
 
-// As the name implies, this function exists purely to work around what appears
-// at my level of comprehension to be an issue with GCC and explicit instantiation.
-
-void _gcc_instantiation_workaround(uint8_t v = 0xff);
-
 }

--- a/Machines/PCCompatible/PCCompatible.cpp
+++ b/Machines/PCCompatible/PCCompatible.cpp
@@ -1193,8 +1193,8 @@ class ConcreteMachine:
 
 		// TODO: eliminate use of Decoder8086 and Decoder8086 in gneral in favour of the templated version, as soon
 		// as whatever error is preventing GCC from picking up Decoder's explicit instantiations becomes apparent.
-		InstructionSet::x86::Decoder8086 decoder;
-//		InstructionSet::x86::Decoder<InstructionSet::x86::Model::i8086> decoder;
+//		InstructionSet::x86::Decoder8086 decoder;
+		InstructionSet::x86::Decoder<InstructionSet::x86::Model::i8086> decoder;
 
 		uint16_t decoded_ip_ = 0;
 		std::pair<int, InstructionSet::x86::Instruction<false>> decoded;

--- a/Machines/PCCompatible/PCCompatible.cpp
+++ b/Machines/PCCompatible/PCCompatible.cpp
@@ -893,7 +893,7 @@ class ConcreteMachine:
 			context(pit_, dma_, ppi_, pic_, video_, fdc_, rtc_)
 		{
 			// Yuck, for GCC. Yuck. See notes in x86 decoder.
-			InstructionSet::x86::_gcc_instantion_workaround();
+			InstructionSet::x86::_gcc_instantiation_workaround();
 
 			// Capture speed.
 			model_ = target.model;

--- a/Machines/PCCompatible/PCCompatible.cpp
+++ b/Machines/PCCompatible/PCCompatible.cpp
@@ -892,6 +892,9 @@ class ConcreteMachine:
 			ppi_(ppi_handler_),
 			context(pit_, dma_, ppi_, pic_, video_, fdc_, rtc_)
 		{
+			// Yuck, for GCC. Yuck. See notes in x86 decoder.
+			InstructionSet::x86::_gcc_instantion_workaround();
+
 			// Capture speed.
 			model_ = target.model;
 

--- a/Machines/PCCompatible/PCCompatible.cpp
+++ b/Machines/PCCompatible/PCCompatible.cpp
@@ -892,9 +892,6 @@ class ConcreteMachine:
 			ppi_(ppi_handler_),
 			context(pit_, dma_, ppi_, pic_, video_, fdc_, rtc_)
 		{
-			// Yuck, for GCC. Yuck. See notes in x86 decoder.
-			InstructionSet::x86::_gcc_instantiation_workaround();
-
 			// Capture speed.
 			model_ = target.model;
 

--- a/OSBindings/Mac/Clock Signal/Machine/StaticAnalyser/CSStaticAnalyser.mm
+++ b/OSBindings/Mac/Clock Signal/Machine/StaticAnalyser/CSStaticAnalyser.mm
@@ -302,8 +302,8 @@
 			case CSPCCompatibleVideoAdaptorCGA:	target->adaptor = Target::VideoAdaptor::CGA;	break;
 		}
 		switch(speed) {
-			case CSPCCompatibleSpeedOriginal:	target->speed = Target::Speed::ApproximatelyOriginal;	break;
-			case CSPCCompatibleSpeedTurbo:		target->speed = Target::Speed::Fast;					break;
+			case CSPCCompatibleSpeedOriginal:	target->model = Target::ModelApproximation::XT;			break;
+			case CSPCCompatibleSpeedTurbo:		target->model = Target::ModelApproximation::TurboXT;	break;
 		}
 		_targets.push_back(std::move(target));
 	}

--- a/OSBindings/Qt/mainwindow.cpp
+++ b/OSBindings/Qt/mainwindow.cpp
@@ -1233,7 +1233,7 @@ void MainWindow::start_pc() {
 
 	switch(ui->pcSpeedComboBox->currentIndex()) {
 			default:	target->model = Target::ModelApproximation::XT;			break;
-			case 1:		target->speed = Target::ModelApproximation::TurboXT;	break;
+			case 1:		target->model = Target::ModelApproximation::TurboXT;	break;
 	}
 
 	switch(ui->pcVideoAdaptorComboBox->currentIndex()) {

--- a/OSBindings/Qt/mainwindow.cpp
+++ b/OSBindings/Qt/mainwindow.cpp
@@ -1232,8 +1232,8 @@ void MainWindow::start_pc() {
 	auto target = std::make_unique<Target>();
 
 	switch(ui->pcSpeedComboBox->currentIndex()) {
-			default:	target->speed = Target::Speed::ApproximatelyOriginal;	break;
-			case 1:		target->speed = Target::Speed::Fast;						break;
+			default:	target->model = Target::ModelApproximation::XT;			break;
+			case 1:		target->speed = Target::ModelApproximation::TurboXT;	break;
 	}
 
 	switch(ui->pcVideoAdaptorComboBox->currentIndex()) {


### PR DESCRIPTION
Minor clean-up steps only:
- eliminate the `Decoder8086` workaround, for more natural templating;
- rename `Model::Speed` to capture that it'll be approximately PC models;
- build PC model type into `PCCompatible` template.

I will subsequently need:
1. 286 stuff: protected mode, mainly. Which is a few extra instructions, a little more state and privilege validation;
2. ATA stuff: probably including support for relevant types of hard disk image (VHDs?); and
3. the other AT additions: second interrupt controller, A20 line, etc.

Support for EGA and VGA would be a huge boon beyond there, but that's already a long way off.