### PR TITLE
Begin move towards automatic cropping.

### DIFF
--- a/Machines/Atari/2600/Atari2600.cpp
+++ b/Machines/Atari/2600/Atari2600.cpp
@@ -13,6 +13,8 @@
 
 #include "Machines/MachineTypes.hpp"
 
+#include "Outputs/CRT/MismatchWarner.hpp"
+
 #include "Analyser/Static/Atari2600/Target.hpp"
 
 #include "Cartridges/Atari8k.hpp"

--- a/Machines/Oric/Video.hpp
+++ b/Machines/Oric/Video.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "Outputs/CRT/CRT.hpp"
+#include "Outputs/CRT/MismatchWarner.hpp"
 #include "ClockReceiver/ClockReceiver.hpp"
 
 #include <cstdint>

--- a/Numeric/CubicCurve.hpp
+++ b/Numeric/CubicCurve.hpp
@@ -1,0 +1,69 @@
+//
+//  CubicCurve.hpp
+//  Clock Signal
+//
+//  Created by Thomas Harte on 04/10/2025.
+//  Copyright © 2025 Thomas Harte. All rights reserved.
+//
+
+#pragma once
+
+#include <cassert>
+
+/*!
+	Provides a cubic Bezier-based timing function.
+*/
+struct CubicCurve {
+	CubicCurve(const float c1x, const float c1y, const float c2x, const float c2y) :
+		c1(c1x, c1y), c2(c2x, c2y)
+	{
+		assert(0.0f <= c1x);	assert(c1x <= 1.0f);
+		assert(0.0f <= c1y);	assert(c1y <= 1.0f);
+		assert(0.0f <= c2x);	assert(c2x <= 1.0f);
+		assert(0.0f <= c2y);	assert(c2y <= 1.0f);
+	}
+
+	/// @returns A standard ease-in-out animation curve.
+	static CubicCurve easeInOut() {
+		return CubicCurve(0.42f, 0.0f, 0.58f, 1.0f);
+	}
+
+	/// @returns The value for y given x, in range [0.0, 1.0].
+	float value(const float x) const {
+		return axis(t(x), 1);
+	}
+
+private:
+	/// @returns The value for @c t that generates the value @c x.
+	float t(const float x) const {
+		static constexpr float Precision = 0.01f;
+		float bounds[2] = {0.0f, 1.0f};
+		const auto midpoint = [&] { return (bounds[0] + bounds[1]) * 0.5f; };
+
+		while(bounds[1] > bounds[0] + Precision) {
+			const float mid = midpoint();
+			const float value = axis(mid, 0);
+			if(value > x) {
+				bounds[1] = mid;
+			} else {
+				bounds[0] = mid;
+			}
+		}
+		return midpoint();
+	}
+
+	/// @returns The value for axis @c index at time @c t.
+	float axis(const float t, int index) const {
+		const float f1 = t * c1[index];
+		const float f2 = t * c2[index] + (1.0f - t) * c1[index];
+		const float f3 = t + (1.0f - t) * c2[index];
+
+		const float c1 = t * f2 + (1.0f - t) * f1;
+		const float c2 = t * f3 + (1.0f - t) * f2;
+
+		return t * c2 + (1.0f - t) * c1;
+	}
+
+	float c1[2];
+	float c2[2];
+};

--- a/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
@@ -1780,6 +1780,7 @@
 		4B83348E1F5DBA6E0097E338 /* 6522Storage.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = 6522Storage.hpp; path = Implementation/6522Storage.hpp; sourceTree = "<group>"; };
 		4B8334911F5E24FF0097E338 /* C1540Base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = C1540Base.hpp; path = Implementation/C1540Base.hpp; sourceTree = "<group>"; };
 		4B8334941F5E25B60097E338 /* C1540.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = C1540.cpp; path = Implementation/C1540.cpp; sourceTree = "<group>"; };
+		4B847B9F2E920C7500774B9B /* CubicCurve.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = CubicCurve.hpp; path = /Users/thomasharte/Projects/CLK/Numeric/CubicCurve.hpp; sourceTree = "<absolute>"; };
 		4B85322922778E4200F26553 /* Comparative68000.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Comparative68000.hpp; sourceTree = "<group>"; };
 		4B85322E2277ABDD00F26553 /* tos100.trace.txt.gz */ = {isa = PBXFileReference; lastKnownFileType = archive.gzip; path = tos100.trace.txt.gz; sourceTree = "<group>"; };
 		4B8671EA2D8B40D8009E1610 /* Descriptors.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Descriptors.hpp; sourceTree = "<group>"; };
@@ -3147,6 +3148,7 @@
 				4BD191D5219113B80042E144 /* OpenGL */,
 				4BB8616B24E22DC500A00E03 /* ScanTargets */,
 				4BD060A41FE49D3C006E14BE /* Speaker */,
