### PR TITLE
Further implement the 80286

### DIFF
--- a/InstructionSets/x86/Descriptors.hpp
+++ b/InstructionSets/x86/Descriptors.hpp
@@ -206,6 +206,7 @@ struct SegmentDescriptor {
 
 	bool present() const 			{	return type_ & 0x80;		}
 	int privilege_level() const		{	return (type_ >> 5) & 3;	}
+	uint8_t access_rights() const	{	return uint8_t(type_);		}
 
 	DescriptorDescription description() const {
 		using Type = DescriptorType;

--- a/InstructionSets/x86/Descriptors.hpp
+++ b/InstructionSets/x86/Descriptors.hpp
@@ -38,6 +38,10 @@ enum class DescriptorType {
 	Invalid,
 };
 
+constexpr bool is_data_or_code(const DescriptorType type) {
+	return type <= DescriptorType::Stack;
+}
+
 enum DescriptorTypeFlag: uint8_t {
 	Accessed	= 1 << 0,
 	Busy		= 1 << 1,

--- a/InstructionSets/x86/Descriptors.hpp
+++ b/InstructionSets/x86/Descriptors.hpp
@@ -132,18 +132,41 @@ struct SegmentDescriptor {
 				}
 			break;
 
-			case Source::CS:
-				if(desc.type != DescriptorType::Code) {
-					printf("TODO: throw for non-code CS target.\n");
-					assert(false);
-				}
-			break;
-
 			default: break;
 		}
 
 		// TODO: is this descriptor privilege within reach?
 		// TODO: is this an empty descriptor*? If so: exception!
+	}
+
+	void validate_call(
+		const std::function<void(const SegmentDescriptor &)> &call_callback
+	) const {
+		const auto desc = description();
+		switch(desc.type) {
+			case DescriptorType::Code:
+				if(desc.conforming) {
+					// TODO:
+					// DPL must be :5 CPL else #GP (code segment selector)
+				} else {
+
+				}
+
+				call_callback(*this);
+			break;
+
+			case DescriptorType::CallGate:
+				assert(false);
+			break;
+
+			case DescriptorType::AvailableTaskStateSegment:
+				assert(false);
+			break;
+
+			default:
+				throw_gpf();
+			break;
+		}
 	}
 
 	/// @returns The base of this segment descriptor.

--- a/InstructionSets/x86/Implementation/FlowControl.hpp
+++ b/InstructionSets/x86/Implementation/FlowControl.hpp
@@ -108,8 +108,8 @@ void jump_absolute(
 
 template <typename AddressT, typename ContextT>
 void call_far(
-	uint16_t segment,
-	AddressT offset,
+	const uint16_t segment,
+	const AddressT offset,
 	ContextT &context
 ) {
 	context.segments.preauthorise(

--- a/InstructionSets/x86/Implementation/FlowControl.hpp
+++ b/InstructionSets/x86/Implementation/FlowControl.hpp
@@ -112,7 +112,7 @@ void call_far(
 	const AddressT offset,
 	ContextT &context
 ) {
-	context.segments.preauthorise(
+	context.segments.preauthorise_call(
 		Source::CS,
 		offset,
 		[&] {

--- a/InstructionSets/x86/Implementation/LoadStore.hpp
+++ b/InstructionSets/x86/Implementation/LoadStore.hpp
@@ -211,9 +211,9 @@ void arpl(
 
 	if(destination_rpl < source_rpl) {
 		destination = uint16_t((destination & ~3) | source_rpl);
-		context.flags.template set_from<Flag::Carry>(1);
+		context.flags.template set_from<Flag::Zero>(0);
 	} else {
-		context.flags.template set_from<Flag::Carry>(0);
+		context.flags.template set_from<Flag::Zero>(1);
 	}
 }
 

--- a/InstructionSets/x86/Implementation/LoadStore.hpp
+++ b/InstructionSets/x86/Implementation/LoadStore.hpp
@@ -143,7 +143,8 @@ void lldt(
 		descriptor_at<SegmentDescriptor>(
 			context.linear_memory,
 			context.registers.template get<DescriptorTable::Global>(),
-			source_segment & ~7);
+			source_segment & ~7,
+			false);
 
 	constexpr auto exception_code = [](const uint16_t segment) {
 		return ExceptionCode(
@@ -228,6 +229,19 @@ void clts(
 	context.registers.set_msw(
 		msw & ~MachineStatus::TaskSwitched
 	);
+}
+
+template <typename ContextT>
+void ltr(
+	read_t<uint16_t> source,
+	ContextT &context
+) {
+	if(context.registers.privilege_level()) {
+		throw Exception::exception<Vector::GeneralProtectionFault>(ExceptionCode::zero());
+	}
+
+	context.segments.preauthorise_task_state(source);
+	context.registers.set_task_state(source);
 }
 
 }

--- a/InstructionSets/x86/Implementation/LoadStore.hpp
+++ b/InstructionSets/x86/Implementation/LoadStore.hpp
@@ -268,4 +268,32 @@ void verw(
 	context.flags.template set_from<Flag::Zero>(!context.segments.template verify<false>(source));
 }
 
+template <typename ContextT>
+void lar(
+	write_t<uint16_t> destination,
+	read_t<uint16_t> source,
+	ContextT &context
+) {
+	if(const auto rights = context.segments.load_access_rights(source); rights.has_value()) {
+		destination = uint16_t(*rights << 8);
+		context.flags.template set_from<Flag::Zero>(0);
+	} else {
+		context.flags.template set_from<Flag::Zero>(1);
+	}
+}
+
+template <typename ContextT>
+void lsl(
+	write_t<uint16_t> destination,
+	read_t<uint16_t> source,
+	ContextT &context
+) {
+	if(const auto limit = context.segments.load_limit(source); limit.has_value()) {
+		destination = *limit;
+		context.flags.template set_from<Flag::Zero>(0);
+	} else {
+		context.flags.template set_from<Flag::Zero>(1);
+	}
+}
+
 }

--- a/InstructionSets/x86/Implementation/LoadStore.hpp
+++ b/InstructionSets/x86/Implementation/LoadStore.hpp
@@ -257,7 +257,7 @@ void verr(
 	read_t<uint16_t> source,
 	ContextT &context
 ) {
-	context.flags.template set_from<Flag::Zero>(!context.segments.template verify<false>(source));
+	context.flags.template set_from<Flag::Zero>(!context.segments.template verify<true>(source));
 }
 
 template <typename ContextT>
@@ -265,7 +265,7 @@ void verw(
 	read_t<uint16_t> source,
 	ContextT &context
 ) {
-	context.flags.template set_from<Flag::Zero>(!context.segments.template verify<true>(source));
+	context.flags.template set_from<Flag::Zero>(!context.segments.template verify<false>(source));
 }
 
 }

--- a/InstructionSets/x86/Implementation/LoadStore.hpp
+++ b/InstructionSets/x86/Implementation/LoadStore.hpp
@@ -244,4 +244,12 @@ void ltr(
 	context.registers.set_task_state(source);
 }
 
+template <typename ContextT>
+void str(
+	write_t<uint16_t> destination,
+	ContextT &context
+) {
+	destination = context.registers.task_state();
+}
+
 }

--- a/InstructionSets/x86/Implementation/LoadStore.hpp
+++ b/InstructionSets/x86/Implementation/LoadStore.hpp
@@ -252,4 +252,20 @@ void str(
 	destination = context.registers.task_state();
 }
 
+template <typename ContextT>
+void verr(
+	read_t<uint16_t> source,
+	ContextT &context
+) {
+	context.flags.template set_from<Flag::Zero>(!context.segments.template verify<false>(source));
+}
+
+template <typename ContextT>
+void verw(
+	read_t<uint16_t> source,
+	ContextT &context
+) {
+	context.flags.template set_from<Flag::Zero>(!context.segments.template verify<true>(source));
+}
+
 }

--- a/InstructionSets/x86/Implementation/PerformImplementation.hpp
+++ b/InstructionSets/x86/Implementation/PerformImplementation.hpp
@@ -605,13 +605,33 @@ template <
 			}
 		break;
 
+		case Operation::VERR:
+			if constexpr (ContextT::model >= Model::i80286 && std::is_same_v<IntT, uint16_t>) {
+				if(is_real(context.cpu_control.mode())) {
+					throw Exception::exception<Vector::InvalidOpcode>();
+					return;
+				}
+				Primitive::verr(source_r(), context);
+			} else {
+				assert(false);
+			}
+		break;
+		case Operation::VERW:
+			if constexpr (ContextT::model >= Model::i80286 && std::is_same_v<IntT, uint16_t>) {
+				if(is_real(context.cpu_control.mode())) {
+					throw Exception::exception<Vector::InvalidOpcode>();
+					return;
+				}
+				Primitive::verw(source_r(), context);
+			} else {
+				assert(false);
+			}
+		break;
+
 		// TODO to reach a full 80286:
 		//
 		//	LAR
-		//	VERR
-		//	VERW
 		//	LSL
-		//	STR
 		//	LOADALL
 	}
 

--- a/InstructionSets/x86/Implementation/PerformImplementation.hpp
+++ b/InstructionSets/x86/Implementation/PerformImplementation.hpp
@@ -581,6 +581,17 @@ template <
 				assert(false);
 			}
 		break;
+		case Operation::LTR:
+			if constexpr (ContextT::model >= Model::i80286) {
+				if(is_real(context.cpu_control.mode())) {
+					throw Exception::exception<Vector::InvalidOpcode>();
+					return;
+				}
+				Primitive::ltr(source_r(), context);
+			} else {
+				assert(false);
+			}
+		break;
 
 		// TODO to reach a full 80286:
 		//
@@ -588,7 +599,6 @@ template <
 		//	VERR
 		//	VERW
 		//	LSL
-		//	LTR
 		//	STR
 		//	LOADALL
 	}
@@ -739,7 +749,7 @@ void interrupt(
 	if constexpr (ContextT::model >= Model::i80286) {
 		if(context.registers.msw() & MachineStatus::ProtectedModeEnable) {
 			const auto call_gate = descriptor_at<InstructionSet::x86::InterruptDescriptor>(
-				context.linear_memory, table_pointer, uint16_t(exception.vector << 3));
+				context.linear_memory, table_pointer, uint16_t(exception.vector << 3), false);
 
 			if(!call_gate.present()) {
 				printf("TODO: should throw for non-present IDT entry\n");

--- a/InstructionSets/x86/Implementation/PerformImplementation.hpp
+++ b/InstructionSets/x86/Implementation/PerformImplementation.hpp
@@ -628,10 +628,31 @@ template <
 			}
 		break;
 
+		case Operation::LAR:
+			if constexpr (ContextT::model >= Model::i80286 && std::is_same_v<IntT, uint16_t>) {
+				if(is_real(context.cpu_control.mode())) {
+					throw Exception::exception<Vector::InvalidOpcode>();
+					return;
+				}
+				Primitive::lar(destination_w(), source_r(), context);
+			} else {
+				assert(false);
+			}
+		break;
+		case Operation::LSL:
+			if constexpr (ContextT::model >= Model::i80286 && std::is_same_v<IntT, uint16_t>) {
+				if(is_real(context.cpu_control.mode())) {
+					throw Exception::exception<Vector::InvalidOpcode>();
+					return;
+				}
+				Primitive::lsl(destination_w(), source_r(), context);
+			} else {
+				assert(false);
+			}
+		break;
+
 		// TODO to reach a full 80286:
 		//
-		//	LAR
-		//	LSL
 		//	LOADALL
 	}
 

--- a/InstructionSets/x86/Implementation/PerformImplementation.hpp
+++ b/InstructionSets/x86/Implementation/PerformImplementation.hpp
@@ -581,13 +581,25 @@ template <
 				assert(false);
 			}
 		break;
+
 		case Operation::LTR:
-			if constexpr (ContextT::model >= Model::i80286) {
+			if constexpr (ContextT::model >= Model::i80286 && std::is_same_v<IntT, uint16_t>) {
 				if(is_real(context.cpu_control.mode())) {
 					throw Exception::exception<Vector::InvalidOpcode>();
 					return;
 				}
 				Primitive::ltr(source_r(), context);
+			} else {
+				assert(false);
+			}
+		break;
+		case Operation::STR:
+			if constexpr (ContextT::model >= Model::i80286 && std::is_same_v<IntT, uint16_t>) {
+				if(is_real(context.cpu_control.mode())) {
+					throw Exception::exception<Vector::InvalidOpcode>();
+					return;
+				}
+				Primitive::str(destination_w(), context);
 			} else {
 				assert(false);
 			}

--- a/InstructionSets/x86/Registers.hpp
+++ b/InstructionSets/x86/Registers.hpp
@@ -119,6 +119,11 @@ public:
 			msw;
 	}
 
+	uint16_t task_state() const { return task_state_; }
+	void set_task_state(const uint16_t tsr) {
+		task_state_ = tsr;
+	}
+
 	uint16_t ldtr() const {	return ldtr_;	}
 	void set_ldtr(const uint16_t ldtr) {
 		ldtr_ = ldtr;
@@ -154,7 +159,7 @@ public:
 private:
 	uint16_t machine_status_;
 	DescriptorTablePointer global_, interrupt_, local_;
-	uint16_t ldtr_;
+	uint16_t ldtr_, task_state_;
 };
 
 }

