### PR TITLE
Repair 286 decoding and `perform`.

### DIFF
--- a/Analyser/Static/PCCompatible/Target.hpp
+++ b/Analyser/Static/PCCompatible/Target.hpp
@@ -13,19 +13,19 @@
 
 namespace Analyser::Static::PCCompatible {
 
+ReflectableEnum(Model,
+	XT,
+	TurboXT,
+	AT
+);
+
 struct Target: public Analyser::Static::Target, public Reflection::StructImpl<Target> {
 	ReflectableEnum(VideoAdaptor,
 		MDA,
 		CGA,
 	);
 	VideoAdaptor adaptor = VideoAdaptor::CGA;
-
-	ReflectableEnum(ModelApproximation,
-		XT,
-		TurboXT,
-		AT
-	);
-	ModelApproximation model = ModelApproximation::TurboXT;
+	Model model = Model::TurboXT;
 
 	Target() : Analyser::Static::Target(Machine::PCCompatible) {}
 
@@ -33,7 +33,7 @@ private:
 	friend Reflection::StructImpl<Target>;
 	void declare_fields() {
 		AnnounceEnum(VideoAdaptor);
-		AnnounceEnum(ModelApproximation);
+		AnnounceEnum(Model);
 		DeclareField(adaptor);
 		DeclareField(model);
 	}

--- a/Analyser/Static/PCCompatible/Target.hpp
+++ b/Analyser/Static/PCCompatible/Target.hpp
@@ -16,12 +16,15 @@ namespace Analyser::Static::PCCompatible {
 struct Target: public Analyser::Static::Target, public Reflection::StructImpl<Target> {
 	ReflectableEnum(VideoAdaptor,
 		MDA,
-		CGA);
+		CGA,
+	);
 	VideoAdaptor adaptor = VideoAdaptor::CGA;
 
 	ReflectableEnum(ModelApproximation,
 		XT,
-		TurboXT);
+		TurboXT,
+		AT
+	);
 	ModelApproximation model = ModelApproximation::TurboXT;
 
 	Target() : Analyser::Static::Target(Machine::PCCompatible) {}

--- a/InstructionSets/x86/Implementation/FlowControl.hpp
+++ b/InstructionSets/x86/Implementation/FlowControl.hpp
@@ -240,11 +240,11 @@ void into(
 	}
 }
 
-template <typename IntT, typename InstructionT, typename ContextT>
+template <typename IntT, typename AddressT, typename InstructionT, typename ContextT>
 void bound(
 	const InstructionT &instruction,
-	read_t<IntT> destination,
-	read_t<IntT> source,
+	read_t<AddressT> destination,
+	read_t<AddressT> source,
 	ContextT &context
 ) {
 	using sIntT = typename std::make_signed<IntT>::type;
@@ -252,10 +252,9 @@ void bound(
 	const auto source_segment = instruction.data_segment();
 	context.memory.preauthorise_read(source_segment, source, 2*sizeof(IntT));
 	const auto lower_bound =
-		sIntT(context.memory.template access<uint16_t, AccessType::PreauthorisedRead>(source_segment, source));
-	source += 2;
+		sIntT(context.memory.template access<IntT, AccessType::PreauthorisedRead>(source_segment, source));
 	const auto upper_bound =
-		sIntT(context.memory.template access<uint16_t, AccessType::PreauthorisedRead>(source_segment, source));
+		sIntT(context.memory.template access<IntT, AccessType::PreauthorisedRead>(source_segment, IntT(source + 2)));
 
 	if(sIntT(destination) < lower_bound || sIntT(destination) > upper_bound) {
 		interrupt(Interrupt::BoundRangeExceeded, context);

--- a/InstructionSets/x86/Implementation/PerformImplementation.hpp
+++ b/InstructionSets/x86/Implementation/PerformImplementation.hpp
@@ -223,7 +223,7 @@ template <
 			} else {
 				static_assert(int(Operation::IDIV_REP) == int(Operation::LEAVE));
 				if constexpr (std::is_same_v<IntT, uint16_t> || std::is_same_v<IntT, uint32_t>) {
-					Primitive::leave<IntT>();
+					Primitive::leave<IntT>(context);
 				}
 			}
 		return;
@@ -338,7 +338,7 @@ template <
 				break;
 			} else {
 				static_assert(int(Operation::SETMOC) == int(Operation::BOUND));
-				Primitive::bound<IntT>(instruction, destination_r(), source_r(), context);
+				Primitive::bound<IntT, AddressT>(instruction, destination_r(), source_r(), context);
 			}
 		return;
 

--- a/InstructionSets/x86/Implementation/Stack.hpp
+++ b/InstructionSets/x86/Implementation/Stack.hpp
@@ -174,7 +174,7 @@ void enter(
 		context.registers.bp() -= 2;
 
 		const auto value = context.memory.template preauthorised_read<uint16_t>(Source::SS, context.registers.bp());
-		push<uint16_t, true>(value);
+		push<uint16_t, true>(value, context);
 	}
 
 	// Set final BP.

--- a/InstructionSets/x86/Implementation/Stack.hpp
+++ b/InstructionSets/x86/Implementation/Stack.hpp
@@ -170,11 +170,14 @@ void enter(
 	const auto frame = context.registers.sp();
 
 	// Copy data as per the nesting level.
-	for(int c = 1; c < nesting_level; c++) {
-		context.registers.bp() -= 2;
+	if(nesting_level > 0) {
+		for(int c = 1; c < nesting_level; c++) {
+			context.registers.bp() -= 2;
 
-		const auto value = context.memory.template preauthorised_read<uint16_t>(Source::SS, context.registers.bp());
-		push<uint16_t, true>(value, context);
+			const auto value = context.memory.template preauthorised_read<uint16_t>(Source::SS, context.registers.bp());
+			push<uint16_t, true>(value, context);
+		}
+		push<uint16_t, true>(frame, context);
 	}
 
 	// Set final BP.

--- a/InstructionSets/x86/Instruction.hpp
+++ b/InstructionSets/x86/Instruction.hpp
@@ -850,7 +850,7 @@ public:
 
 	/// @returns The dynamic storage size argument supplied to an ENTER.
 	constexpr ImmediateT dynamic_storage_size() const	{
-		return displacement();
+		return offset();
 	}
 
 	// Standard comparison operator.

--- a/Machines/PCCompatible/DMA.hpp
+++ b/Machines/PCCompatible/DMA.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "Analyser/Static/PCCompatible/Target.hpp"
 #include "Numeric/RegisterSizes.hpp"
 
 #include "Memory.hpp"
@@ -287,13 +288,14 @@ class DMAPages {
 		}
 };
 
+template <Analyser::Static::PCCompatible::Model model>
 class DMA {
 	public:
 		i8237 controller;
 		DMAPages pages;
 
 		// Memory is set posthoc to resolve a startup time.
-		void set_memory(Memory *memory) {
+		void set_memory(Memory<model> *memory) {
 			memory_ = memory;
 		}
 
@@ -310,7 +312,7 @@ class DMA {
 		}
 
 	private:
-		Memory *memory_;
+		Memory<model> *memory_;
 };
 
 }

--- a/Machines/PCCompatible/Memory.hpp
+++ b/Machines/PCCompatible/Memory.hpp
@@ -8,9 +8,11 @@
 
 #pragma once
 
+#include "ProcessorByModel.hpp"
 #include "Registers.hpp"
 #include "Segments.hpp"
 
+#include "Analyser/Static/PCCompatible/Target.hpp"
 #include "InstructionSets/x86/AccessType.hpp"
 
 #include <array>
@@ -18,198 +20,202 @@
 namespace PCCompatible {
 
 // TODO: send writes to the ROM area off to nowhere.
-struct Memory {
-	public:
-		using AccessType = InstructionSet::x86::AccessType;
+template <Analyser::Static::PCCompatible::Model model>
+class Memory {
+	static constexpr auto x86_model = processor_model(model);
 
-		// Constructor.
-		Memory(Registers &registers, const Segments &segments) : registers_(registers), segments_(segments) {}
+public:
+	using AccessType = InstructionSet::x86::AccessType;
 
-		//
-		// Preauthorisation call-ins. Since only an 8088 is currently modelled, all accesses are implicitly authorised.
-		//
-		void preauthorise_stack_write([[maybe_unused]] uint32_t length) {}
-		void preauthorise_stack_read([[maybe_unused]] uint32_t length) {}
-		void preauthorise_read([[maybe_unused]] InstructionSet::x86::Source segment, [[maybe_unused]] uint16_t start, [[maybe_unused]] uint32_t length) {}
-		void preauthorise_read([[maybe_unused]] uint32_t start, [[maybe_unused]] uint32_t length) {}
+	// Constructor.
+	Memory(Registers<x86_model> &registers, const Segments<x86_model> &segments) :
+		registers_(registers), segments_(segments) {}
 
-		//
-		// Access call-ins.
-		//
+	//
+	// Preauthorisation call-ins. Since only an 8088 is currently modelled, all accesses are implicitly authorised.
+	//
+	void preauthorise_stack_write([[maybe_unused]] uint32_t length) {}
+	void preauthorise_stack_read([[maybe_unused]] uint32_t length) {}
+	void preauthorise_read([[maybe_unused]] InstructionSet::x86::Source segment, [[maybe_unused]] uint16_t start, [[maybe_unused]] uint32_t length) {}
+	void preauthorise_read([[maybe_unused]] uint32_t start, [[maybe_unused]] uint32_t length) {}
 
-		// Accesses an address based on segment:offset.
-		template <typename IntT, AccessType type>
-		typename InstructionSet::x86::Accessor<IntT, type>::type access(
-			const InstructionSet::x86::Source segment,
-			const uint16_t offset
-		) {
-			const uint32_t physical_address = address(segment, offset);
+	//
+	// Access call-ins.
+	//
 
-			if constexpr (std::is_same_v<IntT, uint16_t>) {
-				// If this is a 16-bit access that runs past the end of the segment, it'll wrap back
-				// to the start. So the 16-bit value will need to be a local cache.
-				if(offset == 0xffff) {
-					return split_word<type>(physical_address, address(segment, 0));
-				}
-			}
+	// Accesses an address based on segment:offset.
+	template <typename IntT, AccessType type>
+	typename InstructionSet::x86::Accessor<IntT, type>::type access(
+		const InstructionSet::x86::Source segment,
+		const uint16_t offset
+	) {
+		const uint32_t physical_address = address(segment, offset);
 
-			return access<IntT, type>(physical_address);
-		}
-
-		// Accesses an address based on physical location.
-		template <typename IntT, AccessType type>
-		typename InstructionSet::x86::Accessor<IntT, type>::type access(const uint32_t address) {
-			// Dispense with the single-byte case trivially.
-			if constexpr (std::is_same_v<IntT, uint8_t>) {
-				return memory[address];
-			} else if(address != 0xf'ffff) {
-				return *reinterpret_cast<IntT *>(&memory[address]);
-			} else {
-				return split_word<type>(address, 0);
-			}
-		}
-
-		template <typename IntT>
-		void write_back() {
-			if constexpr (std::is_same_v<IntT, uint16_t>) {
-				if(write_back_address_[0] != NoWriteBack) {
-					memory[write_back_address_[0]] = write_back_value_ & 0xff;
-					memory[write_back_address_[1]] = write_back_value_ >> 8;
-					write_back_address_[0]  = 0;
-				}
-			}
-		}
-
-		//
-		// Direct read and write.
-		//
-		template <typename IntT>
-		void preauthorised_write(
-			const InstructionSet::x86::Source segment,
-			const uint16_t offset,
-			const IntT value
-		) {
-			// Bytes can be written without further ado.
-			if constexpr (std::is_same_v<IntT, uint8_t>) {
-				memory[address(segment, offset) & 0xf'ffff] = value;
-				return;
-			}
-
-			// Words that straddle the segment end must be split in two.
+		if constexpr (std::is_same_v<IntT, uint16_t>) {
+			// If this is a 16-bit access that runs past the end of the segment, it'll wrap back
+			// to the start. So the 16-bit value will need to be a local cache.
 			if(offset == 0xffff) {
-				memory[address(segment, offset) & 0xf'ffff] = value & 0xff;
-				memory[address(segment, 0x0000) & 0xf'ffff] = value >> 8;
-				return;
-			}
-
-			const uint32_t target = address(segment, offset) & 0xf'ffff;
-
-			// Words that straddle the end of physical RAM must also be split in two.
-			if(target == 0xf'ffff) {
-				memory[0xf'ffff] = value & 0xff;
-				memory[0x0'0000] = value >> 8;
-				return;
-			}
-
-			// It's safe just to write then.
-			*reinterpret_cast<IntT *>(&memory[target]) = value;
-		}
-
-		template <typename IntT>
-		IntT preauthorised_read(
-			const InstructionSet::x86::Source segment,
-			const uint16_t offset
-		) {
-			// Bytes can be written without further ado.
-			if constexpr (std::is_same_v<IntT, uint8_t>) {
-				return memory[address(segment, offset) & 0xf'ffff];
-			}
-
-			// Words that straddle the segment end must be split in two.
-			if(offset == 0xffff) {
-				return IntT(
-					memory[address(segment, offset) & 0xf'ffff] |
-					memory[address(segment, 0x0000) & 0xf'ffff] << 8
-				);
-			}
-
-			const uint32_t target = address(segment, offset) & 0xf'ffff;
-
-			// Words that straddle the end of physical RAM must also be split in two.
-			if(target == 0xf'ffff) {
-				return IntT(
-					memory[0xf'ffff] |
-					memory[0x0'0000] << 8
-				);
-			}
-
-			// It's safe just to write then.
-			return *reinterpret_cast<IntT *>(&memory[target]);
-		}
-
-		//
-		// Helper for instruction fetch.
-		//
-		std::pair<const uint8_t *, size_t> next_code() const {
-			const uint32_t start = segments_.cs_base_ + registers_.ip();
-			return std::make_pair(&memory[start], 0x10'000 - start);
-		}
-
-		std::pair<const uint8_t *, size_t> all() const {
-			return std::make_pair(memory.data(), 0x10'000);
-		}
-
-		//
-		// External access.
-		//
-		void install(size_t address, const uint8_t *data, size_t length) {
-			std::copy(data, data + length, memory.begin() + std::vector<uint8_t>::difference_type(address));
-		}
-
-		uint8_t *at(uint32_t address) {
-			return &memory[address];
-		}
-
-	private:
-		std::array<uint8_t, 1024*1024> memory{0xff};
-		Registers &registers_;
-		const Segments &segments_;
-
-		uint32_t segment_base(const InstructionSet::x86::Source segment) const {
-			using Source = InstructionSet::x86::Source;
-			switch(segment) {
-				default:			return segments_.ds_base_;
-				case Source::ES:	return segments_.es_base_;
-				case Source::CS:	return segments_.cs_base_;
-				case Source::SS:	return segments_.ss_base_;
+				return split_word<type>(physical_address, address(segment, 0));
 			}
 		}
 
-		uint32_t address(const InstructionSet::x86::Source segment, const uint16_t offset) const {
-			return (segment_base(segment) + offset) & 0xf'ffff;
+		return access<IntT, type>(physical_address);
+	}
+
+	// Accesses an address based on physical location.
+	template <typename IntT, AccessType type>
+	typename InstructionSet::x86::Accessor<IntT, type>::type access(const uint32_t address) {
+		// Dispense with the single-byte case trivially.
+		if constexpr (std::is_same_v<IntT, uint8_t>) {
+			return memory[address];
+		} else if(address != 0xf'ffff) {
+			return *reinterpret_cast<IntT *>(&memory[address]);
+		} else {
+			return split_word<type>(address, 0);
 		}
+	}
 
-		template <AccessType type>
-		typename InstructionSet::x86::Accessor<uint16_t, type>::type
-		split_word(const uint32_t low_address, const uint32_t high_address) {
-			if constexpr (is_writeable(type)) {
-				write_back_address_[0] = low_address;
-				write_back_address_[1] = high_address;
-
-				// Prepopulate only if this is a modify.
-				if constexpr (type == AccessType::ReadModifyWrite) {
-					write_back_value_ = uint16_t(memory[write_back_address_[0]] | (memory[write_back_address_[1]] << 8));
-				}
-
-				return write_back_value_;
-			} else {
-				return uint16_t(memory[low_address] | (memory[high_address] << 8));
+	template <typename IntT>
+	void write_back() {
+		if constexpr (std::is_same_v<IntT, uint16_t>) {
+			if(write_back_address_[0] != NoWriteBack) {
+				memory[write_back_address_[0]] = write_back_value_ & 0xff;
+				memory[write_back_address_[1]] = write_back_value_ >> 8;
+				write_back_address_[0]  = 0;
 			}
 		}
+	}
 
-		static constexpr uint32_t NoWriteBack = 0;	// A low byte address of 0 can't require write-back.
-		uint32_t write_back_address_[2] = {NoWriteBack, NoWriteBack};
-		uint16_t write_back_value_;
+	//
+	// Direct read and write.
+	//
+	template <typename IntT>
+	void preauthorised_write(
+		const InstructionSet::x86::Source segment,
+		const uint16_t offset,
+		const IntT value
+	) {
+		// Bytes can be written without further ado.
+		if constexpr (std::is_same_v<IntT, uint8_t>) {
+			memory[address(segment, offset) & 0xf'ffff] = value;
+			return;
+		}
+
+		// Words that straddle the segment end must be split in two.
+		if(offset == 0xffff) {
+			memory[address(segment, offset) & 0xf'ffff] = value & 0xff;
+			memory[address(segment, 0x0000) & 0xf'ffff] = value >> 8;
+			return;
+		}
+
+		const uint32_t target = address(segment, offset) & 0xf'ffff;
+
+		// Words that straddle the end of physical RAM must also be split in two.
+		if(target == 0xf'ffff) {
+			memory[0xf'ffff] = value & 0xff;
+			memory[0x0'0000] = value >> 8;
+			return;
+		}
+
+		// It's safe just to write then.
+		*reinterpret_cast<IntT *>(&memory[target]) = value;
+	}
+
+	template <typename IntT>
+	IntT preauthorised_read(
+		const InstructionSet::x86::Source segment,
+		const uint16_t offset
+	) {
+		// Bytes can be written without further ado.
+		if constexpr (std::is_same_v<IntT, uint8_t>) {
+			return memory[address(segment, offset) & 0xf'ffff];
+		}
+
+		// Words that straddle the segment end must be split in two.
+		if(offset == 0xffff) {
+			return IntT(
+				memory[address(segment, offset) & 0xf'ffff] |
+				memory[address(segment, 0x0000) & 0xf'ffff] << 8
+			);
+		}
+
+		const uint32_t target = address(segment, offset) & 0xf'ffff;
+
+		// Words that straddle the end of physical RAM must also be split in two.
+		if(target == 0xf'ffff) {
+			return IntT(
+				memory[0xf'ffff] |
+				memory[0x0'0000] << 8
+			);
+		}
+
+		// It's safe just to write then.
+		return *reinterpret_cast<IntT *>(&memory[target]);
+	}
+
+	//
+	// Helper for instruction fetch.
+	//
+	std::pair<const uint8_t *, size_t> next_code() const {
+		const uint32_t start = segments_.cs_base_ + registers_.ip();
+		return std::make_pair(&memory[start], 0x10'000 - start);
+	}
+
+	std::pair<const uint8_t *, size_t> all() const {
+		return std::make_pair(memory.data(), 0x10'000);
+	}
+
+	//
+	// External access.
+	//
+	void install(size_t address, const uint8_t *data, size_t length) {
+		std::copy(data, data + length, memory.begin() + std::vector<uint8_t>::difference_type(address));
+	}
+
+	uint8_t *at(uint32_t address) {
+		return &memory[address];
+	}
+
+private:
+	std::array<uint8_t, 1024*1024> memory{0xff};
+	Registers<x86_model> &registers_;
+	const Segments<x86_model> &segments_;
+
+	uint32_t segment_base(const InstructionSet::x86::Source segment) const {
+		using Source = InstructionSet::x86::Source;
+		switch(segment) {
+			default:			return segments_.ds_base_;
+			case Source::ES:	return segments_.es_base_;
+			case Source::CS:	return segments_.cs_base_;
+			case Source::SS:	return segments_.ss_base_;
+		}
+	}
+
+	uint32_t address(const InstructionSet::x86::Source segment, const uint16_t offset) const {
+		return (segment_base(segment) + offset) & 0xf'ffff;
+	}
+
+	template <AccessType type>
+	typename InstructionSet::x86::Accessor<uint16_t, type>::type
+	split_word(const uint32_t low_address, const uint32_t high_address) {
+		if constexpr (is_writeable(type)) {
+			write_back_address_[0] = low_address;
+			write_back_address_[1] = high_address;
+
+			// Prepopulate only if this is a modify.
+			if constexpr (type == AccessType::ReadModifyWrite) {
+				write_back_value_ = uint16_t(memory[write_back_address_[0]] | (memory[write_back_address_[1]] << 8));
+			}
+
+			return write_back_value_;
+		} else {
+			return uint16_t(memory[low_address] | (memory[high_address] << 8));
+		}
+	}
+
+	static constexpr uint32_t NoWriteBack = 0;	// A low byte address of 0 can't require write-back.
+	uint32_t write_back_address_[2] = {NoWriteBack, NoWriteBack};
+	uint16_t write_back_value_;
 };
 
 }

--- a/Machines/PCCompatible/PCCompatible.cpp
+++ b/Machines/PCCompatible/PCCompatible.cpp
@@ -122,7 +122,7 @@ class FloppyController {
 				using Command = Intel::i8272::Command;
 				switch(decoder_.command()) {
 					default:
-						log.error().append("TODO: implement FDC command %d\n", uint8_t(decoder_.command()));
+						log.error().append("TODO: implement FDC command %d", uint8_t(decoder_.command()));
 					break;
 
 					case Command::WriteDeletedData:
@@ -619,9 +619,9 @@ class IO {
 			switch(port) {
 				default:
 					if constexpr (std::is_same_v<IntT, uint8_t>) {
-						log.error().append("Unhandled out: %02x to %04x\n", value, port);
+						log.error().append("Unhandled out: %02x to %04x", value, port);
 					} else {
-						log.error().append("Unhandled out: %04x to %04x\n", value, port);
+						log.error().append("Unhandled out: %04x to %04x", value, port);
 					}
 				break;
 
@@ -630,7 +630,7 @@ class IO {
 
 				// On the XT the NMI can be masked by setting bit 7 on I/O port 0xA0.
 				case 0x00a0:
-					log.error().append("TODO: NMIs %s\n", (value & 0x80) ? "masked" : "unmasked");
+					log.error().append("TODO: NMIs %s", (value & 0x80) ? "masked" : "unmasked");
 				break;
 
 				case 0x0000:	dma_.controller.write<0x0>(uint8_t(value));		break;
@@ -703,7 +703,7 @@ class IO {
 					fdc_.set_digital_output(uint8_t(value));
 				break;
 				case 0x03f4:
-					log.error().append("TODO: FDC write of %02x at %04x\n", value, port);
+					log.error().append("TODO: FDC write of %02x at %04x", value, port);
 				break;
 				case 0x03f5:
 					fdc_.write(uint8_t(value));
@@ -730,7 +730,7 @@ class IO {
 		template <typename IntT> IntT in([[maybe_unused]] uint16_t port) {
 			switch(port) {
 				default:
-					log.error().append("Unhandled in: %04x\n", port);
+					log.error().append("Unhandled in: %04x", port);
 				break;
 
 				case 0x0000:	return dma_.controller.read<0x0>();
@@ -844,7 +844,7 @@ class FlowController {
 			halted_ = true;
 		}
 		void wait() {
-			log.error().append("WAIT ????\n");
+			log.error().append("WAIT ????");
 		}
 
 		void repeat_last() {
@@ -1229,9 +1229,11 @@ class ConcreteMachine:
 using namespace PCCompatible;
 
 namespace {
+static constexpr bool ForceAT = false;
+
 template <Target::VideoAdaptor video>
 std::unique_ptr<Machine> machine(const Target &target, const ROMMachine::ROMFetcher &rom_fetcher) {
-	switch(target.model) {
+	switch(ForceAT ? PCModelApproximation::AT : target.model) {
 		case PCModelApproximation::XT:
 			return std::make_unique<PCCompatible::ConcreteMachine<video, PCModelApproximation::XT>>
 				(target, rom_fetcher);

--- a/Machines/PCCompatible/PCCompatible.cpp
+++ b/Machines/PCCompatible/PCCompatible.cpp
@@ -1254,7 +1254,7 @@ class ConcreteMachine:
 using namespace PCCompatible;
 
 namespace {
-static constexpr bool ForceAT = true;
+static constexpr bool ForceAT = false;
 
 template <Target::VideoAdaptor video>
 std::unique_ptr<Machine> machine(const Target &target, const ROMMachine::ROMFetcher &rom_fetcher) {

--- a/Machines/PCCompatible/PCCompatible.cpp
+++ b/Machines/PCCompatible/PCCompatible.cpp
@@ -1109,6 +1109,10 @@ class ConcreteMachine:
 //				}
 			}*/
 
+			if(decoded_.second.operation() == InstructionSet::x86::Operation::Invalid) {
+				log.error().append("Invalid operation");
+			}
+
 			// Execute it.
 			InstructionSet::x86::perform(
 				decoded_.second,
@@ -1250,7 +1254,7 @@ class ConcreteMachine:
 using namespace PCCompatible;
 
 namespace {
-static constexpr bool ForceAT = false;
+static constexpr bool ForceAT = true;
 
 template <Target::VideoAdaptor video>
 std::unique_ptr<Machine> machine(const Target &target, const ROMMachine::ROMFetcher &rom_fetcher) {
@@ -1267,6 +1271,8 @@ std::unique_ptr<Machine> machine(const Target &target, const ROMMachine::ROMFetc
 			return std::make_unique<PCCompatible::ConcreteMachine<Analyser::Static::PCCompatible::Model::AT, video>>
 				(target, rom_fetcher);
 	}
+
+	return nullptr;
 }
 }
 

--- a/Machines/PCCompatible/PIC.hpp
+++ b/Machines/PCCompatible/PIC.hpp
@@ -8,9 +8,12 @@
 
 #pragma once
 
+#include "Analyser/Static/PCCompatible/Target.hpp"
+
 namespace PCCompatible {
 
 // Cf. https://helppc.netcore2k.net/hardware/pic
+template <Analyser::Static::PCCompatible::Model model>
 class PIC {
 	public:
 		template <int address>

--- a/Machines/PCCompatible/ProcessorByModel.hpp
+++ b/Machines/PCCompatible/ProcessorByModel.hpp
@@ -1,0 +1,23 @@
+//
+//  ProcessorByModel.hpp
+//  Clock Signal
+//
+//  Created by Thomas Harte on 04/03/2025.
+//  Copyright © 2025 Thomas Harte. All rights reserved.
+//
+
+#pragma once
+
+#include "Analyser/Static/PCCompatible/Target.hpp"
+#include "InstructionSets/x86/Model.hpp"
+
+namespace PCCompatible {
+
+constexpr InstructionSet::x86::Model processor_model(Analyser::Static::PCCompatible::Model model) {
+	switch(model) {
+		default:											return InstructionSet::x86::Model::i8086;
+		case Analyser::Static::PCCompatible::Model::AT:		return InstructionSet::x86::Model::i80286;
+	}
+}
+
+}

--- a/Machines/PCCompatible/Registers.hpp
+++ b/Machines/PCCompatible/Registers.hpp
@@ -8,9 +8,15 @@
 
 #pragma once
 
+#include "InstructionSets/x86/Model.hpp"
+
 namespace PCCompatible {
 
-struct Registers {
+template <InstructionSet::x86::Model>
+struct Registers;
+
+template <>
+struct Registers<InstructionSet::x86::Model::i8086> {
 	public:
 		static constexpr bool is_32bit = false;
 
@@ -65,6 +71,14 @@ struct Registers {
 		uint16_t di_;
 		uint16_t es_, cs_, ds_, ss_;
 		uint16_t ip_;
+};
+
+template <>
+struct Registers<InstructionSet::x86::Model::i80186>: public Registers<InstructionSet::x86::Model::i8086> {
+};
+
+template <>
+struct Registers<InstructionSet::x86::Model::i80286>: public Registers<InstructionSet::x86::Model::i80186> {
 };
 
 }

--- a/Machines/PCCompatible/Segments.hpp
+++ b/Machines/PCCompatible/Segments.hpp
@@ -11,12 +11,14 @@
 #include "Registers.hpp"
 
 #include "InstructionSets/x86/Instruction.hpp"
+#include "InstructionSets/x86/Model.hpp"
 
 namespace PCCompatible {
 
+template <InstructionSet::x86::Model model>
 class Segments {
 	public:
-		Segments(const Registers &registers) : registers_(registers) {}
+		Segments(const Registers<model> &registers) : registers_(registers) {}
 
 		using Source = InstructionSet::x86::Source;
 
@@ -49,7 +51,7 @@ class Segments {
 		}
 
 	private:
-		const Registers &registers_;
+		const Registers<model> &registers_;
 };
 
 }

--- a/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
@@ -290,6 +290,8 @@
 		4B1EC716255398B000A1F44B /* Sound.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B1EC714255398B000A1F44B /* Sound.cpp */; };
 		4B1EC717255398B000A1F44B /* Sound.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B1EC714255398B000A1F44B /* Sound.cpp */; };
 		4B1EDB451E39A0AC009D6819 /* chip.png in Resources */ = {isa = PBXBuildFile; fileRef = 4B1EDB431E39A0AC009D6819 /* chip.png */; };
+		4B1FBE202D77AAC500BAC888 /* ProcessorByModel.hpp in Resources */ = {isa = PBXBuildFile; fileRef = 4B1FBE1F2D77AAC500BAC888 /* ProcessorByModel.hpp */; };
+		4B1FBE212D77AAC500BAC888 /* ProcessorByModel.hpp in Resources */ = {isa = PBXBuildFile; fileRef = 4B1FBE1F2D77AAC500BAC888 /* ProcessorByModel.hpp */; };
 		4B2005432B804D6400420C5C /* ARMDecoderTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4B2005422B804D6400420C5C /* ARMDecoderTests.mm */; };
 		4B2130E2273A7A0A008A77B4 /* Audio.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B2130E0273A7A0A008A77B4 /* Audio.cpp */; };
 		4B2130E3273A7A0A008A77B4 /* Audio.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B2130E0273A7A0A008A77B4 /* Audio.cpp */; };
@@ -1451,6 +1453,7 @@
 		4B1EC714255398B000A1F44B /* Sound.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Sound.cpp; sourceTree = "<group>"; };
 		4B1EC715255398B000A1F44B /* Sound.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Sound.hpp; sourceTree = "<group>"; };
 		4B1EDB431E39A0AC009D6819 /* chip.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = chip.png; sourceTree = "<group>"; };
+		4B1FBE1F2D77AAC500BAC888 /* ProcessorByModel.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = ProcessorByModel.hpp; sourceTree = "<group>"; };
 		4B2005402B804AA300420C5C /* OperationMapper.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = OperationMapper.hpp; sourceTree = "<group>"; };
 		4B2005422B804D6400420C5C /* ARMDecoderTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ARMDecoderTests.mm; sourceTree = "<group>"; };
 		4B2005462B8BD7A500420C5C /* Registers.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Registers.hpp; sourceTree = "<group>"; };
@@ -2561,6 +2564,7 @@
 				425739362B051EA800B7D1E4 /* PCCompatible.hpp */,
 				4267A9C82B0D4EC2008A59BB /* PIC.hpp */,
 				4267A9C72B0C26FA008A59BB /* PIT.hpp */,
+				4B1FBE1F2D77AAC500BAC888 /* ProcessorByModel.hpp */,
 				423820142B1A23C200964EFE /* Registers.hpp */,
 				42EB81252B21788200429AF4 /* RTC.hpp */,
 				423820152B1A23E100964EFE /* Segments.hpp */,
@@ -5585,6 +5589,7 @@
 				4B79E4441E3AF38600141F11 /* cassette.png in Resources */,
 				4BB73EAC1B587A5100552FC2 /* MainMenu.xib in Resources */,
 				4B8FE21D1DA19D5F0090D3CE /* QuickLoadCompositeOptions.xib in Resources */,
+				4B1FBE202D77AAC500BAC888 /* ProcessorByModel.hpp in Resources */,
 				4B49F0A923346F7A0045E6A6 /* MacintoshOptions.xib in Resources */,
 				4B051C93266D9D6900CA44E8 /* ROMImages in Resources */,
 				4B79E4461E3AF38600141F11 /* floppy525.png in Resources */,
@@ -5809,6 +5814,7 @@
 				4BB299F01B587D8400A49093 /* trap4 in Resources */,
 				4B8DF6722550D91600F3433C /* CPUBIT.sfc in Resources */,
 				4BB299451B587D8400A49093 /* dcmay in Resources */,
+				4B1FBE212D77AAC500BAC888 /* ProcessorByModel.hpp in Resources */,
 				4BB299081B587D8400A49093 /* asln in Resources */,
 				4BB2996E1B587D8400A49093 /* laxa in Resources */,
 				4BB2990A1B587D8400A49093 /* aslzx in Resources */,

--- a/OSBindings/Mac/Clock Signal/Machine/StaticAnalyser/CSStaticAnalyser.mm
+++ b/OSBindings/Mac/Clock Signal/Machine/StaticAnalyser/CSStaticAnalyser.mm
@@ -302,8 +302,8 @@
 			case CSPCCompatibleVideoAdaptorCGA:	target->adaptor = Target::VideoAdaptor::CGA;	break;
 		}
 		switch(speed) {
-			case CSPCCompatibleSpeedOriginal:	target->model = Target::ModelApproximation::XT;			break;
-			case CSPCCompatibleSpeedTurbo:		target->model = Target::ModelApproximation::TurboXT;	break;
+			case CSPCCompatibleSpeedOriginal:	target->model = Analyser::Static::PCCompatible::Model::XT;		break;
+			case CSPCCompatibleSpeedTurbo:		target->model = Analyser::Static::PCCompatible::Model::TurboXT;	break;
 		}
 		_targets.push_back(std::move(target));
 	}

--- a/OSBindings/Qt/mainwindow.cpp
+++ b/OSBindings/Qt/mainwindow.cpp
@@ -1232,8 +1232,8 @@ void MainWindow::start_pc() {
 	auto target = std::make_unique<Target>();
 
 	switch(ui->pcSpeedComboBox->currentIndex()) {
-			default:	target->model = Target::ModelApproximation::XT;			break;
-			case 1:		target->model = Target::ModelApproximation::TurboXT;	break;
+			default:	target->model = Analyser::Static::PCCompatible::Model::XT;		break;
+			case 1:		target->model = Analyser::Static::PCCompatible::Model::TurboXT;	break;
 	}
 
 	switch(ui->pcVideoAdaptorComboBox->currentIndex()) {


### PR DESCRIPTION
At least as far as building; various syntax issues were being hidden by the fact that perform<286> just wasn't in use anywhere in the build.

This also heavily templates the PC compatible's parts on the PC or processor they're meant to represent, to allow for further development there.