+				4B847B9F2E920C7500774B9B /* CubicCurve.hpp */,
 			);
 			name = Outputs;
 			path = ../../Outputs;

--- a/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
@@ -1781,6 +1781,7 @@
 		4B8334911F5E24FF0097E338 /* C1540Base.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = C1540Base.hpp; path = Implementation/C1540Base.hpp; sourceTree = "<group>"; };
 		4B8334941F5E25B60097E338 /* C1540.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = C1540.cpp; path = Implementation/C1540.cpp; sourceTree = "<group>"; };
 		4B847B9F2E920C7500774B9B /* CubicCurve.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = CubicCurve.hpp; path = /Users/thomasharte/Projects/CLK/Numeric/CubicCurve.hpp; sourceTree = "<absolute>"; };
+		4B847BA42E94320B00774B9B /* MismatchWarner.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = MismatchWarner.hpp; sourceTree = "<group>"; };
 		4B85322922778E4200F26553 /* Comparative68000.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Comparative68000.hpp; sourceTree = "<group>"; };
 		4B85322E2277ABDD00F26553 /* tos100.trace.txt.gz */ = {isa = PBXFileReference; lastKnownFileType = archive.gzip; path = tos100.trace.txt.gz; sourceTree = "<group>"; };
 		4B8671EA2D8B40D8009E1610 /* Descriptors.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Descriptors.hpp; sourceTree = "<group>"; };
@@ -2798,6 +2799,7 @@
 			children = (
 				4B0CCC421C62D0B3001CAC5F /* CRT.cpp */,
 				4B0CCC431C62D0B3001CAC5F /* CRT.hpp */,
+				4B847BA42E94320B00774B9B /* MismatchWarner.hpp */,
 				4BBF99071C8FBA6F0075DAFB /* Internals */,
 			);
 			path = CRT;

