### PR TITLE
Further prefer `static constexpr`.

### DIFF
--- a/Components/9918/Implementation/Draw.hpp
+++ b/Components/9918/Implementation/Draw.hpp
@@ -526,7 +526,7 @@ void Base<personality>::draw_yamaha(const uint8_t y, int start, int end) {
 		}
 	}
 
-	constexpr std::array<uint32_t, 16> graphics7_sprite_palette = {
+	static constexpr std::array<uint32_t, 16> graphics7_sprite_palette = {
 		palette_pack(0b00000000, 0b00000000, 0b00000000),	palette_pack(0b00000000, 0b00000000, 0b01001001),
 		palette_pack(0b00000000, 0b01101101, 0b00000000),	palette_pack(0b00000000, 0b01101101, 0b01001001),
 		palette_pack(0b01101101, 0b00000000, 0b00000000),	palette_pack(0b01101101, 0b00000000, 0b01001001),

--- a/Components/AY38910/AY38910.cpp
+++ b/Components/AY38910/AY38910.cpp
@@ -91,7 +91,7 @@ void AY38910SampleSource<is_stereo>::set_sample_volume_range(const std::int16_t 
 	// from the YM's datasheet, showing a clear power curve, and fitting that to observed
 	// values reported elsewhere.
 	const float max_volume = float(range) / 3.0f;	// As there are three channels.
-	constexpr float root_two = 1.414213562373095f;
+	static constexpr float root_two = 1.414213562373095f;
 	for(int v = 0; v < 32; v++) {
 		volumes_[v] = int(max_volume / powf(root_two, float(v ^ 0x1f) / 3.18f));
 	}

--- a/Components/OPx/Implementation/KeyLevelScaler.hpp
+++ b/Components/OPx/Implementation/KeyLevelScaler.hpp
@@ -33,7 +33,7 @@ public:
 	*/
 	void set_key_scaling_level(const int level) {
 		// '7' is just a number large enough to render all possible scaling coefficients as 0.
-		constexpr int key_level_scale_shifts[4] = {7, 1, 2, 0};
+		static constexpr int key_level_scale_shifts[4] = {7, 1, 2, 0};
 		shift_ = key_level_scale_shifts[level];
 	}
 

--- a/Components/OPx/Implementation/PhaseGenerator.hpp
+++ b/Components/OPx/Implementation/PhaseGenerator.hpp
@@ -24,8 +24,8 @@ public:
 		Advances the phase generator a single step, given the current state of the low-frequency oscillator, @c oscillator.
 	*/
 	void update(const LowFrequencyOscillator &oscillator) {
-		constexpr int vibrato_shifts[4] = {3, 1, 0, 1};
-		constexpr int vibrato_signs[2] = {1, -1};
+		static constexpr int vibrato_shifts[4] = {3, 1, 0, 1};
+		static constexpr int vibrato_signs[2] = {1, -1};
 
 		// Get just the top three bits of the period_.
 		const int top_freq = period_ >> (precision - 3);
@@ -61,7 +61,7 @@ public:
 		plus the degree of feedback to apply
 	*/
 	void apply_feedback(const LogSign first, const LogSign second, const int level) {
-		constexpr int masks[] = {0, ~0, ~0, ~0, ~0, ~0, ~0, ~0};
+		static constexpr int masks[] = {0, ~0, ~0, ~0, ~0, ~0, ~0, ~0};
 		phase_ += ((second.level(precision) + first.level(precision)) >> (8 - level)) & masks[level];
 	}
 
@@ -72,7 +72,7 @@ public:
 	void set_multiple(const int multiple) {
 		// This encodes the MUL -> multiple table given on page 12,
 		// multiplied by two.
-		constexpr int multipliers[] = {
+		static constexpr int multipliers[] = {
 			1, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 20, 24, 24, 30, 30
 		};
 		assert(multiple < 16);

--- a/Components/Serial/Line.cpp
+++ b/Components/Serial/Line.cpp
@@ -101,7 +101,7 @@ template <bool lsb_first, typename IntT> void Line<include_clock>::write_interna
 			bit = levels & 1;
 			levels >>= 1;
 		} else {
-			constexpr auto top_bit = IntT(0x80) << ((sizeof(IntT) - 1) * 8);
+			static constexpr auto top_bit = IntT(0x80) << ((sizeof(IntT) - 1) * 8);
 			bit = levels & top_bit;
 			levels <<= 1;
 		}

--- a/InstructionSets/6809/OperationMapper.hpp
+++ b/InstructionSets/6809/OperationMapper.hpp
@@ -79,23 +79,23 @@ template <int i, typename SchedulerT> void OperationMapper<Page::Page0>::dispatc
 	using AM = AddressingMode;
 	using O = Operation;
 
-	constexpr auto upper = (i >> 4) & 0xf;
-	constexpr auto lower = (i >> 0) & 0xf;
+	static constexpr auto upper = (i >> 4) & 0xf;
+	static constexpr auto lower = (i >> 0) & 0xf;
 
-	constexpr AddressingMode modes[] = {
+	static constexpr AddressingMode modes[] = {
 		AM::Immediate, AM::Direct, AM::Indexed, AM::Extended
 	};
-	constexpr AddressingMode mode = modes[(i >> 4) & 3];
+	static constexpr AddressingMode mode = modes[(i >> 4) & 3];
 
 	switch(upper) {
 		default: break;
 
 		case 0x1: {
-			constexpr Operation operations[] = {
+			static constexpr Operation operations[] = {
 				O::Page1,	O::Page2,	O::NOP,		O::SYNC,	O::None,	O::None,	O::LBRA,	O::LBSR,
 				O::None,	O::DAA,		O::ORCC,	O::None,	O::ANDCC,	O::SEX,		O::EXG,		O::TFR,
 			};
-			constexpr AddressingMode modes[] = {
+			static constexpr AddressingMode modes[] = {
 				AM::Variant,	AM::Variant,	AM::Inherent,	AM::Inherent,
 				AM::Illegal,	AM::Illegal,	AM::Relative,	AM::Relative,
 				AM::Illegal,	AM::Inherent,	AM::Immediate,	AM::Illegal,
@@ -104,18 +104,18 @@ template <int i, typename SchedulerT> void OperationMapper<Page::Page0>::dispatc
 			s.template schedule<operations[lower], modes[lower]>();
 		} break;
 		case 0x2: {
-			constexpr Operation operations[] = {
+			static constexpr Operation operations[] = {
 				O::BRA,		O::BRN,		O::BHI,		O::BLS,		O::BCC,		O::BCS,		O::BNE,		O::BEQ,
 				O::BVC,		O::BVS,		O::BPL,		O::BMI,		O::BGE,		O::BLT,		O::BGT,		O::BLE,
 			};
 			s.template schedule<operations[lower], AM::Relative>();
 		} break;
 		case 0x3: {
-			constexpr Operation operations[] = {
+			static constexpr Operation operations[] = {
 				O::LEAX,	O::LEAY,	O::LEAS,	O::LEAU,	O::PSHS,	O::PULS,	O::PSHU,	O::PULU,
 				O::None,	O::RTS,		O::ABX,		O::RTI,		O::CWAI,	O::MUL,		O::RESET,	O::SWI,
 			};
-			constexpr auto op = operations[lower];
+			static constexpr auto op = operations[lower];
 			switch(lower) {
 				case 0x0:	case 0x1:	case 0x2:	case 0x3:
 					s.template schedule<op, AM::Indexed>();
@@ -132,31 +132,31 @@ template <int i, typename SchedulerT> void OperationMapper<Page::Page0>::dispatc
 			}
 		} break;
 		case 0x4: {
-			constexpr Operation operations[] = {
+			static constexpr Operation operations[] = {
 				O::NEGA,	O::None,	O::None,	O::COMA,	O::LSRA,	O::None,	O::RORA,	O::ASRA,
 				O::LSLA,	O::ROLA,	O::DECA,	O::None,	O::INCA,	O::TSTA,	O::None,	O::CLRA,
 			};
-			constexpr auto op = operations[lower];
+			static constexpr auto op = operations[lower];
 			s.template schedule<op, op == O::None ? AM::Illegal : AM::Inherent>();
 		} break;
 		case 0x5: {
-			constexpr Operation operations[] = {
+			static constexpr Operation operations[] = {
 				O::NEGB,	O::None,	O::None,	O::COMB,	O::LSRB,	O::None,	O::RORB,	O::ASRB,
 				O::LSLB,	O::ROLB,	O::DECB,	O::None,	O::INCB,	O::TSTB,	O::None,	O::CLRB,
 			};
-			constexpr auto op = operations[lower];
+			static constexpr auto op = operations[lower];
 			s.template schedule<op, op == O::None ? AM::Illegal : AM::Inherent>();
 		} break;
 		case 0x0: case 0x6:	case 0x7: {
-			constexpr Operation operations[] = {
+			static constexpr Operation operations[] = {
 				O::NEG,		O::None,	O::None,	O::COM,		O::LSR,		O::None,	O::ROR,		O::ASR,
 				O::LSL,		O::ROL,		O::DEC,		O::None,	O::INC,		O::TST,		O::JMP,		O::CLR,
 			};
-			constexpr auto op = operations[lower];
+			static constexpr auto op = operations[lower];
 			s.template schedule<op, op == O::None ? AM::Illegal : upper == 0 ? AM::Direct : mode>();
 		} break;
 		case 0x8:	case 0x9:	case 0xa:	case 0xb: {
-			constexpr Operation operations[] = {
+			static constexpr Operation operations[] = {
 				O::SUBA,	O::CMPA,	O::SBCA,	O::SUBD,	O::ANDA,	O::BITA,	O::LDA,		O::STA,
 				O::EORA,	O::ADCA,	O::ORA,		O::ADDA,	O::CMPX,	O::JSR,		O::LDX,		O::STX,
 			};
@@ -164,7 +164,7 @@ template <int i, typename SchedulerT> void OperationMapper<Page::Page0>::dispatc
 			else			s.template schedule<operations[lower], mode>();
 		} break;
 		case 0xc:	case 0xd:	case 0xe:	case 0xf: {
-			constexpr Operation operations[] = {
+			static constexpr Operation operations[] = {
 				O::SUBB,	O::CMPB,	O::SBCB,	O::ADDD,	O::ANDB,	O::BITB,	O::LDB,		O::STB,
 				O::EORB,	O::ADCB,	O::ORB,		O::ADDB,	O::LDD,		O::STD,		O::LDU,		O::STU,
 			};
@@ -178,13 +178,13 @@ template <int i, typename SchedulerT> void OperationMapper<Page::Page1>::dispatc
 	using AM = AddressingMode;
 	using O = Operation;
 
-	constexpr AddressingMode modes[] = {
+	static constexpr AddressingMode modes[] = {
 		AM::Immediate, AM::Direct, AM::Indexed, AM::Extended
 	};
-	constexpr auto mode = modes[(i >> 4) & 3];
+	static constexpr auto mode = modes[(i >> 4) & 3];
 
 	if constexpr (i >= 0x21 && i < 0x30) {
-		constexpr Operation operations[] = {
+		static constexpr Operation operations[] = {
 						O::LBRN,	O::LBHI,	O::LBLS,	O::LBCC,	O::LBCS,	O::LBNE,	O::LBEQ,
 			O::LBVC,	O::LBVS,	O::LBPL,	O::LBMI,	O::LBGE,	O::LBLT,	O::LBGT,	O::LBLE,
 		};
@@ -219,10 +219,10 @@ template <int i, typename SchedulerT> void OperationMapper<Page::Page2>::dispatc
 	using AM = AddressingMode;
 	using O = Operation;
 
-	constexpr AddressingMode modes[] = {
+	static constexpr AddressingMode modes[] = {
 		AM::Immediate, AM::Direct, AM::Indexed, AM::Extended
 	};
-	constexpr auto mode = modes[(i >> 4) & 3];
+	static constexpr auto mode = modes[(i >> 4) & 3];
 
 	switch(i) {
 		default:	s.template schedule<O::None, AM::Illegal>();	break;

--- a/InstructionSets/ARM/Disassembler.hpp
+++ b/InstructionSets/ARM/Disassembler.hpp
@@ -172,7 +172,7 @@ struct Disassembler {
 	}
 
 	template <Flags f> void perform(const DataProcessing fields) {
-		constexpr DataProcessingFlags flags(f);
+		static constexpr DataProcessingFlags flags(f);
 
 		instruction_.operand1.type = Operand::Type::Register;
 		instruction_.operand1.value = fields.operand1();
@@ -215,7 +215,7 @@ struct Disassembler {
 
 	template <Flags> void perform(Multiply) {}
 	template <Flags f> void perform(const SingleDataTransfer fields) {
-		constexpr SingleDataTransferFlags flags(f);
+		static constexpr SingleDataTransferFlags flags(f);
 		instruction_.operation =
 			(flags.operation() == SingleDataTransferFlags::Operation::STR) ?
 				Instruction::Operation::STR : Instruction::Operation::LDR;
@@ -227,7 +227,7 @@ struct Disassembler {
 		instruction_.operand1.value = fields.base();
 	}
 	template <Flags f> void perform(const BlockDataTransfer fields) {
-		constexpr BlockDataTransferFlags flags(f);
+		static constexpr BlockDataTransferFlags flags(f);
 		instruction_.operation =
 			(flags.operation() == BlockDataTransferFlags::Operation::STM) ?
 				Instruction::Operation::STM : Instruction::Operation::LDM;
@@ -239,7 +239,7 @@ struct Disassembler {
 		instruction_.operand1.value = fields.register_list();
 	}
 	template <Flags f> void perform(const Branch fields) {
-		constexpr BranchFlags flags(f);
+		static constexpr BranchFlags flags(f);
 		instruction_.operation =
 			(flags.operation() == BranchFlags::Operation::BL) ?
 				Instruction::Operation::BL : Instruction::Operation::B;
@@ -247,7 +247,7 @@ struct Disassembler {
 		instruction_.operand1.value = fields.offset();
 	}
 	template <Flags f> void perform(CoprocessorRegisterTransfer) {
-		constexpr CoprocessorRegisterTransferFlags flags(f);
+		static constexpr CoprocessorRegisterTransferFlags flags(f);
 		instruction_.operation =
 			(flags.operation() == CoprocessorRegisterTransferFlags::Operation::MRC) ?
 				Instruction::Operation::MRC : Instruction::Operation::MCR;

--- a/InstructionSets/ARM/Executor.hpp
+++ b/InstructionSets/ARM/Executor.hpp
@@ -105,7 +105,7 @@ struct Executor {
 	}
 
 	template <Flags f> void perform(const DataProcessing fields) {
-		constexpr DataProcessingFlags flags(f);
+		static constexpr DataProcessingFlags flags(f);
 		const bool shift_by_register = !flags.operand2_is_immediate() && fields.shift_count_is_register();
 
 		// Write a raw result into the PC proxy if the target is R15; it'll be stored properly later.
@@ -127,7 +127,7 @@ struct Executor {
 		uint32_t rotate_carry = registers_.c();
 
 		// Populate carry from the shift only if it'll be used.
-		constexpr bool shift_sets_carry = is_logical(flags.operation()) && flags.set_condition_codes();
+		static constexpr bool shift_sets_carry = is_logical(flags.operation()) && flags.set_condition_codes();
 
 		// Get operand 2.
 		if constexpr (flags.operand2_is_immediate()) {
@@ -230,7 +230,7 @@ struct Executor {
 	}
 
 	template <Flags f> void perform(const Multiply fields) {
-		constexpr MultiplyFlags flags(f);
+		static constexpr MultiplyFlags flags(f);
 
 		// R15 rules:
 		//
@@ -257,7 +257,7 @@ struct Executor {
 	}
 
 	template <Flags f> void perform(const Branch branch) {
-		constexpr BranchFlags flags(f);
+		static constexpr BranchFlags flags(f);
 
 		if constexpr (flags.operation() == BranchFlags::Operation::BL) {
 			registers_[14] = registers_.pc_status(0);
@@ -266,7 +266,7 @@ struct Executor {
 	}
 
 	template <Flags f> void perform(const SingleDataTransfer transfer) {
-		constexpr SingleDataTransferFlags flags(f);
+		static constexpr SingleDataTransferFlags flags(f);
 
 		// Calculate offset.
 		uint32_t offset;
@@ -391,8 +391,8 @@ struct Executor {
 		}
 	}
 	template <Flags f> void perform(const BlockDataTransfer transfer) {
-		constexpr BlockDataTransferFlags flags(f);
-		constexpr bool is_ldm = flags.operation() == BlockDataTransferFlags::Operation::LDM;
+		static constexpr BlockDataTransferFlags flags(f);
+		static constexpr bool is_ldm = flags.operation() == BlockDataTransferFlags::Operation::LDM;
 
 		// Ensure that *base points to the base register if it can be written back;
 		// also set address to the base.

--- a/InstructionSets/M68k/Implementation/ExecutorImplementation.hpp
+++ b/InstructionSets/M68k/Implementation/ExecutorImplementation.hpp
@@ -202,7 +202,7 @@ template <typename IntT> IntT Executor<model, BusHandler>::State::read_pc() {
 template <Model model, typename BusHandler>
 uint32_t Executor<model, BusHandler>::State::index_8bitdisplacement(uint32_t base) {
 	// Determine whether full extension addressing modes are supported.
-	constexpr bool supports_full_extensions = model >= Model::M68020;
+	static constexpr bool supports_full_extensions = model >= Model::M68020;
 
 	// Get the [first] extension word.
 	const auto extension = read_pc<uint16_t>();

--- a/InstructionSets/PowerPC/Instruction.hpp
+++ b/InstructionSets/PowerPC/Instruction.hpp
@@ -1500,7 +1500,7 @@ struct Instruction {
 
 	/// A 24-bit signed number; provided as already sign extended.
 	int32_t li() const {
-		constexpr uint32_t extensions[2] = {
+		static constexpr uint32_t extensions[2] = {
 			0x0000'0000,
 			0xfc00'0000
 		};

--- a/InstructionSets/x86/Implementation/Arithmetic.hpp
+++ b/InstructionSets/x86/Implementation/Arithmetic.hpp
@@ -189,7 +189,7 @@ void divide_error(ContextT &context) {
 	//
 	// 80286-style: throw the divide error, allowing the caller to insert
 	// additional context (primarily: IP of this instruction, not the next).
-	constexpr auto exception = Exception::exception<Vector::DivideError>();
+	static constexpr auto exception = Exception::exception<Vector::DivideError>();
 	if constexpr (uses_8086_exceptions(ContextT::model)) {
 		interrupt(exception, context);
 	} else {

--- a/InstructionSets/x86/Implementation/BCD.hpp
+++ b/InstructionSets/x86/Implementation/BCD.hpp
@@ -83,7 +83,7 @@ void aam(
 		If ... an immediate value of 0 is used, it will cause a #DE (divide error) exception.
 	*/
 	if(!imm) {
-		constexpr auto exception = Exception::exception<Vector::DivideError>();
+		static constexpr auto exception = Exception::exception<Vector::DivideError>();
 		if constexpr (uses_8086_exceptions(ContextT::model)) {
 			interrupt(exception, context);
 			return;
@@ -104,7 +104,7 @@ void daas(
 	ContextT &context
 ) {
 	bool top_exceeded_threshold;
-	constexpr bool is_8086 = ContextT::model == Model::i8086;
+	static constexpr bool is_8086 = ContextT::model == Model::i8086;
 	if constexpr (is_8086) {
 		top_exceeded_threshold = al > (context.flags.template flag<Flag::AuxiliaryCarry>() ? 0x9f : 0x99);
 	} else {

--- a/InstructionSets/x86/Implementation/FlowControl.hpp
+++ b/InstructionSets/x86/Implementation/FlowControl.hpp
@@ -251,7 +251,7 @@ void into(
 	ContextT &context
 ) {
 	if(context.flags.template flag<Flag::Overflow>()) {
-		constexpr auto exception = Exception::exception<Vector::Overflow>();
+		static constexpr auto exception = Exception::exception<Vector::Overflow>();
 		if constexpr (uses_8086_exceptions(ContextT::model)) {
 			interrupt(exception, context);
 		} else {
@@ -276,7 +276,7 @@ void bound(
 		sIntT(context.memory.template access<IntT, AccessType::Read>(source_segment, IntT(source + 2)));
 
 	if(sIntT(destination) < lower_bound || sIntT(destination) > upper_bound) {
-		constexpr auto exception = Exception::exception<Vector::BoundRangeExceeded>();
+		static constexpr auto exception = Exception::exception<Vector::BoundRangeExceeded>();
 		if constexpr (uses_8086_exceptions(ContextT::model)) {
 			interrupt(exception, context);
 		} else {

--- a/InstructionSets/x86/Instruction.cpp
+++ b/InstructionSets/x86/Instruction.cpp
@@ -159,55 +159,55 @@ std::string InstructionSet::x86::to_string(Operation operation, DataSize size, M
 		case Operation::LEA:	return "lea";
 
 		case Operation::CMPS: {
-			constexpr char sizes[][6] = { "cmpsb", "cmpsw", "cmpsd", "?" };
+			static constexpr char sizes[][6] = { "cmpsb", "cmpsw", "cmpsd", "?" };
 			return sizes[static_cast<int>(size)];
 		}
 		case Operation::CMPS_REPE: {
-			constexpr char sizes[][11] = { "repe cmpsb", "repe cmpsw", "repe cmpsd", "?" };
+			static constexpr char sizes[][11] = { "repe cmpsb", "repe cmpsw", "repe cmpsd", "?" };
 			return sizes[static_cast<int>(size)];
 		}
 		case Operation::CMPS_REPNE: {
-			constexpr char sizes[][12] = { "repne cmpsb", "repne cmpsw", "repne cmpsd", "?" };
+			static constexpr char sizes[][12] = { "repne cmpsb", "repne cmpsw", "repne cmpsd", "?" };
 			return sizes[static_cast<int>(size)];
 		}
 
 		case Operation::SCAS: {
-			constexpr char sizes[][6] = { "scasb", "scasw", "scasd", "?" };
+			static constexpr char sizes[][6] = { "scasb", "scasw", "scasd", "?" };
 			return sizes[static_cast<int>(size)];
 		}
 		case Operation::SCAS_REPE: {
-			constexpr char sizes[][11] = { "repe scasb", "repe scasw", "repe scasd", "?" };
+			static constexpr char sizes[][11] = { "repe scasb", "repe scasw", "repe scasd", "?" };
 			return sizes[static_cast<int>(size)];
 		}
 		case Operation::SCAS_REPNE: {
-			constexpr char sizes[][12] = { "repne scasb", "repne scasw", "repne scasd", "?" };
+			static constexpr char sizes[][12] = { "repne scasb", "repne scasw", "repne scasd", "?" };
 			return sizes[static_cast<int>(size)];
 		}
 
 		case Operation::LODS: {
-			constexpr char sizes[][6] = { "lodsb", "lodsw", "lodsd", "?" };
+			static constexpr char sizes[][6] = { "lodsb", "lodsw", "lodsd", "?" };
 			return sizes[static_cast<int>(size)];
 		}
 		case Operation::LODS_REP: {
-			constexpr char sizes[][10] = { "rep lodsb", "rep lodsw", "rep lodsd", "?" };
+			static constexpr char sizes[][10] = { "rep lodsb", "rep lodsw", "rep lodsd", "?" };
 			return sizes[static_cast<int>(size)];
 		}
 
 		case Operation::MOVS: {
-			constexpr char sizes[][6] = { "movsb", "movsw", "movsd", "?" };
+			static constexpr char sizes[][6] = { "movsb", "movsw", "movsd", "?" };
 			return sizes[static_cast<int>(size)];
 		}
 		case Operation::MOVS_REP: {
-			constexpr char sizes[][10] = { "rep movsb", "rep movsw", "rep movsd", "?" };
+			static constexpr char sizes[][10] = { "rep movsb", "rep movsw", "rep movsd", "?" };
 			return sizes[static_cast<int>(size)];
 		}
 
 		case Operation::STOS: {
-			constexpr char sizes[][6] = { "stosb", "stosw", "stosd", "?" };
+			static constexpr char sizes[][6] = { "stosb", "stosw", "stosd", "?" };
 			return sizes[static_cast<int>(size)];
 		}
 		case Operation::STOS_REP: {
-			constexpr char sizes[][10] = { "rep stosb", "rep stosw", "rep stosd", "?" };
+			static constexpr char sizes[][10] = { "rep stosb", "rep stosw", "rep stosd", "?" };
 			return sizes[static_cast<int>(size)];
 		}
 
@@ -310,42 +310,42 @@ bool InstructionSet::x86::mnemonic_implies_data_size(Operation operation) {
 }
 
 std::string InstructionSet::x86::to_string(DataSize size) {
-	constexpr char sizes[][6] = { "byte", "word", "dword", "?" };
+	static constexpr char sizes[][6] = { "byte", "word", "dword", "?" };
 	return sizes[static_cast<int>(size)];
 }
 
 std::string InstructionSet::x86::to_string(Source source, DataSize size) {
 	switch(source) {
 		case Source::eAX: {
-			constexpr char sizes[][4] = { "al", "ax", "eax", "?" };
+			static constexpr char sizes[][4] = { "al", "ax", "eax", "?" };
 			return sizes[static_cast<int>(size)];
 		}
 		case Source::eCX: {
-			constexpr char sizes[][4] = { "cl", "cx", "ecx", "?" };
+			static constexpr char sizes[][4] = { "cl", "cx", "ecx", "?" };
 			return sizes[static_cast<int>(size)];
 		}
 		case Source::eDX: {
-			constexpr char sizes[][4] = { "dl", "dx", "edx", "?" };
+			static constexpr char sizes[][4] = { "dl", "dx", "edx", "?" };
 			return sizes[static_cast<int>(size)];
 		}
 		case Source::eBX: {
-			constexpr char sizes[][4] = { "bl", "bx", "ebx", "?" };
+			static constexpr char sizes[][4] = { "bl", "bx", "ebx", "?" };
 			return sizes[static_cast<int>(size)];
 		}
 		case Source::eSPorAH: {
-			constexpr char sizes[][4] = { "ah", "sp", "esp", "?" };
+			static constexpr char sizes[][4] = { "ah", "sp", "esp", "?" };
 			return sizes[static_cast<int>(size)];
 		}
 		case Source::eBPorCH: {
-			constexpr char sizes[][4] = { "ch", "bp", "ebp", "?" };
+			static constexpr char sizes[][4] = { "ch", "bp", "ebp", "?" };
 			return sizes[static_cast<int>(size)];
 		}
 		case Source::eSIorDH: {
-			constexpr char sizes[][4] = { "dh", "si", "esi", "?" };
+			static constexpr char sizes[][4] = { "dh", "si", "esi", "?" };
 			return sizes[static_cast<int>(size)];
 		}
 		case Source::eDIorBH: {
-			constexpr char sizes[][4] = { "bh", "di", "edi", "?" };
+			static constexpr char sizes[][4] = { "bh", "di", "edi", "?" };
 			return sizes[static_cast<int>(size)];
 		}
 

--- a/Machines/Acorn/Archimedes/Archimedes.cpp
+++ b/Machines/Acorn/Archimedes/Archimedes.cpp
@@ -117,7 +117,7 @@ public:
 	) : executor_(*this, *this, *this) {
 		set_clock_rate(ClockRate);
 
-		constexpr ROM::Name risc_os = ROM::Name::AcornRISCOS311;
+		static constexpr ROM::Name risc_os = ROM::Name::AcornRISCOS311;
 		ROM::Request request(risc_os);
 		auto roms = rom_fetcher(request);
 		if(!request.validate(roms)) {

--- a/Machines/Acorn/Archimedes/InputOutputController.hpp
+++ b/Machines/Acorn/Archimedes/InputOutputController.hpp
@@ -142,7 +142,7 @@ struct InputOutputController: public ClockingHint::Observer {
 
 	/// Decomposes an Archimedes bus address into bank, offset and type.
 	struct Address {
-		constexpr Address(uint32_t bus_address) noexcept {
+		constexpr Address(const uint32_t bus_address) noexcept {
 			bank = (bus_address >> 16) & 0b111;
 			type = Type((bus_address >> 19) & 0b11);
 			offset = bus_address & 0b1111100;

--- a/Machines/Amiga/Amiga.cpp
+++ b/Machines/Amiga/Amiga.cpp
@@ -57,7 +57,7 @@ public:
 		chipset_(memory_, PALClockRate)
 	{
 		// Temporary: use a hard-coded Kickstart selection.
-		constexpr ROM::Name rom_name = ROM::Name::AmigaA500Kickstart13;
+		static constexpr ROM::Name rom_name = ROM::Name::AmigaA500Kickstart13;
 		ROM::Request request(rom_name);
 		auto roms = rom_fetcher(request);
 		if(!request.validate(roms)) {

--- a/Machines/AmstradCPC/AmstradCPC.cpp
+++ b/Machines/AmstradCPC/AmstradCPC.cpp
@@ -521,7 +521,7 @@ private:
 		static constexpr auto COL = [](int r, int g, int b) {
 			return uint8_t((r << 4) | (g << 2) | b);
 		};
-		constexpr uint8_t mapping[32] = {
+		static constexpr uint8_t mapping[32] = {
 			COL(1, 1, 1),	COL(1, 1, 1),	COL(0, 2, 1),	COL(2, 2, 1),
 			COL(0, 0, 1),	COL(2, 0, 1),	COL(0, 1, 1),	COL(2, 1, 1),
 			COL(2, 0, 1),	COL(2, 2, 1),	COL(2, 2, 0),	COL(2, 2, 2),

--- a/Machines/Apple/ADB/ReactiveDevice.cpp
+++ b/Machines/Apple/ADB/ReactiveDevice.cpp
@@ -97,7 +97,7 @@ void ReactiveDevice::advance_state(double microseconds, bool current_level) {
 	}
 
 	// Convert that into a level.
-	constexpr double low_periods[] = {66, 33};
+	static constexpr double low_periods[] = {66, 33};
 	bus_.set_device_output(device_id_, microseconds_at_bit_ > low_periods[bit]);
 }
 

--- a/Machines/Apple/AppleII/Video.hpp
+++ b/Machines/Apple/AppleII/Video.hpp
@@ -471,9 +471,9 @@ private:
 						// Supply the real phase value if this is an Apple build.
 						// TODO: eliminate UGLY HACK.
 #if defined(__APPLE__) && !defined(IGNORE_APPLE)
-						constexpr uint8_t phase = 224;
+						static constexpr uint8_t phase = 224;
 #else
-						constexpr uint8_t phase = 192;
+						static constexpr uint8_t phase = 192;
 #endif
 
 						crt_.output_colour_burst((colour_burst_end - colour_burst_start) * 14, phase);

--- a/Machines/Apple/AppleIIgs/ADB.cpp
+++ b/Machines/Apple/AppleIIgs/ADB.cpp
@@ -124,16 +124,16 @@ uint8_t GLU::get_status() {
 	return status_ | ((visible_mouse_register_ == 2) ? 0 : uint8_t(CPUFlags::MouseXIsAvailable));
 }
 
-void GLU::set_status(uint8_t status) {
+void GLU::set_status(const uint8_t status) {
 	// This permits only the interrupt flags to be set.
-	constexpr uint8_t interrupt_flags =
+	static constexpr uint8_t interrupt_flags =
 		uint8_t(CPUFlags::MouseInterruptEnabled) |
 		uint8_t(CPUFlags::CommandDataInterruptEnabled) |
 		uint8_t(CPUFlags::KeyboardDataInterruptEnabled);
 	status_ = (status_ & ~interrupt_flags) | (status & interrupt_flags);
 }
 
-void GLU::set_command(uint8_t command) {
+void GLU::set_command(const uint8_t command) {
 	registers_[1] = command;
 	registers_[4] |= uint8_t(MicrocontrollerFlags::CommandRegisterFull);
 	status_ |= uint8_t(CPUFlags::CommandRegisterFull);

--- a/Machines/Apple/AppleIIgs/AppleIIgs.cpp
+++ b/Machines/Apple/AppleIIgs/AppleIIgs.cpp
@@ -117,8 +117,8 @@ public:
 			case Target::Model::ROM01:	system = ROM::Name::AppleIIgsROM01;	break;
 			default:					system = ROM::Name::AppleIIgsROM03;	break;
 		}
-		constexpr ROM::Name characters = ROM::Name::AppleIIEnhancedECharacter;
-		constexpr ROM::Name microcontroller = ROM::Name::AppleIIgsMicrocontrollerROM03;
+		static constexpr ROM::Name characters = ROM::Name::AppleIIEnhancedECharacter;
+		static constexpr ROM::Name microcontroller = ROM::Name::AppleIIgsMicrocontrollerROM03;
 
 		ROM::Request request = ROM::Request(system) && ROM::Request(characters) && ROM::Request(microcontroller);
 		auto roms = rom_fetcher(request);

--- a/Machines/Apple/AppleIIgs/Video.cpp
+++ b/Machines/Apple/AppleIIgs/Video.cpp
@@ -625,7 +625,7 @@ uint16_t *Video::output_super_high_res(uint16_t *target, int start, int end, int
 
 uint16_t *Video::output_double_high_resolution_mono(uint16_t *target, int start, int end, int row) {
 	const uint16_t row_address = get_row_address(row);
-	constexpr uint16_t colours[] = {0, 0xffff};
+	static constexpr uint16_t colours[] = {0, 0xffff};
 	for(int c = start; c < end; c++) {
 		const uint8_t source[2] = {
 			ram_[0x10000 + row_address + c],
@@ -766,7 +766,7 @@ uint16_t *Video::output_shift(uint16_t *target, int column) {
 	// I've picked for my rolls table and with my decision to count
 	// columns as aligned with double-mode.
 	const int phase = column * 7 + 3;
-	constexpr uint8_t rolls[4][16] = {
+	static constexpr uint8_t rolls[4][16] = {
 		{
 			0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf
 		},

--- a/Machines/Atari/ST/AtariST.cpp
+++ b/Machines/Atari/ST/AtariST.cpp
@@ -93,7 +93,7 @@ public:
 			ram_.size() >> 1
 		);
 
-		constexpr ROM::Name rom_name = ROM::Name::AtariSTTOS100;
+		static constexpr ROM::Name rom_name = ROM::Name::AtariSTTOS100;
 		ROM::Request request(rom_name);
 		auto roms = rom_fetcher(request);
 		if(!request.validate(roms)) {

--- a/Machines/ColecoVision/ColecoVision.cpp
+++ b/Machines/ColecoVision/ColecoVision.cpp
@@ -127,7 +127,7 @@ public:
 		joysticks_.emplace_back(new Joystick);
 		joysticks_.emplace_back(new Joystick);
 
-		constexpr ROM::Name rom_name = ROM::Name::ColecoVisionBIOS;
+		static constexpr ROM::Name rom_name = ROM::Name::ColecoVisionBIOS;
 		const ROM::Request request(rom_name);
 		auto roms = rom_fetcher(request);
 		if(!request.validate(roms)) {

--- a/Machines/Commodore/Plus4/Keyboard.cpp
+++ b/Machines/Commodore/Plus4/Keyboard.cpp
@@ -59,7 +59,7 @@ uint16_t KeyboardMapper::mapped_key_for_key(Inputs::Keyboard::Key key) const {
 }
 
 const uint16_t *CharacterMapper::sequence_for_character(char character) const {
-	constexpr KeySequence X = { MachineTypes::MappedKeyboardMachine::KeyNotMapped };
+	static constexpr KeySequence X = { MachineTypes::MappedKeyboardMachine::KeyNotMapped };
 	const auto key = [](Key k) -> KeySequence {
 		return { k, MachineTypes::MappedKeyboardMachine::KeyEndSequence };
 	};

--- a/Machines/Commodore/Plus4/Plus4.cpp
+++ b/Machines/Commodore/Plus4/Plus4.cpp
@@ -89,7 +89,7 @@ public:
 			target = uint16_t((target & 0x00ff) | (value << 8));
 		};
 
-		constexpr auto timer = offset >> 1;
+		static constexpr auto timer = offset >> 1;
 		paused_[timer] = ~offset & 1;
 		if constexpr (offset & 1) {
 			load_high(timers_[timer]);
@@ -106,7 +106,7 @@ public:
 
 	template <int offset>
 	uint8_t read() {
-		constexpr auto timer = offset >> 1;
+		static constexpr auto timer = offset >> 1;
 		if constexpr (offset & 1) {
 			return uint8_t(timers_[timer] >> 8);
 		} else {
@@ -310,7 +310,7 @@ public:
 //				superspeed_ &= (address != 0xe68b) && (address != 0xe68d);
 //			}
 
-			constexpr bool use_hle = true;
+			static constexpr bool use_hle = true;
 
 //			if(
 //				use_fast_tape_hack_ &&
@@ -359,7 +359,7 @@ public:
 			// TODO: rdbyte and ldsync is probably sufficient?
 
 //			if(use_fast_tape_hack_ && operation == CPU::MOS6502Esque::BusOperation::ReadOpcode) {
-//				constexpr uint16_t ldsync = 0;
+//				static constexpr uint16_t ldsync = 0;
 //				switch(address) {
 //					default: break;
 //

--- a/Machines/MSX/MSX.cpp
+++ b/Machines/MSX/MSX.cpp
@@ -221,7 +221,7 @@ public:
 
 		// Install the proper TV standard and select an ideal BIOS name.
 		const std::string machine_name = "MSX";
-		constexpr ROM::Name bios_name = model == Target::Model::MSX1 ? ROM::Name::MSXGenericBIOS : ROM::Name::MSX2GenericBIOS;
+		static constexpr ROM::Name bios_name = model == Target::Model::MSX1 ? ROM::Name::MSXGenericBIOS : ROM::Name::MSX2GenericBIOS;
 
 		ROM::Request bios_request = ROM::Request(bios_name);
 		if constexpr (model == Target::Model::MSX2) {

--- a/Machines/PCCompatible/CGA.hpp
+++ b/Machines/PCCompatible/CGA.hpp
@@ -416,12 +416,12 @@ private:
 		}
 
 		/// @returns The brightened (i.e. high intensity) version of @c source.
-		constexpr uint8_t bright(const uint8_t source) {
+		static constexpr uint8_t bright(const uint8_t source) {
 			return source | (source >> 1);
 		}
 
 		/// Maps the RGB TTL triplet @c source to an appropriate output colour.
-		constexpr uint8_t rgb(const uint8_t source) {
+		static constexpr uint8_t rgb(const uint8_t source) {
 			return uint8_t(
 				((source & 0x01) << 1) |
 				((source & 0x02) << 2) |

--- a/Machines/PCCompatible/PCCompatible.cpp
+++ b/Machines/PCCompatible/PCCompatible.cpp
@@ -716,15 +716,15 @@ public:
 		// Fetch the BIOS.
 		const auto font = Video::FontROM;
 
-		constexpr auto bios_XT = ROM::Name::PCCompatibleGLaBIOS;
-		constexpr auto tick_XT = ROM::Name::PCCompatibleGLaTICK;
+		static constexpr auto bios_XT = ROM::Name::PCCompatibleGLaBIOS;
+		static constexpr auto tick_XT = ROM::Name::PCCompatibleGLaTICK;
 
-		constexpr auto bios_AT = ROM::Name::PCCompatibleIBMATBIOS;
-		constexpr auto bios_AT_even = ROM::Name::PCCompatibleIBMATBIOSNov85U27;
-		constexpr auto bios_AT_odd = ROM::Name::PCCompatibleIBMATBIOSNov85U47;
-		constexpr auto bios_AT_Phoenix = ROM::Name::PCCompatiblePhoenix80286BIOS;
+		static constexpr auto bios_AT = ROM::Name::PCCompatibleIBMATBIOS;
+		static constexpr auto bios_AT_even = ROM::Name::PCCompatibleIBMATBIOSNov85U27;
+		static constexpr auto bios_AT_odd = ROM::Name::PCCompatibleIBMATBIOSNov85U47;
+		static constexpr auto bios_AT_Phoenix = ROM::Name::PCCompatiblePhoenix80286BIOS;
 
-		constexpr auto rom_BASIC = ROM::Name::IBMBASIC110;
+		static constexpr auto rom_BASIC = ROM::Name::IBMBASIC110;
 
 		ROM::Request request = ROM::Request(font);
 		switch(pc_model) {

--- a/Machines/Sinclair/ZXSpectrum/Video.hpp
+++ b/Machines/Sinclair/ZXSpectrum/Video.hpp
@@ -324,7 +324,7 @@ public:
 		@returns The amount of time until the next change in the interrupt line, that being the only internally-observeable output.
 	*/
 	HalfCycles next_sequence_point() {
-		constexpr auto timings = get_timings();
+		static constexpr auto timings = get_timings();
 
 		// Is the frame still ahead of this interrupt?
 		if(time_into_frame_ < timings.interrupt_time) {
@@ -344,7 +344,7 @@ public:
 		@returns The current state of the interrupt output.
 	*/
 	bool get_interrupt_line() const {
-		constexpr auto timings = get_timings();
+		static constexpr auto timings = get_timings();
 		return time_into_frame_ >= timings.interrupt_time && time_into_frame_ < timings.interrupt_time + interrupt_duration;
 	}
 
@@ -353,7 +353,7 @@ public:
 		needs to be applied in @c offset half-cycles from now.
 	*/
 	HalfCycles access_delay(HalfCycles offset) const {
-		constexpr auto timings = get_timings();
+		static constexpr auto timings = get_timings();
 		const int delay_time = (time_into_frame_ + offset.as<int>() + timings.contention_leadin) % (timings.half_cycles_per_line * timings.lines_per_frame);
 		assert(!(delay_time&1));
 
@@ -374,7 +374,7 @@ public:
 		@returns Whatever the ULA or gate array would expose via the floating bus, this cycle.
 	*/
 	uint8_t get_floating_value() const {
-		constexpr auto timings = get_timings();
+		static constexpr auto timings = get_timings();
 		const uint8_t out_of_bounds = (timing == Timing::Plus3) ? last_contended_access_ : 0xff;
 
 		const int line = time_into_frame_ / timings.half_cycles_per_line;

--- a/Numeric/UpperBound.hpp
+++ b/Numeric/UpperBound.hpp
@@ -32,7 +32,7 @@ int upper_bound_bounded(int location) {
 		return at_index<0, left+1, Args...>();
 	}
 
-	constexpr auto midpoint = (left + right) >> 1;
+	static constexpr auto midpoint = (left + right) >> 1;
 	if(location >= at_index<0, midpoint, Args...>()) {
 		return upper_bound_bounded<midpoint, right, Args...>(location);
 	} else {

--- a/OSBindings/Mac/Clock Signal/Info.plist
+++ b/OSBindings/Mac/Clock Signal/Info.plist
@@ -821,11 +821,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>25.05.27</string>
+	<string>25.09.13</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>25.05.27</string>
+	<string>25.09.13</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.entertainment</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Outputs/Speaker/Implementation/CompoundSource.hpp
+++ b/Outputs/Speaker/Implementation/CompoundSource.hpp
@@ -81,7 +81,7 @@ private:
 					Outputs::Speaker::apply<action>(target[c], StereoSample(conversion_source_[c]));
 				}
 			} else {
-				constexpr bool is_final_source = sizeof...(R) == 0;
+				static constexpr bool is_final_source = sizeof...(R) == 0;
 
 				// Get the rest of the output, if any.
 				if constexpr (!is_final_source) {


### PR DESCRIPTION
This feels silly, since it'll have no effect on production code generation, but it seems to affect debug builds. I  prefer the `static` modifier there so that there's less to step over.