### PR TITLE
Extend signalled hsync through to the end of the back porch.

### DIFF
--- a/Components/6847/6847.cpp
+++ b/Components/6847/6847.cpp
@@ -321,21 +321,18 @@ void MC6847Base::sync_line(const int, const int end) {
 	}
 }
 
-//
-// Assumed in these two functions: hsync is signalled from the start of the sync level until the end of the back
-// porch (with, conveniently, the start of the sync level falling at position 0 in my line counting).
-//
+namespace {
+constexpr auto EndOfHSyncPinOutput = MC6847Base::LineLayout::EndOfBackPorch;
+}
+
 bool MC6847Base::hsync(const int column) const {
-	return column <= LineLayout::EndOfBackPorch;
+	return column <= EndOfHSyncPinOutput;
 }
 
 Cycles MC6847Base::next_sequence_point(const int column) const {
-	if(column < LineLayout::EndOfColourBurst) return LineLayout::EndOfBackPorch - column;
+	if(column < EndOfHSyncPinOutput) return EndOfHSyncPinOutput - column;
 	return LineLayout::EndOfLine - column;
 }
-//
-// Belief about hsync timing full expressed as of here.
-//
 
 void MC6847Base::reset() {
 	address_.apply_vertical_preload();

--- a/Components/6847/6847.cpp
+++ b/Components/6847/6847.cpp
@@ -321,14 +321,21 @@ void MC6847Base::sync_line(const int, const int end) {
 	}
 }
 
+//
+// Assumed in these two functions: hsync is signalled from the start of the sync level until the end of the back
+// porch (with, conveniently, the start of the sync level falling at position 0 in my line counting).
+//
 bool MC6847Base::hsync(const int column) const {
-	return column <= LineLayout::EndOfSync;
+	return column <= LineLayout::EndOfBackPorch;
 }
 
 Cycles MC6847Base::next_sequence_point(const int column) const {
-	if(column < LineLayout::EndOfSync) return LineLayout::EndOfSync - column;
+	if(column < LineLayout::EndOfColourBurst) return LineLayout::EndOfBackPorch - column;
 	return LineLayout::EndOfLine - column;
 }
+//
+// Belief about hsync timing full expressed as of here.
+//
 
 void MC6847Base::reset() {
 	address_.apply_vertical_preload();

--- a/Machines/Tandy/CoCo/CoCo.cpp
+++ b/Machines/Tandy/CoCo/CoCo.cpp
@@ -179,8 +179,11 @@ public:
 		CPU::M6809::data_t<read_write> value
 	) {
 		// TODO, maybe: pull the switch inside this SAM call outside the loop?
-		const auto delay = sam_.cycle_cost<bus_phase, read_write>(address);
+		const auto delay = sam_.cycle_cost<bus_phase, read_write>(address, bus_phase_);
 		const auto duration = delay + CPU::M6809::duration<Cycles>(bus_phase);
+
+		bus_phase_ += duration;
+		bus_phase_ &= 1;
 		if(m6847_ += duration) {
 			pia0_.set<Motorola::MC6821::Control::CA1>(m6847_.get()->hsync());
 			pia0_.set<Motorola::MC6821::Control::CB1>(m6847_.get()->fsync());
@@ -601,6 +604,7 @@ private:
 
 	// MARK: - SAM.
 
+	Cycles bus_phase_;
 	struct SAM {
 		SAM(MemoryMap &memory) : memory_(memory) {}
 
@@ -718,21 +722,28 @@ private:
 			CPU::M6809::BusPhase bus_phase,
 			CPU::M6809::ReadWrite read_write,
 			typename AddressT
-		> Cycles cycle_cost(const AddressT address) {
+		> Cycles cycle_cost(const AddressT address, const Cycles phase) {
+			//
+			// Without documentation I've made a guess here that the half-speed bus has an alignment requirement,
+			// so switching from full-speed to half-speed might result in a two-cycle access but might result in
+			// a three-cycle access (followed by two-cycle accesses).
+			//
+			// If that proves to be untrue, `phase` can be eliminated as an argument.
+			//
 			switch(speed_) {
 				case ClockSpeed::Full1:
 				case ClockSpeed::Full2:
 				return Cycles(0);
 
 				case ClockSpeed::Half:
-				return duration<Cycles>(bus_phase);
+				return duration<Cycles>(bus_phase) + phase;
 
 				case ClockSpeed::HalfInRAM:
 					if constexpr (read_write == CPU::M6809::ReadWrite::NoData) {
 						return Cycles(0);
 					} else {
 						if(address < 0x8000 || all_ram_) {
-							return duration<Cycles>(bus_phase);
+							return duration<Cycles>(bus_phase) + phase;
 						} else {
 							return Cycles(0);
 						}

--- a/Processors/6809/6809.hpp
+++ b/Processors/6809/6809.hpp
@@ -1214,6 +1214,8 @@ struct Processor {
 
 			sync:
 				addressed_internal_cycle(LIC::Inactive, Address::Literal(registers_.pc.full));
+
+			sync_loop:
 			[[fallthrough]]; case ResumePoint::Sync:
 				// Always consider taking a break here, regardless of selected pause precision; otherwise there's
 				// a risk of never exiting.
@@ -1232,7 +1234,7 @@ struct Processor {
 					>(Address::Fixed<0xffff>(), Data::NoValue());
 
 				if(!(exceptions_ & (uint8_t(Exception::NMI) | uint8_t(Exception::IRQ) | uint8_t(Exception::FIRQ)))) {
-					goto sync;
+					goto sync_loop;
 				}
 
 				// Per AN-865 there is a one-cycle latency in response.


### PR DESCRIPTION
Most of this is influenced by Dragon Fire, which seems to race the raster on almost every platform it's on and on the Tandy does so in order to switch palettes mid-line so as to produce this:

<img width="4000" height="3000" alt="Clock Signal Screen Shot 14-05-2026, 10 44 35 GMT-4" src="https://github.com/user-attachments/assets/215b5aec-77d8-4479-b29b-aa770d3f779a" />

Note that the 'buff' palette is used for castle elements and most of the water whereas the green is used for the background hills and for where the drawbridge has cast a shadow on water.

With these changes, the effect is now entirely stable.