### PR TITLE
Expand Loriciels fast-loading support; force MO5 where empirically required.

### DIFF
--- a/Analyser/Static/Thomson/StaticAnalyser.cpp
+++ b/Analyser/Static/Thomson/StaticAnalyser.cpp
@@ -62,6 +62,7 @@ CartridgeList validated(const CartridgeList &cartridges) {
 bool implies_mo5(const Storage::Tape::Thomson::MO::File &file) {
 	static constexpr const char *mo5_titles[] = {
 		"PULSAR II",
+		"ELIMINATOR",
 	};
 
 	for(auto it = std::begin(mo5_titles); it != std::end(mo5_titles); ++it) {

--- a/Analyser/Static/Thomson/StaticAnalyser.cpp
+++ b/Analyser/Static/Thomson/StaticAnalyser.cpp
@@ -76,7 +76,7 @@ bool implies_mo5(const Storage::Tape::Thomson::MO::File &file) {
 }
 
 static constexpr bool DefaultMO6 = true;	// Indicates whether to load content on an MO5 or MO6.
-static constexpr bool DumpFiles = true;		// Helpful to me for inspecting tape contents. Very ugly. I apologise.
+static constexpr bool DumpFiles = false;	// Helpful to me for inspecting tape contents. Very ugly. I apologise.
 
 }
 

--- a/Analyser/Static/Thomson/StaticAnalyser.cpp
+++ b/Analyser/Static/Thomson/StaticAnalyser.cpp
@@ -59,6 +59,21 @@ CartridgeList validated(const CartridgeList &cartridges) {
 	return result;
 }
 
+bool implies_mo5(const Storage::Tape::Thomson::MO::File &file) {
+	static constexpr const char *mo5_titles[] = {
+		"PULSAR II",
+	};
+
+	for(auto it = std::begin(mo5_titles); it != std::end(mo5_titles); ++it) {
+		if(
+			std::search(file.data.begin(), file.data.end(), *it, *it + strlen(*it))
+			!= file.data.end()
+		) return true;
+	}
+
+	return false;
+}
+
 static constexpr bool DefaultMO6 = true;	// Indicates whether to load content on an MO5 or MO6.
 static constexpr bool DumpFiles = true;		// Helpful to me for inspecting tape contents. Very ugly. I apologise.
 
@@ -97,6 +112,10 @@ Analyser::Static::TargetList Analyser::Static::Thomson::GetTargets(
 				// Note on that: Microsoft BASIC provides optional 'protection', in which case the file on tape is
 				// encrypted. That's currently obscuring efforts here. Will need to figure out how to
 				// reverse-engineer that.
+
+				if(implies_mo5(*file)) {
+					target->model = MOTarget::Model::MO5v11;
+				}
 				break;
 			}
 		}
@@ -113,7 +132,7 @@ Analyser::Static::TargetList Analyser::Static::Thomson::GetTargets(
 
 		// Decorate loading command according to machine.
 		if(!target->media.tapes.empty()) {
-			if(DefaultMO6) {
+			if(is_mo6(target->model)) {
 				target->loading_command = std::wstring(L"2                ") + target->loading_command;
 			}
 			target->loading_command += '\n';

--- a/Machines/Apple/AppleIIgs/AppleIIgs.cpp
+++ b/Machines/Apple/AppleIIgs/AppleIIgs.cpp
@@ -231,11 +231,11 @@ public:
 	}
 
 	void set_scan_target(Outputs::Display::ScanTarget *target) override {
-		video_->set_scan_target(target);
+		video_.last_valid()->set_scan_target(target);
 	}
 
 	Outputs::Display::ScanStatus get_scaled_scan_status() const override {
-		return video_->get_scaled_scan_status() * 2.0f;	// TODO: expose multiplier and divider via the JustInTime template?
+		return video_.last_valid()->get_scaled_scan_status() * 2.0f;	// TODO: expose multiplier and divider via the JustInTime template?
 	}
 
 	void set_display_type(Outputs::Display::DisplayType display_type) final {

--- a/Machines/Atari/ST/AtariST.cpp
+++ b/Machines/Atari/ST/AtariST.cpp
@@ -149,19 +149,19 @@ public:
 
 	// MARK: CRTMachine::Machine
 	void set_scan_target(Outputs::Display::ScanTarget *scan_target) final {
-		video_->set_scan_target(scan_target);
+		video_.last_valid()->set_scan_target(scan_target);
 	}
 
 	Outputs::Display::ScanStatus get_scaled_scan_status() const final {
-		return video_->get_scaled_scan_status();
+		return video_.last_valid()->get_scaled_scan_status();
 	}
 
 	void set_display_type(Outputs::Display::DisplayType display_type) final {
-		video_->set_display_type(display_type);
+		video_.last_valid()->set_display_type(display_type);
 	}
 
 	Outputs::Display::DisplayType get_display_type() const final {
-		return video_->get_display_type();
+		return video_.last_valid()->get_display_type();
 	}
 
 	Outputs::Speaker::Speaker *get_speaker() final {

--- a/Machines/MSX/MSX.cpp
+++ b/Machines/MSX/MSX.cpp
@@ -364,11 +364,11 @@ public:
 	}
 
 	void set_scan_target(Outputs::Display::ScanTarget *scan_target) final {
-		vdp_->set_scan_target(scan_target);
+		vdp_.last_valid()->set_scan_target(scan_target);
 	}
 
 	Outputs::Display::ScanStatus get_scaled_scan_status() const final {
-		return vdp_->get_scaled_scan_status();
+		return vdp_.last_valid()->get_scaled_scan_status();
 	}
 
 	void set_display_type(Outputs::Display::DisplayType display_type) final {

--- a/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
+++ b/Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
@@ -290,7 +290,7 @@ public:
 	// MARK: - ScanProducer.
 
 	void set_scan_target(Outputs::Display::ScanTarget *scan_target) override {
-		video_->set_scan_target(scan_target);
+		video_.last_valid()->set_scan_target(scan_target);
 	}
 
 	Outputs::Display::ScanStatus get_scaled_scan_status() const override {

--- a/Machines/Thomson/MO/FastTapeSchemes/LoricielsBactron.hpp
+++ b/Machines/Thomson/MO/FastTapeSchemes/LoricielsBactron.hpp
@@ -120,6 +120,7 @@ struct LoricielsBactron: public Loader {
 				case 0x9d76: return 0x9d59;	// Yeti.
 				case 0x5f66: return 0x5f49;	// Eliminator
 				case 0x3459: return 0x343a;	// Mach 3
+				case 0x402b: return 0x400c; // Space Racer
 				default:
 #ifndef NDEBUG
 					if(logged_.find(address) == logged_.end()) {
@@ -168,6 +169,7 @@ struct LoricielsBactron: public Loader {
 			Yeti,
 			Eliminator,
 			Mach3,
+			SpaceRacer,
 		};
 
 		const auto direct_page = uint16_t(registers.reg<CPU::M6809::R8::DP>() << 8);
@@ -178,6 +180,7 @@ struct LoricielsBactron: public Loader {
 				case 0x9d59:	return Type::Yeti;
 				case 0x5f49:	return Type::Eliminator;
 				case 0x343a:	return Type::Mach3;
+				case 0x400c:	return Type::SpaceRacer;
 				default: __builtin_unreachable();
 			}
 		} ();
@@ -188,6 +191,7 @@ struct LoricielsBactron: public Loader {
 				case Type::Yeti:		return memory[direct_page | 0xb3];
 				case Type::Eliminator:	return memory[direct_page | 0xa5];
 				case Type::Mach3:		return memory[0x3394];
+				case Type::SpaceRacer:	return memory[0x3f66];
 				default: __builtin_unreachable();
 			}
 		} ();
@@ -198,6 +202,7 @@ struct LoricielsBactron: public Loader {
 				case Type::Yeti:		return memory[direct_page | 0xb4];
 				case Type::Eliminator:	return memory[direct_page | 0xa6];
 				case Type::Mach3:		return memory[0x3395];
+				case Type::SpaceRacer:	return memory[0x3f67];
 				default: __builtin_unreachable();
 			}
 		} ();

--- a/Machines/Thomson/MO/FastTapeSchemes/LoricielsBactron.hpp
+++ b/Machines/Thomson/MO/FastTapeSchemes/LoricielsBactron.hpp
@@ -10,6 +10,10 @@
 
 #include <algorithm>
 
+#ifndef NDEBUG
+#include <unordered_set>
+#endif
+
 namespace Thomson::FastLoader {
 
 /*
@@ -114,14 +118,21 @@ struct LoricielsBactron: public Loader {
 				case 0x35cc: return 0x35ad;	// Bactron, MGT.
 				case 0x5f65: return 0x5f48;	// Pulsar II.
 				case 0x9d76: return 0x9d59;	// Yeti.
+				case 0x5f66: return 0x5f49;	// Eliminator
 				default:
-					printf("Probable relocated Loriciels Bactron at %04x\n", address);
+#ifndef NDEBUG
+					if(logged_.find(address) == logged_.end()) {
+						logged_.insert(address);
 
-					printf("%04x:\n", address - 0x200);
-					for(int c = address - 0x200; c < address + 0x200; c++) {
-						printf("%02x ", memory.read(c));
+						printf("Probable relocated Loriciels Bactron at %04x\n", address);
+
+						printf("%04x:\n", address - 0x200);
+						for(int c = address - 0x200; c < address + 0x200; c++) {
+							printf("%02x ", memory.read(c));
+						}
+						printf("\n");
 					}
-					printf("\n");
+#endif
 				break;
 			}
 		}
@@ -154,6 +165,7 @@ struct LoricielsBactron: public Loader {
 			Bactron,
 			PulsarII,
 			Yeti,
+			Eliminator,
 		};
 
 		const auto direct_page = uint16_t(registers.reg<CPU::M6809::R8::DP>() << 8);
@@ -162,6 +174,7 @@ struct LoricielsBactron: public Loader {
 				case 0x35ad:	return Type::Bactron;
 				case 0x5f48:	return Type::PulsarII;
 				case 0x9d59:	return Type::Yeti;
+				case 0x5f49:	return Type::Eliminator;
 				default: __builtin_unreachable();
 			}
 		} ();
@@ -170,6 +183,7 @@ struct LoricielsBactron: public Loader {
 				case Type::Bactron:		return memory[0x3507];
 				case Type::PulsarII:	return memory[direct_page | 0xa4];
 				case Type::Yeti:		return memory[direct_page | 0xb3];
+				case Type::Eliminator:	return memory[direct_page | 0xa5];
 				default: __builtin_unreachable();
 			}
 		} ();
@@ -178,6 +192,7 @@ struct LoricielsBactron: public Loader {
 				case Type::Bactron:		return memory[0x3508];
 				case Type::PulsarII:	return memory[direct_page | 0xa5];
 				case Type::Yeti:		return memory[direct_page | 0xb4];
+				case Type::Eliminator:	return memory[direct_page | 0xa6];
 				default: __builtin_unreachable();
 			}
 		} ();
@@ -207,6 +222,11 @@ struct LoricielsBactron: public Loader {
 
 		return std::make_pair(TrapAction::RTS, true);
 	}
+
+#ifndef NDEBUG
+private:
+	inline static std::unordered_set<uint16_t> logged_;
+#endif
 };
 
 }

--- a/Machines/Thomson/MO/FastTapeSchemes/LoricielsBactron.hpp
+++ b/Machines/Thomson/MO/FastTapeSchemes/LoricielsBactron.hpp
@@ -111,10 +111,17 @@ struct LoricielsBactron: public Loader {
 			)
 		) {
 			switch(address) {
-				case 0x35cc: return 0x35ad;
-				case 0x5f65: return 0x5f48;
+				case 0x35cc: return 0x35ad;	// Bactron, MGT.
+				case 0x5f65: return 0x5f48;	// Pulsar II.
+				case 0x9d76: return 0x9d59;	// Yeti.
 				default:
 					printf("Probable relocated Loriciels Bactron at %04x\n", address);
+
+					printf("%04x:\n", address - 0x200);
+					for(int c = address - 0x200; c < address + 0x200; c++) {
+						printf("%02x ", memory.read(c));
+					}
+					printf("\n");
 				break;
 			}
 		}
@@ -143,10 +150,37 @@ struct LoricielsBactron: public Loader {
 			return std::make_pair(TrapAction::None, false);
 		}
 
-		const bool is_bactron = address == 0x35AD;
+		enum class Type {
+			Bactron,
+			PulsarII,
+			Yeti,
+		};
+
 		const auto direct_page = uint16_t(registers.reg<CPU::M6809::R8::DP>() << 8);
-		uint8_t &level = is_bactron ? memory[0x3507] : memory[direct_page | 0xa4];
-		uint8_t &byte = is_bactron ? memory[0x3508] : memory[direct_page | 0xa5];
+		const auto type = [&]() {
+			switch(address) {
+				case 0x35ad:	return Type::Bactron;
+				case 0x5f48:	return Type::PulsarII;
+				case 0x9d59:	return Type::Yeti;
+				default: __builtin_unreachable();
+			}
+		} ();
+		uint8_t &level = [&]() -> uint8_t & {
+			switch(type) {
+				case Type::Bactron:		return memory[0x3507];
+				case Type::PulsarII:	return memory[direct_page | 0xa4];
+				case Type::Yeti:		return memory[direct_page | 0xb3];
+				default: __builtin_unreachable();
+			}
+		} ();
+		uint8_t &byte = [&]() -> uint8_t & {
+			switch(type) {
+				case Type::Bactron:		return memory[0x3508];
+				case Type::PulsarII:	return memory[direct_page | 0xa5];
+				case Type::Yeti:		return memory[direct_page | 0xb4];
+				default: __builtin_unreachable();
+			}
+		} ();
 
 		// Sample current level.
 		const bool start_level = level & 0x80;

--- a/Machines/Thomson/MO/FastTapeSchemes/LoricielsBactron.hpp
+++ b/Machines/Thomson/MO/FastTapeSchemes/LoricielsBactron.hpp
@@ -119,6 +119,7 @@ struct LoricielsBactron: public Loader {
 				case 0x5f65: return 0x5f48;	// Pulsar II.
 				case 0x9d76: return 0x9d59;	// Yeti.
 				case 0x5f66: return 0x5f49;	// Eliminator
+				case 0x3459: return 0x343a;	// Mach 3
 				default:
 #ifndef NDEBUG
 					if(logged_.find(address) == logged_.end()) {
@@ -166,6 +167,7 @@ struct LoricielsBactron: public Loader {
 			PulsarII,
 			Yeti,
 			Eliminator,
+			Mach3,
 		};
 
 		const auto direct_page = uint16_t(registers.reg<CPU::M6809::R8::DP>() << 8);
@@ -175,6 +177,7 @@ struct LoricielsBactron: public Loader {
 				case 0x5f48:	return Type::PulsarII;
 				case 0x9d59:	return Type::Yeti;
 				case 0x5f49:	return Type::Eliminator;
+				case 0x343a:	return Type::Mach3;
 				default: __builtin_unreachable();
 			}
 		} ();
@@ -184,6 +187,7 @@ struct LoricielsBactron: public Loader {
 				case Type::PulsarII:	return memory[direct_page | 0xa4];
 				case Type::Yeti:		return memory[direct_page | 0xb3];
 				case Type::Eliminator:	return memory[direct_page | 0xa5];
+				case Type::Mach3:		return memory[0x3394];
 				default: __builtin_unreachable();
 			}
 		} ();
@@ -193,6 +197,7 @@ struct LoricielsBactron: public Loader {
 				case Type::PulsarII:	return memory[direct_page | 0xa5];
 				case Type::Yeti:		return memory[direct_page | 0xb4];
 				case Type::Eliminator:	return memory[direct_page | 0xa6];
+				case Type::Mach3:		return memory[0x3395];
 				default: __builtin_unreachable();
 			}
 		} ();

--- a/Machines/Thomson/MO/MO.cpp
+++ b/Machines/Thomson/MO/MO.cpp
@@ -597,7 +597,7 @@ private:
 	// MARK: - ScanProducer.
 
 	void set_scan_target(Outputs::Display::ScanTarget *const target) final {
-		video_->set_scan_target(target);
+		video_.last_valid()->set_scan_target(target);
 	}
 
 	Outputs::Display::ScanStatus get_scaled_scan_status() const final {


### PR DESCRIPTION
I'm worried that I'm on a bad path here; it's getting a bit title-by-title. But with the limited Thomson library size and weird media image format choices I'm not on confident ground. Probably the correct argument is:

1. each of these titles works fully without any special-case code;
2. all that's being offered here is fast loading, which does require code detection, but is entirely optional.