### PR TITLE
Add some missing <cstdint> includes

### DIFF
--- a/Analyser/Static/Acorn/File.hpp
+++ b/Analyser/Static/Acorn/File.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>

--- a/Storage/Cartridge/Cartridge.hpp
+++ b/Storage/Cartridge/Cartridge.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <vector>
 #include <memory>
 


### PR DESCRIPTION
When building the 2025-03-20 release with GCC 15, these two files were missing the `<cstdint>` include.

However, the current Git master builds happily with GCC 15 with no changes, so you may want to reject this. I'm not sure whether you're trying to ensure that includes are always present in the files that use their definitions (in this case, both files do use cstdint types), or just have been included somewhere already...