--- a/Machines/PCCompatible/PCCompatible.cpp
+++ b/Machines/PCCompatible/PCCompatible.cpp
@@ -696,7 +696,7 @@ public:
 	using Exception = InstructionSet::x86::Exception;
 
 	void run_for(const Cycles duration) final {
-		const auto pit_ticks = duration.as<int>();
+		const auto pit_ticks = duration.as<int>() * 10;
 		constexpr int pit_multiplier = [] {
 			switch(pc_model) {
 				// This is implicitly treated as running at 1/3 the PIT clock = around 0.4 MIPS.

--- a/Machines/PCCompatible/RTC.hpp
+++ b/Machines/PCCompatible/RTC.hpp
@@ -18,12 +18,13 @@ namespace PCCompatible {
 class RTC {
 public:
 	template <int address>
+	requires(address >= 0 && address < 2)
 	void write(const uint8_t value) {
 		switch(address) {
 			default: break;
 			case 0:
 				selected_ = value & 0x7f;
-				// NMI not yet supported.
+				// NMI enable/disable not yet supported.
 			break;
 			case 1:
 				write_register(value);
@@ -40,6 +41,7 @@ public:
 		switch(selected_) {
 			default:
 				if(ram_selected()) {
+					printf("RTC: %02x <- %zu\n", ram_[ram_address()], ram_address());
 					return ram_[ram_address()];
 				}
 			return 0xff;

--- a/Machines/PCCompatible/Segments.hpp
+++ b/Machines/PCCompatible/Segments.hpp
@@ -72,7 +72,17 @@ public:
 	std::optional<uint16_t> load_limit(const uint16_t source) {
 		try {
 			const auto incoming = descriptor(source);
-			return incoming.offset();
+			const auto description = incoming.description();
+			using DescriptorType = InstructionSet::x86::DescriptorType;
+			if(
+				InstructionSet::x86::is_data_or_code(description.type) ||
+				description.type == DescriptorType::AvailableTaskStateSegment ||
+				description.type == DescriptorType::BusyTaskStateSegment ||
+				description.type == DescriptorType::LDT) {
+				return incoming.offset();
+			} else {
+				return std::nullopt;
+			}
 		} catch (const InstructionSet::x86::Exception &e) {
 			return std::nullopt;
 		}

--- a/Machines/PCCompatible/Segments.hpp
+++ b/Machines/PCCompatible/Segments.hpp
@@ -58,26 +58,23 @@ public:
 		const Source segment,
 		const uint16_t value,
 		const std::function<void()> &real_callback,
-		const std::function<void(const Descriptor &)> &protected_callback	// TODO: this needs to be more granular.
+		const std::function<void(const Descriptor &)> &call_callback	// TODO: call gate and task segment callbacks.
 	) {
 #ifndef NDEBUG
 		last_source_ = segment;
 #endif
 
 		if constexpr (model <= InstructionSet::x86::Model::i80186) {
-			if(real_callback) real_callback();
+			real_callback();
 			return;
 		} else {
 			if(is_real(mode_)) {
-				if(real_callback) real_callback();
+				real_callback();
 				return;
 			}
 
 			const auto incoming = descriptor(value);
-			incoming.validate_as(segment);
-			if(protected_callback) protected_callback(incoming);
-
-			// TODO: does the descriptor itself have enough context to handle/validate CALL far, JMP far, interrupts, etc?
+			incoming.validate_call(call_callback);
 		}
 	}
 

--- a/Machines/PCCompatible/Segments.hpp
+++ b/Machines/PCCompatible/Segments.hpp
@@ -60,6 +60,24 @@ public:
 		}
 	}
 
+	std::optional<uint8_t> load_access_rights(const uint16_t source) {
+		try {
+			const auto incoming = descriptor(source);
+			return incoming.access_rights();
+		} catch (const InstructionSet::x86::Exception &e) {
+			return std::nullopt;
+		}
+	}
+
+	std::optional<uint16_t> load_limit(const uint16_t source) {
+		try {
+			const auto incoming = descriptor(source);
+			return incoming.offset();
+		} catch (const InstructionSet::x86::Exception &e) {
+			return std::nullopt;
+		}
+	}
+
 	void preauthorise(
 		const Source segment,
 		const uint16_t value

--- a/Machines/PCCompatible/Segments.hpp
+++ b/Machines/PCCompatible/Segments.hpp
@@ -42,10 +42,14 @@ public:
 				return false;
 			}
 
-			if(for_read && !description.readable) {
-				return false;
-			} else if(!description.writeable) {
-				return false;
+			if constexpr (for_read) {
+				if(!description.readable) {
+					return false;
+				}
+			} else {
+				if(!description.writeable) {
+					return false;
+				}
 			}
 
 			// TODO: privilege level?

--- a/Machines/PCCompatible/Segments.hpp
+++ b/Machines/PCCompatible/Segments.hpp
@@ -32,6 +32,30 @@ public:
 	using Mode = InstructionSet::x86::Mode;
 	using Source = InstructionSet::x86::Source;
 
+	template <bool for_read>
+	bool verify(const uint16_t value) {
+		try {
+			const auto incoming = descriptor(value);
+			const auto description = incoming.description();
+
+			if(!is_data_or_code(description.type)) {
+				return false;
+			}
+
+			if(for_read && !description.readable) {
+				return false;
+			} else if(!description.writeable) {
+				return false;
+			}
+
+			// TODO: privilege level?
+
+			return true;
+		} catch (const InstructionSet::x86::Exception &e) {
+			return false;
+		}
+	}
+
 	void preauthorise(
 		const Source segment,
 		const uint16_t value

--- a/Machines/PCCompatible/Segments.hpp
+++ b/Machines/PCCompatible/Segments.hpp
@@ -58,23 +58,11 @@ public:
 					registers_.template get<DescriptorTable::Global>();
 			const auto incoming = descriptor_at<Descriptor>(memory_, table, value & ~7);
 			last_descriptor_ = incoming;
-
-			// TODO: authorise otherwise, i.e. test anything telse that should cause a throw
-			// prior to modification of the segment register.
-
-			// Check privilege level.
-	//		const auto requested_privilege_level = value & 3;
-	//		if(requested_privilege_level < descriptors[Source::CS].privilege_level()) {
-	//			printf("TODO: privilege exception.\n");
-	//			assert(false);
-	//		}
-
-			// TODO: set descriptor accessed bit in memory if it's a segment.
-
-			// Get and validate descriptor.
 			last_descriptor_.validate_as(segment);
-
 			if(protected_callback) protected_callback(incoming);
+
+			// TODO: does the descriptor itself have enough context to handle/validate CALL far, JMP far, interrupts, etc?
+			// TODO: set descriptor accessed bit in memory if it's a segment.
 		}
 	}
 


### PR DESCRIPTION
Adding:
* LTR, STR, VERR, VERW, LSL, LAR

Correcting:
* ARPL

... and stepping further toward proper support for protected mode flow control.

The IBM PC AT BIOS now seems to hit further confusion with the keyboard controller, so probably best to look there a bit more.