### PR TITLE
Catch MO6 RDBITS for accelerated loading.

### DIFF
--- a/Analyser/Static/Thomson/StaticAnalyser.cpp
+++ b/Analyser/Static/Thomson/StaticAnalyser.cpp
@@ -58,6 +58,8 @@ CartridgeList validated(const CartridgeList &cartridges) {
 	return result;
 }
 
+static constexpr bool DefaultMO6 = true;
+
 }
 
 Analyser::Static::TargetList Analyser::Static::Thomson::GetTargets(
@@ -70,6 +72,10 @@ Analyser::Static::TargetList Analyser::Static::Thomson::GetTargets(
 
 	TargetList destination;
 	auto target = std::make_unique<MOTarget>();
+
+	if(DefaultMO6) {
+		target->model = MOTarget::Model::MO6v3;
+	}
 
 	if(!media.tapes.empty()) {
 		Storage::Tape::Thomson::MO::Parser parser;
@@ -85,10 +91,18 @@ Analyser::Static::TargetList Analyser::Static::Thomson::GetTargets(
 			// in ->data.
 			static constexpr size_t TypeOffset = 0xb;
 			if(!first->type && first->data.size() > TypeOffset) {
-				if(!first->data[TypeOffset]) {	// File type; 0 = BASIC, 1 = DATA; 2 = binary.
-					target->loading_command = L"RUN\"\n";
+				const auto command = [&]() -> std::wstring {
+					if(!first->data[TypeOffset]) {	// File type; 0 = BASIC, 1 = DATA; 2 = binary.
+						return L"RUN\"";
+					} else {
+						return L"LOADM\"\",,R";
+					}
+				};
+
+				if(DefaultMO6) {
+					target->loading_command = std::wstring(L"1    ") + command() + L"\n";
 				} else {
-					target->loading_command = L"LOADM\"\",,R\n";
+					target->loading_command = command() + L"\n";
 				}
 			}
 		}
@@ -98,10 +112,19 @@ Analyser::Static::TargetList Analyser::Static::Thomson::GetTargets(
 	if(!media.disks.empty()) {
 		target->floppy = MOTarget::Floppy::CD90_640;
 		target->media.disks = media.disks;
+		if(DefaultMO6) {
+			target->loading_command = L"1";
+		}
 	}
 
 	if(!media.cartridges.empty()) {
 		target->media.cartridges = is_confident ? media.cartridges : validated(media.cartridges);
+
+		// Upon survey, it seemed that there are no catridges that require or that do anything additional on an MO6.
+		// So switch to an MO5 for faster launch.
+		if(!target->media.cartridges.empty()) {
+			target->model = MOTarget::Model::MO5v11;
+		}
 	}
 
 	if(!target->media.empty()) {

--- a/Analyser/Static/Thomson/StaticAnalyser.cpp
+++ b/Analyser/Static/Thomson/StaticAnalyser.cpp
@@ -99,8 +99,9 @@ Analyser::Static::TargetList Analyser::Static::Thomson::GetTargets(
 					}
 				};
 
+				// TODO: determine whether BASIC 1 or BASIC 128 is appropriate.
 				if(DefaultMO6) {
-					target->loading_command = std::wstring(L"1    ") + command() + L"\n";
+					target->loading_command = std::wstring(L"2                ") + command() + L"\n";
 				} else {
 					target->loading_command = command() + L"\n";
 				}
@@ -113,7 +114,7 @@ Analyser::Static::TargetList Analyser::Static::Thomson::GetTargets(
 		target->floppy = MOTarget::Floppy::CD90_640;
 		target->media.disks = media.disks;
 		if(DefaultMO6) {
-			target->loading_command = L"1";
+			target->loading_command = L"2";
 		}
 	}
 

--- a/Analyser/Static/Thomson/Target.hpp
+++ b/Analyser/Static/Thomson/Target.hpp
@@ -22,7 +22,7 @@ struct MOTarget: public Analyser::Static::Target, public Reflection::StructImpl<
 	Floppy floppy = Floppy::None;
 
 	ReflectableEnum(Model, MO5v1, MO5v11, MO6v1, MO6v2, MO6v3, Prodest128);
-	Model model = Model::MO5v11;
+	Model model = Model::MO6v3;
 
 	MOTarget() : Analyser::Static::Target(Machine::ThomsonMO) {}
 

--- a/Machines/Thomson/MO/MO.cpp
+++ b/Machines/Thomson/MO/MO.cpp
@@ -244,17 +244,25 @@ struct ConcreteMachine:
 					value = memory_.read(address);
 
 					if constexpr (lic == CPU::M6809::LIC::InstructionFetch) {
+						//
 						// Catch RDBITS.
-						if(allow_fast_tape_hack_ && address == 0xf168) {
-							// Inputs:
-							//
-							//	M0044 = current tape polarity (complement if applicable).
-							//	M0045 = byte in progress; ROL new bit into here.
-							//
-							// Additional output:
-							//
-							//	A = 00 or FF as per bit detected.
-							//
+						//
+						// Inputs:
+						//
+						//	M0044 = current tape polarity (complement if applicable).
+						//	M0045 = byte in progress; ROL new bit into here.
+						//
+						// Additional output:
+						//
+						//	A = 00 or FF as per bit detected.
+						//
+						// TODO: MO6: check for 1200 or 2400 baud?
+						if(
+							(
+								(!is_mo6 && address == 0xf168) ||
+								(is_mo6 && memory_.visible_monitor_page() && address == 0xf3fd)
+							) && allow_fast_tape_hack_
+						) [[unlikely]] {
 							[&] {
 								auto *const serialiser = tape_player_.serialiser();
 								if(!serialiser) return;
@@ -357,8 +365,7 @@ private:
 		template <Motorola::MC6821::Port port>
 		uint8_t input() {
 			if constexpr (port == Motorola::MC6821::Port::A) {
-				return
-					(machine_.tape_player_.input() ? 0x00 : 0x80);
+				return machine_.tape_player_.input() ? 0x00 : 0x80;
 			}
 
 			if constexpr (port == Motorola::MC6821::Port::B) {

--- a/Machines/Thomson/MO/MO.cpp
+++ b/Machines/Thomson/MO/MO.cpp
@@ -664,7 +664,7 @@ private:
 
 	HalfCycles typer_delay(const std::wstring &) const final {
 		if(m6809_.template get<CPU::M6809::Line::PowerOnReset>()) {
-			return Cycles(1'000'000);
+			return is_mo6 ? Cycles(1'750'000) : Cycles(1'000'000);
 		} else {
 			return Cycles(0);
 		}

--- a/Machines/Thomson/MO/MO.cpp
+++ b/Machines/Thomson/MO/MO.cpp
@@ -664,14 +664,14 @@ private:
 
 	HalfCycles typer_delay(const std::wstring &) const final {
 		if(m6809_.template get<CPU::M6809::Line::PowerOnReset>()) {
-			return is_mo6 ? Cycles(1'750'000) : Cycles(1'000'000);
+			return is_mo6 ? Cycles(1'000'000) : Cycles(1'000'000);
 		} else {
 			return Cycles(0);
 		}
 	}
 
 	HalfCycles typer_frequency() const final {
-		return Cycles(20'000);
+		return Cycles(30'000);
 	}
 
 	// MARK: - MediaTarget and MediaChangeObserver.

--- a/Machines/Thomson/MO/MemoryMap.hpp
+++ b/Machines/Thomson/MO/MemoryMap.hpp
@@ -103,6 +103,10 @@ public:
 		}
 	}
 
+	bool visible_monitor_page() const {
+		return rom_page_;
+	}
+
 	// MARK: - Memory Access.
 
 	template <typename AddressT>

--- a/Storage/Tape/Formats/K7.cpp
+++ b/Storage/Tape/Formats/K7.cpp
@@ -170,10 +170,9 @@ void K7::Serialiser::push_next_pulses() {
 		};
 
 		const auto post = [&](const bool bit) {
-			// Real timings below should be ~833 µs and ~417 µs. These accelerated timings seem to be within
-			// acceptable bounds for the ROM routines, and K7 seems to be a ROM-assuming format.
-			static constexpr auto FullPulse = Time(12, 20408);		// ~833 µs.
-			static constexpr auto HalfPulse = Time(12, 40816);		// ~417 µs.
+			// Provide a perfect 1200 baud.
+			static constexpr auto FullPulse = Time(1, 1200);
+			static constexpr auto HalfPulse = Time(1, 2400);
 
 			if(bit) {
 				emplace_back(pulse_type(), HalfPulse);


### PR DESCRIPTION
I think I can't be too far away from looking at accelerating custom loaders, much like the +4 does; the MO6 is a 1986 machine so it's into the realm of sophisticated software from mature companies.

Various loading screens until then:

<img width="1200" height="900" alt="Clock Signal Screen Shot 22-04-2026, 14 38 36 GMT-4" src="https://github.com/user-attachments/assets/d137599d-c7a9-4528-bc19-77c4d89d3d1c" />
<img width="2400" height="1800" alt="Clock Signal Screen Shot 22-04-2026, 14 41 04 GMT-4" src="https://github.com/user-attachments/assets/50f10545-edf1-4227-9daf-854fd2f75e8e" />
<img width="1200" height="900" alt="Clock Signal Screen Shot 22-04-2026, 14 41 11 GMT-4" src="https://github.com/user-attachments/assets/b0db9835-d8bf-45f1-9400-48e9dee05b32" />
