### PR TITLE
Reduce AT to 640kb RAM.

### DIFF
--- a/Machines/PCCompatible/PCCompatible.cpp
+++ b/Machines/PCCompatible/PCCompatible.cpp
@@ -1016,7 +1016,7 @@ using namespace PCCompatible;
 
 namespace {
 #ifndef NDEBUG
-static constexpr bool ForceAT = false;//true;
+static constexpr bool ForceAT = true;
 #else
 static constexpr bool ForceAT = false;
 #endif


### PR DESCRIPTION
This substantially speeds up the boot process, clearing the way for other experimentation.