### PR TITLE
Add S-Video and RGB output to the CoCo.

### DIFF
--- a/Machines/Tandy/CoCo/CoCo.cpp
+++ b/Machines/Tandy/CoCo/CoCo.cpp
@@ -810,7 +810,15 @@ private:
 	}
 
 	Outputs::Display::ScanStatus get_scaled_scan_status() const final {
-		return m6847_.get()->get_scaled_scan_status() / 2.0;
+		return m6847_.get()->get_scaled_scan_status() / 4.0;
+	}
+
+	void set_display_type(Outputs::Display::DisplayType display_type) final {
+		m6847_.get()->set_display_type(display_type);
+	}
+
+	Outputs::Display::DisplayType get_display_type() const final {
+		return m6847_.get()->get_display_type();
 	}
 
 	// MARK: - MappedKeyboardMachine.
@@ -887,12 +895,14 @@ private:
 	std::unique_ptr<Reflection::Struct> get_options() const final {
 		auto options = std::make_unique<Options>(Configurable::OptionsType::UserFriendly);
 		options->quick_load = allow_fast_tape_loading_;
+		options->output = get_video_signal_configurable();
 		return options;
 	}
 
 	void set_options(const std::unique_ptr<Reflection::Struct> &str) final {
 		const auto options = dynamic_cast<Options *>(str.get());
 		allow_fast_tape_loading_ = options->quick_load;
+		set_video_signal_configurable(options->output);
 	}
 
 	// MARK: - Activity Source.

--- a/Machines/Tandy/CoCo/CoCo.hpp
+++ b/Machines/Tandy/CoCo/CoCo.hpp
@@ -23,11 +23,19 @@ struct Machine {
 
 	class Options:
 		public Reflection::StructImpl<Options>,
+		public Configurable::Options::Display<Options>,
 		public Configurable::Options::QuickLoad<Options>
 	{
+		friend Configurable::Options::Display<Options>;
 		friend Configurable::Options::QuickLoad<Options>;
 	public:
 		Options(const Configurable::OptionsType type) :
+			Configurable::Options::Display<Options>(
+				Configurable::Display::CompositeColour	// Some games use artefact colour; therefore a composite display
+														// is not only most accurate but also most user-friendly in not
+														// requiring further configuration should the user play one
+														// of those.
+			),
 			Configurable::Options::QuickLoad<Options>(
 				type == Configurable::OptionsType::UserFriendly) {}
 
@@ -36,6 +44,7 @@ struct Machine {
 
 		friend Reflection::StructImpl<Options>;
 		void declare_fields() {
+			declare_display_option();
 			declare_quickload_option();
 		}
 	};

--- a/OSBindings/Mac/Clock Signal/Machine/StaticAnalyser/CSStaticAnalyser.mm
+++ b/OSBindings/Mac/Clock Signal/Machine/StaticAnalyser/CSStaticAnalyser.mm
@@ -662,7 +662,7 @@ static Analyser::Static::ZX8081::Target::MemoryModel ZX8081MemoryModelFromSize(K
 		case Analyser::Machine::Oric:			return @"OricOptions";
 		case Analyser::Machine::Plus4:			return @"QuickLoadCompositeOptions";
 		case Analyser::Machine::PCCompatible:	return @"CompositeOptions";
-		case Analyser::Machine::TandyCoCo:		return @"QuickLoadOptions";
+		case Analyser::Machine::TandyCoCo:		return @"QuickLoadCompositeOptions";
 		case Analyser::Machine::ThomsonMO:		return @"QuickLoadOptions";
 		case Analyser::Machine::Vic20:			return @"QuickLoadCompositeOptions";
 		case Analyser::Machine::ZX8081:			return @"ZX8081Options";


### PR DESCRIPTION
There is an S-Video mod for the CoCo2; S-Video is not inaccurate for the CoCo.

Not that I've quite crossed that bridge yet, but the Dragon has an RGB output. Hence the inclusion of RGB.