### PR TITLE
Pull clock divider inside the loop.

### DIFF
--- a/Machines/Acorn/Archimedes/Video.hpp
+++ b/Machines/Acorn/Archimedes/Video.hpp
@@ -27,6 +27,15 @@ struct Video {
 		sound_(sound),
 		ram_(ram),
 		crt_(Outputs::Display::InputDataType::Red4Green4Blue4) {
+		const auto cycles_per_line = static_cast<int>(24'000'000 / (312 * 50));
+		crt_.set_new_timing(
+			cycles_per_line,
+			312,								/* Height of display. */
+			Outputs::CRT::PAL::ColourSpace,
+			Outputs::CRT::PAL::ColourCycleNumerator,
+			Outputs::CRT::PAL::ColourCycleDenominator,
+			Outputs::CRT::PAL::VerticalSyncLength,
+			Outputs::CRT::PAL::AlternatesPhase);
 		set_clock_divider(3);
 		crt_.set_fixed_framing(Outputs::Display::Rect(0.041f, 0.04f, 0.95f, 0.95f));
 		crt_.set_display_type(Outputs::Display::DisplayType::RGB);
@@ -210,7 +219,7 @@ struct Video {
 			case Phase::StartInterlacedSync:	tick_horizontal<Phase::StartInterlacedSync>();		break;
 			case Phase::EndInterlacedSync:		tick_horizontal<Phase::EndInterlacedSync>();		break;
 		}
-		++time_in_phase_;
+		time_in_phase_ += clock_divider_;
 	}
 
 	/// @returns @c true if a vertical retrace interrupt has been signalled since the last call to @c interrupt(); @c false otherwise.
@@ -476,15 +485,6 @@ private:
 		}
 
 		clock_divider_ = divider;
-		const auto cycles_per_line = static_cast<int>(24'000'000 / (divider * 312 * 50));
-		crt_.set_new_timing(
-			cycles_per_line,
-			312,								/* Height of display. */
-			Outputs::CRT::PAL::ColourSpace,
-			Outputs::CRT::PAL::ColourCycleNumerator,
-			Outputs::CRT::PAL::ColourCycleDenominator,
-			Outputs::CRT::PAL::VerticalSyncLength,
-			Outputs::CRT::PAL::AlternatesPhase);
 		clock_rate_observer_.update_clock_rates();
 	}
 

--- a/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
@@ -2547,10 +2547,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4B0150262D71286B00F270C7 /* SDL2.framework in Frameworks */,
 				4B055AF21FAE9C1C0060FFFF /* OpenGL.framework in Frameworks */,
 				4BB8617224E22F5A00A00E03 /* Accelerate.framework in Frameworks */,
 				4B055ABD1FAE86530060FFFF /* libz.tbd in Frameworks */,
-				4B0150262D71286B00F270C7 /* SDL2.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OSBindings/Mac/Clock Signal.xcodeproj/xcshareddata/xcschemes/Clock Signal Kiosk.xcscheme
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/xcshareddata/xcschemes/Clock Signal Kiosk.xcscheme
@@ -57,8 +57,12 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "--new=archimedes"
+            argument = "&quot;/Users/thomasharte/Library/Mobile\ Documents/com\~apple\~CloudDocs/Soft/Archimedes/Lemmings.adf&quot;"
             isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--new=archimedes"
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "/Users/thomasharte/Downloads/Program/Program.prg"


### PR DESCRIPTION
It's just as semantically valid, and happens to avoid a current issue in the OpenGL scan target.

Resolves #1615 (though I'll have to really open the can of OpenGL worms to eliminate the desktop shimmer; I'm hoping that for now this emulator is mainly used for lower-resolution games).