### PR TITLE
x86: clear auxiliary carry on AND, OR, XOR and TEST.

### DIFF
--- a/InstructionSets/x86/Implementation/Arithmetic.hpp
+++ b/InstructionSets/x86/Implementation/Arithmetic.hpp
@@ -92,11 +92,11 @@ void test(
 	/*
 		The OF and CF flags are cleared to 0.
 		The SF, ZF, and PF flags are set according to the result (see the “Operation” section above).
-		The state of the AF flag is undefined.
+		The state of the AF flag is formally undefined but known to be reset.
 	*/
 	const IntT result = destination & source;
 
-	context.flags.template set_from<Flag::Carry, Flag::Overflow>(0);
+	context.flags.template set_from<Flag::Carry, Flag::Overflow, Flag::AuxiliaryCarry>(0);
 	context.flags.template set_from<IntT, Flag::Zero, Flag::Sign, Flag::ParityOdd>(result);
 }
 

--- a/InstructionSets/x86/Implementation/Logical.hpp
+++ b/InstructionSets/x86/Implementation/Logical.hpp
@@ -23,11 +23,11 @@ void and_(
 	*/
 	/*
 		The OF and CF flags are cleared; the SF, ZF, and PF flags are set according to the result.
-		The state of the AF flag is undefined.
+		The state of the AF flag is formally undefined but implicitly cleared per 8080 compatibility.
 	*/
 	destination &= source;
 
-	context.flags.template set_from<Flag::Overflow, Flag::Carry>(0);
+	context.flags.template set_from<Flag::Overflow, Flag::Carry, Flag::AuxiliaryCarry>(0);
 	context.flags.template set_from<IntT, Flag::Zero, Flag::Sign, Flag::ParityOdd>(destination);
 }
 
@@ -42,11 +42,11 @@ void or_(
 	*/
 	/*
 		The OF and CF flags are cleared; the SF, ZF, and PF flags are set according to the result.
-		The state of the AF flag is undefined.
+		The state of the AF flag is formally undefined but implicitly cleared per 8080 compatibility.
 	*/
 	destination |= source;
 
-	context.flags.template set_from<Flag::Overflow, Flag::Carry>(0);
+	context.flags.template set_from<Flag::Overflow, Flag::Carry, Flag::AuxiliaryCarry>(0);
 	context.flags.template set_from<IntT, Flag::Zero, Flag::Sign, Flag::ParityOdd>(destination);
 }
 
@@ -61,11 +61,11 @@ void xor_(
 	*/
 	/*
 		The OF and CF flags are cleared; the SF, ZF, and PF flags are set according to the result.
-		The state of the AF flag is undefined.
+		The state of the AF flag is formally undefined but implicitly cleared per 8080 compatibility.
 	*/
 	destination ^= source;
 
-	context.flags.template set_from<Flag::Overflow, Flag::Carry>(0);
+	context.flags.template set_from<Flag::Overflow, Flag::Carry, Flag::AuxiliaryCarry>(0);
 	context.flags.template set_from<IntT, Flag::Zero, Flag::Sign, Flag::ParityOdd>(destination);
 }
 


### PR DESCRIPTION
Resolves #1513