--- a/Outputs/CRT/CRT.cpp
+++ b/Outputs/CRT/CRT.cpp
@@ -203,6 +203,9 @@ void CRT::advance_cycles(
 	const bool is_output_run = ((type == Scan::Type::Level) || (type == Scan::Type::Data));
 	const auto total_cycles = number_of_cycles;
 	bool did_output = false;
+	const auto end_point = [&] {
+		return this->end_point(uint16_t((total_cycles - number_of_cycles) * number_of_samples / total_cycles));
+	};
 
 	while(number_of_cycles) {
 		// Get time until next horizontal and vertical sync generator events.
@@ -233,9 +236,7 @@ void CRT::advance_cycles(
 
 		// If outputting, store the start location and scan constants.
 		if(next_scan) {
-			next_scan->end_points[0] = end_point(
-				uint16_t((total_cycles - number_of_cycles) * number_of_samples / total_cycles)
-			);
+			next_scan->end_points[0] = end_point();
 			next_scan->composite_amplitude = colour_burst_amplitude_;
 		}
 
@@ -256,9 +257,7 @@ void CRT::advance_cycles(
 
 		// End the scan if necessary.
 		if(next_scan) {
-			next_scan->end_points[1] = end_point(
-				uint16_t((total_cycles - number_of_cycles) * number_of_samples / total_cycles)
-			);
+			next_scan->end_points[1] = end_point();
 			scan_target_->end_scan();
 		}
 
@@ -286,7 +285,7 @@ void CRT::advance_cycles(
 			scan_target_->announce(
 				event,
 				!(horizontal_flywheel_.is_in_retrace() || vertical_flywheel_.is_in_retrace()),
-				end_point(uint16_t((total_cycles - number_of_cycles) * number_of_samples / total_cycles)),
+				end_point(),
 				colour_burst_amplitude_);
 
 			// If retrace is starting, update phase if required and mark no colour burst spotted yet.
@@ -307,7 +306,7 @@ void CRT::advance_cycles(
 			scan_target_->announce(
 				event,
 				!(horizontal_flywheel_.is_in_retrace() || vertical_flywheel_.is_in_retrace()),
-				end_point(uint16_t((total_cycles - number_of_cycles) * number_of_samples / total_cycles)),
+				end_point(),
 				colour_burst_amplitude_);
 		}
 

--- a/Outputs/CRT/CRT.cpp
+++ b/Outputs/CRT/CRT.cpp
@@ -207,7 +207,10 @@ void CRT::advance_cycles(
 	while(number_of_cycles) {
 		// Get time until next horizontal and vertical sync generator events.
 		const auto vertical_event = vertical_flywheel_.next_event_in_period(vsync_requested, number_of_cycles);
+		assert(vertical_event.second >= 0 && vertical_event.second <= number_of_cycles);
+
 		const auto horizontal_event = horizontal_flywheel_.next_event_in_period(hsync_requested, vertical_event.second);
+		assert(horizontal_event.second >= 0 && horizontal_event.second <= vertical_event.second);
 
 		// Whichever event is scheduled to happen first is the one to advance to.
 		const int next_run_length = horizontal_event.second;

--- a/Outputs/CRT/CRT.cpp
+++ b/Outputs/CRT/CRT.cpp
@@ -193,11 +193,11 @@ CRT::CRT(Outputs::Display::InputDataType data_type) : CRT(100, 1, 100, 1, data_t
 
 // MARK: - Sync loop
 
-Flywheel::SyncEvent CRT::get_next_vertical_sync_event(bool vsync_is_requested, int cycles_to_run_for, int *cycles_advanced) {
+Flywheel::SyncEvent CRT::get_next_vertical_sync_event(bool vsync_is_requested, int cycles_to_run_for, int &cycles_advanced) {
 	return vertical_flywheel_.get_next_event_in_period(vsync_is_requested, cycles_to_run_for, cycles_advanced);
 }
 
-Flywheel::SyncEvent CRT::get_next_horizontal_sync_event(bool hsync_is_requested, int cycles_to_run_for, int *cycles_advanced) {
+Flywheel::SyncEvent CRT::get_next_horizontal_sync_event(bool hsync_is_requested, int cycles_to_run_for, int &cycles_advanced) {
 	return horizontal_flywheel_.get_next_event_in_period(hsync_is_requested, cycles_to_run_for, cycles_advanced);
 }
 
@@ -230,8 +230,8 @@ void CRT::advance_cycles(int number_of_cycles, bool hsync_requested, bool vsync_
 
 		// Get time until next horizontal and vertical sync generator events.
 		int time_until_vertical_sync_event, time_until_horizontal_sync_event;
-		const Flywheel::SyncEvent next_vertical_sync_event = get_next_vertical_sync_event(vsync_requested, number_of_cycles, &time_until_vertical_sync_event);
-		const Flywheel::SyncEvent next_horizontal_sync_event = get_next_horizontal_sync_event(hsync_requested, time_until_vertical_sync_event, &time_until_horizontal_sync_event);
+		const Flywheel::SyncEvent next_vertical_sync_event = get_next_vertical_sync_event(vsync_requested, number_of_cycles, time_until_vertical_sync_event);
+		const Flywheel::SyncEvent next_horizontal_sync_event = get_next_horizontal_sync_event(hsync_requested, time_until_vertical_sync_event, time_until_horizontal_sync_event);
 
 		// Whichever event is scheduled to happen first is the one to advance to.
 		const int next_run_length = std::min(time_until_vertical_sync_event, time_until_horizontal_sync_event);

--- a/Outputs/CRT/CRT.cpp
+++ b/Outputs/CRT/CRT.cpp
@@ -504,7 +504,7 @@ Outputs::Display::Rect CRT::get_rect_for_area(
 	int number_of_lines,
 	int first_cycle_after_sync,
 	int number_of_cycles,
-	float aspect_ratio
+	const float aspect_ratio
 ) const {
 	assert(number_of_cycles > 0);
 	assert(number_of_lines > 0);

--- a/Outputs/CRT/CRT.hpp
+++ b/Outputs/CRT/CRT.hpp
@@ -333,17 +333,6 @@ private:
 		const Scan::Type,
 		int number_of_samples);
 
-	Flywheel::SyncEvent get_next_vertical_sync_event(
-		bool vsync_is_requested,
-		int cycles_to_run_for,
-		int &cycles_advanced
-	);
-	Flywheel::SyncEvent get_next_horizontal_sync_event(
-		bool hsync_is_requested,
-		int cycles_to_run_for,
-		int &cycles_advanced
-	);
-
 	Delegate *delegate_ = nullptr;
 	int frames_since_last_delegate_call_ = 0;
 

--- a/Outputs/CRT/CRT.hpp
+++ b/Outputs/CRT/CRT.hpp
@@ -81,12 +81,12 @@ public:
 	CRT(int cycles_per_line,
 		int clocks_per_pixel_greatest_common_divisor,
 		int height_of_display,
-		Outputs::Display::ColourSpace colour_space,
+		Outputs::Display::ColourSpace,
 		int colour_cycle_numerator,
 		int colour_cycle_denominator,
 		int vertical_sync_half_lines,
 		bool should_alternate,
-		Outputs::Display::InputDataType data_type);
+		Outputs::Display::InputDataType);
 
 	/*! Constructs a monitor-style CRT — one that will take only an RGB or monochrome signal, and therefore has
 		no colour space or colour subcarrier frequency. This monitor will automatically map colour bursts to the black level.
@@ -95,15 +95,15 @@ public:
 		int clocks_per_pixel_greatest_common_divisor,
 		int height_of_display,
 		int vertical_sync_half_lines,
-		Outputs::Display::InputDataType data_type);
+		Outputs::Display::InputDataType);
 
 	/*!	Exactly identical to calling the designated constructor with colour subcarrier information
 		looked up by display type.
 	*/
 	CRT(int cycles_per_line,
 		int minimum_cycles_per_pixel,
-		Outputs::Display::Type display_type,
-		Outputs::Display::InputDataType data_type);
+		Outputs::Display::Type,
+		Outputs::Display::InputDataType);
 
 	/*!	Constructs a CRT with no guaranteed expectations as to input signal other than data type;
 		this allows for callers that intend to rely on @c set_new_timing.
@@ -115,7 +115,7 @@ public:
 	void set_new_timing(
 		int cycles_per_line,
 		int height_of_display,
-		Outputs::Display::ColourSpace colour_space,
+		Outputs::Display::ColourSpace,
 		int colour_cycle_numerator,
 		int colour_cycle_denominator,
 		int vertical_sync_half_lines,
@@ -125,15 +125,15 @@ public:
 		as though the new timing had been provided at construction. */
 	void set_new_display_type(
 		int cycles_per_line,
-		Outputs::Display::Type display_type);
+		Outputs::Display::Type);
 
 	/*!	Changes the type of data being supplied as input.
 	*/
-	void set_new_data_type(Outputs::Display::InputDataType data_type);
+	void set_new_data_type(Outputs::Display::InputDataType);
 
 	/*!	Sets the CRT's intended aspect ratio — 4.0/3.0 by default.
 	*/
-	void set_aspect_ratio(float aspect_ratio);
+	void set_aspect_ratio(float);
 
 	/*!	Output at the sync level.
 
@@ -176,7 +176,7 @@ public:
 	*/
 	void output_data(int number_of_cycles, size_t number_of_samples);
 
-	/*! A shorthand form for output_data that assumes the number of cycles to output for is the same as the number of samples. */
+	/*! A shorthand form for @c output_data that assumes the number of cycles to output for is the same as the number of samples. */
 	void output_data(int number_of_cycles) {
 		output_data(number_of_cycles, size_t(number_of_cycles));
 	}
@@ -191,7 +191,12 @@ public:
 		@param amplitude The amplitude of the colour burst in 1/255ths of the amplitude of the
 		positive portion of the wave.
 	*/
-	void output_colour_burst(int number_of_cycles, uint8_t phase, bool is_alternate_line = false, uint8_t amplitude = DefaultAmplitude);
+	void output_colour_burst(
+		int number_of_cycles,
+		uint8_t phase,
+		bool is_alternate_line = false,
+		uint8_t amplitude = DefaultAmplitude
+	);
 
 	/*! Outputs a colour burst exactly in phase with CRT expectations using the idiomatic amplitude.
 
@@ -230,7 +235,7 @@ public:
 	}
 
 	/*!	Sets the gamma exponent for the simulated screen. */
-	void set_input_gamma(float gamma);
+	void set_input_gamma(float);
 
 	enum CompositeSourceType {
 		/// The composite function provides continuous output.
@@ -253,7 +258,7 @@ public:
 	void set_composite_function_type(CompositeSourceType type, float offset_of_first_sample = 0.0f);
 
 	/*!	Nominates a section of the display to crop to for output. */
-	void set_visible_area(Outputs::Display::Rect visible_area);
+	void set_visible_area(Outputs::Display::Rect);
 
 	/*!	@returns The rectangle describing a subset of the display, allowing for sync periods. */
 	Outputs::Display::Rect get_rect_for_area(

--- a/Outputs/CRT/CRT.hpp
+++ b/Outputs/CRT/CRT.hpp
@@ -62,7 +62,7 @@ private:
 	// Two flywheels regulate scanning; the vertical will have a range much greater than the horizontal;
 	// the output divider is what that'll need to be divided by to reduce it into a 16-bit range as
 	// posted on to the scan target.
-	std::unique_ptr<Flywheel> horizontal_flywheel_, vertical_flywheel_;
+	Flywheel horizontal_flywheel_, vertical_flywheel_;
 	int vertical_flywheel_output_divider_ = 1;
 	int cycles_since_horizontal_sync_ = 0;
 	Display::ScanTarget::Scan::EndPoint end_point(uint16_t data_offset);

--- a/Outputs/CRT/Internals/Flywheel.hpp
+++ b/Outputs/CRT/Internals/Flywheel.hpp
@@ -60,7 +60,7 @@ struct Flywheel {
 
 		@returns The next synchronisation event.
 	*/
-	inline SyncEvent get_next_event_in_period(
+	SyncEvent next_event_in_period(
 		const bool sync_is_requested,
 		const int cycles_to_run_for,
 		int &cycles_advanced
@@ -110,7 +110,7 @@ struct Flywheel {
 
 		@param event The synchronisation event to apply after that period.
 	*/
-	inline void apply_event(const int cycles_advanced, const SyncEvent event) {
+	void apply_event(const int cycles_advanced, const SyncEvent event) {
 		// In debug builds, perform a sanity check for counter overflow.
 #ifndef NDEBUG
 		const int old_counter = counter_;
@@ -133,7 +133,7 @@ struct Flywheel {
 
 		@returns The current output position.
 	*/
-	inline int get_current_output_position() const {
+	int current_output_position() const {
 		if(counter_ < retrace_time_) {
 			const int retrace_distance = int((int64_t(counter_) * int64_t(standard_period_)) / int64_t(retrace_time_));
 			if(retrace_distance > counter_before_retrace_) return 0;
@@ -145,60 +145,60 @@ struct Flywheel {
 
 	/*!
 		Returns the current 'phase' — 0 is the start of the display; a count up to 0 from a negative number represents
-		the retrace period and it will then count up to get_locked_scan_period().
+		the retrace period and it will then count up to @c locked_scan_period().
 
 		@returns The current output position.
 	*/
-	inline int get_current_phase() const {
+	int current_phase() const {
 		return counter_ - retrace_time_;
 	}
 
 	/*!
 		@returns the amount of time since retrace last began. Time then counts monotonically up from zero.
 	*/
-	inline int get_current_time() const {
+	int current_time() const {
 		return counter_;
 	}
 
 	/*!
 		@returns whether the output is currently retracing.
 	*/
-	inline bool is_in_retrace() const {
+	bool is_in_retrace() const {
 		return counter_ < retrace_time_;
 	}
 
 	/*!
 		@returns the expected length of the scan period (excluding retrace).
 	*/
-	inline int get_scan_period() const {
+	int scan_period() const {
 		return standard_period_ - retrace_time_;
 	}
 
 	/*!
 		@returns the actual length of the scan period (excluding retrace).
 	*/
-	inline int get_locked_scan_period() const {
+	int locked_scan_period() const {
 		return expected_next_sync_ - retrace_time_;
 	}
 
 	/*!
 		@returns the expected length of a complete scan and retrace cycle.
 	*/
-	inline int get_standard_period() const {
+	int standard_period() const {
 		return standard_period_;
 	}
 
 	/*!
 		@returns the actual current period for a complete scan (including retrace).
 	*/
-	inline int get_locked_period() const {
+	int locked_period() const {
 		return expected_next_sync_;
 	}
 
 	/*!
 		@returns the amount by which the @c locked_period was adjusted, the last time that an adjustment was applied.
 	*/
-	inline int get_last_period_adjustment() const {
+	int last_period_adjustment() const {
 		return last_adjustment_;
 	}
 
@@ -206,7 +206,7 @@ struct Flywheel {
 		@returns the number of synchronisation events that have seemed surprising since the last time this method was called;
 		a low number indicates good synchronisation.
 	*/
-	inline int get_and_reset_number_of_surprises() {
+	int get_and_reset_number_of_surprises() {
 		const int result = number_of_surprises_;
 		number_of_surprises_ = 0;
 		return result;
@@ -215,21 +215,21 @@ struct Flywheel {
 	/*!
 		@returns A count of the number of retraces so far performed.
 	*/
-	inline int get_number_of_retraces() const {
+	int number_of_retraces() const {
 		return number_of_retraces_;
 	}
 
 	/*!
 		@returns The amount of time this flywheel spends in retrace, as supplied at construction.
 	*/
-	inline int get_retrace_period() const {
+	int retrace_period() const {
 		return retrace_time_;
 	}
 
 	/*!
 		@returns `true` if a sync is expected soon or if the time at which it was expected (or received) was recent.
 	*/
-	inline bool is_near_expected_sync() const {
+	bool is_near_expected_sync() const {
 		return
 			(counter_ < (standard_period_ / 100)) ||
 			(counter_ >= expected_next_sync_ - (standard_period_ / 100));

--- a/Outputs/CRT/Internals/Flywheel.hpp
+++ b/Outputs/CRT/Internals/Flywheel.hpp
@@ -29,12 +29,14 @@ struct Flywheel {
 		@param retrace_time The amount of time it takes to complete a retrace.
 		@param sync_error_window The permitted deviation of sync timings from the norm.
 	*/
-	Flywheel(int standard_period, int retrace_time, int sync_error_window) :
+	Flywheel(const int standard_period, const int retrace_time, const int sync_error_window) noexcept :
 		standard_period_(standard_period),
 		retrace_time_(retrace_time),
 		sync_error_window_(sync_error_window),
 		counter_before_retrace_(standard_period - retrace_time),
 		expected_next_sync_(standard_period) {}
+
+	Flywheel() = default;
 
 	enum SyncEvent {
 		/// Indicates that no synchronisation events will occur in the queried window.
@@ -58,7 +60,11 @@ struct Flywheel {
 
 		@returns The next synchronisation event.
 	*/
-	inline SyncEvent get_next_event_in_period(bool sync_is_requested, int cycles_to_run_for, int *cycles_advanced) {
+	inline SyncEvent get_next_event_in_period(
+		const bool sync_is_requested,
+		const int cycles_to_run_for,
+		int *const cycles_advanced
+	) {
 		// If sync is signalled _now_, consider adjusting expected_next_sync_.
 		if(sync_is_requested) {
 			const auto last_sync = expected_next_sync_;
@@ -104,7 +110,7 @@ struct Flywheel {
 
 		@param event The synchronisation event to apply after that period.
 	*/
-	inline void apply_event(int cycles_advanced, SyncEvent event) {
+	inline void apply_event(const int cycles_advanced, const SyncEvent event) {
 		// In debug builds, perform a sanity check for counter overflow.
 #ifndef NDEBUG
 		const int old_counter = counter_;
@@ -230,9 +236,9 @@ struct Flywheel {
 	}
 
 private:
-	const int standard_period_;		// The idealised length of time between syncs.
-	const int retrace_time_;		// A constant indicating the amount of time it takes to perform a retrace.
-	const int sync_error_window_;	// A constant indicating the window either side of the next expected sync in which we'll accept other syncs.
+	int standard_period_;		// The idealised length of time between syncs.
+	int retrace_time_;			// A constant indicating the amount of time it takes to perform a retrace.
+	int sync_error_window_;		// A constant indicating the window either side of the next expected sync in which we'll accept other syncs.
 
 	int counter_ = 0;				// Time since the _start_ of the last sync.
 	int counter_before_retrace_;	// The value of _counter immediately before retrace began.

--- a/Outputs/CRT/Internals/Flywheel.hpp
+++ b/Outputs/CRT/Internals/Flywheel.hpp
@@ -63,7 +63,7 @@ struct Flywheel {
 	inline SyncEvent get_next_event_in_period(
 		const bool sync_is_requested,
 		const int cycles_to_run_for,
-		int *const cycles_advanced
+		int &cycles_advanced
 	) {
 		// If sync is signalled _now_, consider adjusting expected_next_sync_.
 		if(sync_is_requested) {
@@ -98,7 +98,7 @@ struct Flywheel {
 			proposed_event = SyncEvent::StartRetrace;
 		}
 
-		*cycles_advanced = proposed_sync_time;
+		cycles_advanced = proposed_sync_time;
 		return proposed_event;
 	}
 

--- a/Outputs/CRT/Internals/Flywheel.hpp
+++ b/Outputs/CRT/Internals/Flywheel.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cassert>
 #include <cstdlib>
 #include <cstdint>
@@ -61,7 +62,7 @@ struct Flywheel {
 		// In practice this is a weighted mix of the two values, with the exact weighting affecting how
 		// quickly the flywheel adjusts to new input. It's a IIR lowpass filter.
 		constexpr auto mix = [](const int expected, const int actual) {
-			return (expected + actual) >> 1;
+			return (expected + 3*actual) >> 2;
 		};
 
 		// A debugging helper.
@@ -99,7 +100,9 @@ struct Flywheel {
 
 		// Start a retrace?
 		if(counter_ + proposed_sync_time >= expected_next_sync_) {
-			proposed_sync_time = require_positive(expected_next_sync_ - counter_);
+			// A change in expectations above may have moved the expected sync time to before now.
+			// If so, just start sync ASAP.
+			proposed_sync_time = std::max(0, expected_next_sync_ - counter_);
 			proposed_event = SyncEvent::StartRetrace;
 		}
 

--- a/Outputs/CRT/Internals/Flywheel.hpp
+++ b/Outputs/CRT/Internals/Flywheel.hpp
@@ -64,6 +64,12 @@ struct Flywheel {
 			return (expected + actual) >> 1;
 		};
 
+		// A debugging helper.
+		constexpr auto require_positive = [](const int value) {
+			assert(value >= 0);
+			return value;
+		};
+
 		// If sync is signalled _now_, consider adjusting expected_next_sync_.
 		if(sync_is_requested) {
 			const auto last_sync = expected_next_sync_;
@@ -87,13 +93,13 @@ struct Flywheel {
 
 		// End an ongoing retrace?
 		if(counter_ < retrace_time_ && counter_ + proposed_sync_time >= retrace_time_) {
-			proposed_sync_time = retrace_time_ - counter_;
+			proposed_sync_time = require_positive(retrace_time_ - counter_);
 			proposed_event = SyncEvent::EndRetrace;
 		}
 
 		// Start a retrace?
 		if(counter_ + proposed_sync_time >= expected_next_sync_) {
-			proposed_sync_time = expected_next_sync_ - counter_;
+			proposed_sync_time = require_positive(expected_next_sync_ - counter_);
 			proposed_event = SyncEvent::StartRetrace;
 		}
 

--- a/Outputs/CRT/MismatchWarner.hpp
+++ b/Outputs/CRT/MismatchWarner.hpp
@@ -1,0 +1,69 @@
+//
+//  MismatchWarner.hpp
+//  Clock Signal
+//
+//  Created by Thomas Harte on 06/10/2025.
+//  Copyright © 2025 Thomas Harte. All rights reserved.
+//
+
+#pragma once
+
+#include "CRT.hpp"
+
+namespace Outputs::CRT {
+
+/*!
+	Provides a CRT delegate that will will observe sync mismatches and, when an appropriate threshold is crossed,
+	ask its receiver to try a different display frequency.
+*/
+template <typename Receiver>
+class CRTFrequencyMismatchWarner: public Outputs::CRT::Delegate {
+public:
+	CRTFrequencyMismatchWarner(Receiver &receiver) : receiver_(receiver) {}
+
+	void crt_did_end_batch_of_frames(
+		Outputs::CRT::CRT &,
+		const int number_of_frames,
+		const int number_of_unexpected_vertical_syncs
+	) final {
+		auto &record = frame_records_[frame_record_pointer_ & (NumberOfFrameRecords - 1)];
+		record.number_of_frames = number_of_frames;
+		record.number_of_unexpected_vertical_syncs = number_of_unexpected_vertical_syncs;
+		++frame_record_pointer_;
+		check_for_mismatch();
+	}
+
+	void reset() {
+		frame_records_ = std::array<FrameRecord, NumberOfFrameRecords>{};
+	}
+
+private:
+	Receiver &receiver_;
+	struct FrameRecord {
+		int number_of_frames = 0;
+		int number_of_unexpected_vertical_syncs = 0;
+	};
+
+	void check_for_mismatch() {
+		if(frame_record_pointer_ * 2 >= NumberOfFrameRecords * 3) {
+			int total_number_of_frames = 0;
+			int total_number_of_unexpected_vertical_syncs = 0;
+			for(const auto &record: frame_records_) {
+				total_number_of_frames += record.number_of_frames;
+				total_number_of_unexpected_vertical_syncs += record.number_of_unexpected_vertical_syncs;
+			}
+
+			if(total_number_of_unexpected_vertical_syncs >= total_number_of_frames >> 1) {
+				reset();
+				receiver_.register_crt_frequency_mismatch();
+			}
+		}
+	}
+
+	static constexpr int NumberOfFrameRecords = 4;
+	static_assert(!(NumberOfFrameRecords & (NumberOfFrameRecords - 1)));
+	int frame_record_pointer_ = 0;
+	std::array<FrameRecord, NumberOfFrameRecords> frame_records_;
+};
+
+}


### PR DESCRIPTION
This might end up being a hefty one; currently machines nominate a crop window for their output ahead of time and the virtual screen is fixed at that crop window. For many machines the window is expressed in terms of magic constants. So the relevant issues are:

1. machines such as the BBC, CPC, Vic-20 and Atari 2600 are explicitly fully programmable in terms of which parts of the display they paint, making a fixed crop always something of a trade-off;
2. even machines such as the ZX Spectrum can sometimes be a target for demo-scene border trickery, in which rapid changing of the border colours appear to put graphics within the borders, giving a similar problem;
3. as it is, I actually have to invest thought into the crop when it's already almost implied by the semantics of the video stream; and
4. as implied above, too many machines are using magic constants.

Now that I have a much better CRTC, it's become evident that both Both Bomb Jack Extra Sugar on the CPC and Frogger on the BBC lose content to the respective machine crops. But a looser crop for either machine would just make almost every other title look smaller on screen. Not to mention that a dynamic crop could actually expand games that are inherently small better to fill space — most common on the BBC where it's common to claw back some memory from the display by making the display smaller.

So the objective for this pull request is:

1. add any such annotations as are necessary to the video stream to flag up the difference between interesting content and uninteresting content. Which might well be none. Any change in a 'level' output, the entire section of any PCM content, etc, are hints.
2. do a multiframe analysis of such hints to determine if/when a stable new crop rectangle is implied;
3. transition smoothly to that new crop rectangle.

It might end up going deeper into CRT renovation since that is some of the oldest still-standing code in the emulator and has kind of introduced some anti-patterns — e.g. several machines keep a custom enum of what sort of region they're in plus a time count, then map that to `output_blank`, `output_sync`, etc, upon demand. But the CRT then just turns that back into a struct with a type that it passes onwards. So there's a whole layer of redundant mapping that could be excised.