### PR TITLE
Add CoCo disk interface.

### DIFF
--- a/Analyser/Static/StaticAnalyser.cpp
+++ b/Analyser/Static/StaticAnalyser.cpp
@@ -47,6 +47,7 @@
 #include "Storage/Disk/DiskImage/Formats/AcornADF.hpp"
 #include "Storage/Disk/DiskImage/Formats/AmigaADF.hpp"
 #include "Storage/Disk/DiskImage/Formats/AppleDSK.hpp"
+#include "Storage/Disk/DiskImage/Formats/CoCoDSK.hpp"
 #include "Storage/Disk/DiskImage/Formats/CPCDSK.hpp"
 #include "Storage/Disk/DiskImage/Formats/D64.hpp"
 #include "Storage/Disk/DiskImage/Formats/G64.hpp"
@@ -237,6 +238,7 @@ static Media GetMediaAndPlatforms(const std::string &file_name, TargetPlatform::
 	accumulator.try_standard<MassStorage::DAT>(TargetPlatform::Acorn, "dat");
 	accumulator.try_standard<Disk::DiskImageHolder<Disk::DMK>>(TargetPlatform::MSX, "dmk");
 	accumulator.try_standard<Disk::DiskImageHolder<Disk::AppleDSK>>(TargetPlatform::DiskII, "do");
+	accumulator.try_standard<Disk::DiskImageHolder<Disk::CoCoDSK>>(TargetPlatform::TandyCoCo, "dsk");
 	accumulator.try_standard<Disk::DiskImageHolder<Disk::SSD>>(TargetPlatform::Acorn, "dsd");
 	accumulator.try_standard<Disk::DiskImageHolder<Disk::CPCDSK>>(
 		TargetPlatform::AmstradCPC | TargetPlatform::Oric | TargetPlatform::ZXSpectrum, "dsk");

--- a/Analyser/Static/TandyCoCo/StaticAnalyser.cpp
+++ b/Analyser/Static/TandyCoCo/StaticAnalyser.cpp
@@ -44,6 +44,11 @@ Analyser::Static::TargetList Analyser::Static::TandyCoCo::GetTargets(
 		}
 	}
 
+	if(!media.disks.empty()) {
+		target->has_disk_drive = true;
+		// TODO: examine further?
+	}
+
 	targets.push_back(std::move(target));
 	return targets;
 }

--- a/Analyser/Static/TandyCoCo/Target.hpp
+++ b/Analyser/Static/TandyCoCo/Target.hpp
@@ -31,6 +31,7 @@ struct Target: public Analyser::Static::Target, public Reflection::StructImpl<Ta
 	std::wstring loading_command;
 	MemorySize memory_size = MemorySize::SixtyFourKB;
 	Model model = Model::TandyCoCo;
+	bool has_disk_drive = false;
 
 private:
 	friend Reflection::StructImpl<Target>;
@@ -39,6 +40,7 @@ private:
 		AnnounceEnum(MemorySize);
 		DeclareField(model);
 		DeclareField(memory_size);
+		DeclareField(has_disk_drive);
 	}
 };
 

--- a/Components/1770/1770.cpp
+++ b/Components/1770/1770.cpp
@@ -524,7 +524,7 @@ void WD1770::posit_event(const int new_event_type) {
 
 	type2_check_crc:
 		WAIT_FOR_EVENT(Event::Token);
-		if(get_latest_token().type != Token::Byte) goto type2_read_byte;
+		if(get_latest_token().type != Token::Byte) goto type2_check_crc;
 		header_[distance_into_section_] = get_latest_token().byte_value;
 		distance_into_section_++;
 		if(distance_into_section_ == 2) {

--- a/Components/1770/1770.cpp
+++ b/Components/1770/1770.cpp
@@ -111,6 +111,9 @@ uint8_t WD1770::read(const int address) {
 			Logger::info().append("Returned sector %d", sector_);
 			return sector_;
 		case 3:
+			if(!status_.data_request) {
+				Logger::info().append("Repeat read", data_, status_.data_request);
+			}
 			update_status([] (Status &status) {
 				status.data_request = false;
 			});

--- a/Components/1770/1770.cpp
+++ b/Components/1770/1770.cpp
@@ -112,7 +112,7 @@ uint8_t WD1770::read(const int address) {
 			return sector_;
 		case 3:
 			if(!status_.data_request) {
-				Logger::info().append("Repeat read", data_, status_.data_request);
+				Logger::info().append("Repeat read.");
 			}
 			update_status([] (Status &status) {
 				status.data_request = false;

--- a/Components/1770/1770.hpp
+++ b/Components/1770/1770.hpp
@@ -63,15 +63,15 @@ public:
 	};
 
 	/// @returns The current value of the IRQ line output.
-	inline bool get_interrupt_request_line() const	{	return status_.interrupt_request;	}
+	inline bool get_interrupt_request_line() const		{	return status_.interrupt_request;	}
 
 	/// @returns The current value of the DRQ line output.
-	inline bool get_data_request_line() const		{	return status_.data_request;		}
+	inline bool get_data_request_line() const			{	return status_.data_request;		}
 
 	struct Delegate {
 		virtual void wd1770_did_change_output(WD1770 &) = 0;
 	};
-	inline void set_delegate(Delegate *delegate)	{	delegate_ = delegate;				}
+	inline void set_delegate(Delegate *const delegate)	{	delegate_ = delegate;				}
 
 	ClockingHint::Preference preferred_clocking() const final;
 
@@ -127,7 +127,7 @@ private:
 		IndexHoleTarget	= (1 << 6),	// Indicates that index_hole_count_ has reached index_hole_count_target_.
 		ForceInterrupt	= (1 << 7)	// Indicates a forced interrupt.
 	};
-	void posit_event(int type);
+	void posit_event(int);
 	int interesting_event_mask_;
 	Cycles::IntType delay_time_ = 0;
 

--- a/Machines/Tandy/CoCo/CoCo.cpp
+++ b/Machines/Tandy/CoCo/CoCo.cpp
@@ -387,7 +387,8 @@ class ConcreteMachine:
 	public MachineTypes::MediaTarget,
 	public MachineTypes::ScanProducer,
 	public MachineTypes::TimedMachine,
-	public Utility::TypeRecipient<Tandy::CoCo::Keyboard::CharacterMapper>
+	public Utility::TypeRecipient<Tandy::CoCo::Keyboard::CharacterMapper>,
+	public WD::WD1770::Delegate
 {
 public:
 	ConcreteMachine(const Analyser::Static::TandyCoCo::Target &target, const ROMMachine::ROMFetcher &rom_fetcher) :
@@ -453,6 +454,7 @@ public:
 
 		if(has_disk_drive) {
 			sam_.insert_cartridge(roms.find(DiskBASIC)->second);
+			disk_controller_.set_delegate(this);
 		}
 
 		insert_media(target.media);
@@ -1109,6 +1111,10 @@ private:
 
 	DiskController disk_controller_;
 	Cycles cycles_16mhz_;
+	void wd1770_did_change_output(WD::WD1770 &) override {
+		m6809_.template set<CPU::M6809::Line::NMI>(disk_controller_.nmi());
+		m6809_.template set<CPU::M6809::Line::Halt>(disk_controller_.halt());
+	}
 };
 
 }

--- a/Machines/Tandy/CoCo/CoCo.cpp
+++ b/Machines/Tandy/CoCo/CoCo.cpp
@@ -388,7 +388,7 @@ class ConcreteMachine:
 	public MachineTypes::ScanProducer,
 	public MachineTypes::TimedMachine,
 	public Utility::TypeRecipient<Tandy::CoCo::Keyboard::CharacterMapper>,
-	public WD::WD1770::Delegate
+	public DiskController::Delegate
 {
 public:
 	ConcreteMachine(const Analyser::Static::TandyCoCo::Target &target, const ROMMachine::ROMFetcher &rom_fetcher) :
@@ -1114,9 +1114,9 @@ private:
 
 	DiskController disk_controller_;
 	Cycles cycles_16mhz_;
-	void wd1770_did_change_output(WD::WD1770 &) override {
-		m6809_.template set<CPU::M6809::Line::NMI>(disk_controller_.nmi());
-		m6809_.template set<CPU::M6809::Line::Halt>(disk_controller_.halt());
+	void set_halt_nmi(const bool halt, const bool nmi) {
+		m6809_.template set<CPU::M6809::Line::NMI>(nmi);
+		m6809_.template set<CPU::M6809::Line::Halt>(halt);
 	}
 };
 

--- a/Machines/Tandy/CoCo/CoCo.cpp
+++ b/Machines/Tandy/CoCo/CoCo.cpp
@@ -482,11 +482,9 @@ public:
 		bus_phase_ &= 1;
 
 		if constexpr (has_disk_drive) {
-			// Piggy-back off the existing bus_phase_ counter to multiply the clock by 4.5,
-			// giving very close to the standard 8Mhz. Unless and until a real clock speed emerges.
-			disk_controller_.run_for(
-				duration * 4 + bus_phase_
-			);
+			// Multiply by 4.5 to get very close to 8Mhz for the controller.
+			cycles_16mhz_ += duration * 9;
+			disk_controller_.run_for(cycles_16mhz_.divide(2));
 		}
 
 		if(m6847_ += duration) {
@@ -1012,11 +1010,18 @@ private:
 			tape_player_.set_tape(media.tapes.front(), TargetPlatform::ThomsonMO);
 		}
 
+		if(has_disk_drive && !media.disks.empty()) {
+			for(size_t c = 0; c < media.disks.size() && c < 4; c++) {
+				disk_controller_.set_disk(media.disks[c], c);
+			}
+		}
+
 		const bool had_cartridge =
+			!has_disk_drive &&
 			!media.cartridges.empty() &&
 			sam_.insert_cartridge(media.cartridges.front()->segments().front().data);
 
-		return !media.tapes.empty() || had_cartridge;
+		return !media.tapes.empty() || had_cartridge || (has_disk_drive && !media.disks.empty());
 	}
 
 	ChangeEffect effect_for_file_did_change(const std::string &) const override {
@@ -1042,6 +1047,9 @@ private:
 
 	void set_activity_observer(Activity::Observer *const observer) override {
 		tape_player_.set_activity_observer(observer);
+		if(has_disk_drive) {
+			disk_controller_.set_activity_observer(observer);
+		}
 	}
 
 	// MARK: - Joysticks.
@@ -1100,6 +1108,7 @@ private:
 	// MARK: - Disk.
 
 	DiskController disk_controller_;
+	Cycles cycles_16mhz_;
 };
 
 }

--- a/Machines/Tandy/CoCo/CoCo.cpp
+++ b/Machines/Tandy/CoCo/CoCo.cpp
@@ -8,6 +8,7 @@
 
 #include "CoCo.hpp"
 
+#include "DiskController.hpp"
 #include "Keyboard.hpp"
 
 #include "Processors/6809/6809.hpp"
@@ -370,7 +371,7 @@ static constexpr auto AudioDivider = Cycles(1);
 
 namespace TandyCoCo {
 
-template <bool is_pal>
+template <bool is_pal, bool has_disk_drive>
 class ConcreteMachine:
 	public Activity::Source,
 	public Configurable::Device,
@@ -1056,7 +1057,27 @@ private:
 		update_audio();
 		audio_.set_output(new_audio_output);
 	}
+
+	// MARK: - Disk.
+
+	DiskController disk_controller_;
 };
+
+}
+
+namespace {
+
+template <bool has_disk_drive>
+std::unique_ptr<Machine> create(
+	const Analyser::Static::TandyCoCo::Target &target,
+	const ROMMachine::ROMFetcher &rom_fetcher
+) {
+	if(Analyser::Static::TandyCoCo::is_pal(target.model)) {
+		return std::make_unique<TandyCoCo::ConcreteMachine<true, has_disk_drive>>(target, rom_fetcher);
+	} else {
+		return std::make_unique<TandyCoCo::ConcreteMachine<false, has_disk_drive>>(target, rom_fetcher);
+	}
+}
 
 }
 
@@ -1065,9 +1086,9 @@ std::unique_ptr<Machine> Machine::create(
 	const ROMMachine::ROMFetcher &rom_fetcher
 ) {
 	const auto &coco_target = static_cast<const Analyser::Static::TandyCoCo::Target &>(target);
-	if(Analyser::Static::TandyCoCo::is_pal(coco_target.model)) {
-		return std::make_unique<TandyCoCo::ConcreteMachine<true>>(coco_target, rom_fetcher);
+	if(coco_target.has_disk_drive) {
+		return ::create<true>(coco_target, rom_fetcher);
 	} else {
-		return std::make_unique<TandyCoCo::ConcreteMachine<false>>(coco_target, rom_fetcher);
+		return ::create<false>(coco_target, rom_fetcher);
 	}
 }

--- a/Machines/Tandy/CoCo/CoCo.cpp
+++ b/Machines/Tandy/CoCo/CoCo.cpp
@@ -429,7 +429,7 @@ public:
 
 		auto request = ROM::Request(BasicROM);
 		if(alternateBasicROM.has_value()) request = request && ROM::Request(*alternateBasicROM);
-		if(extendedBasicROM.has_value()) request = request && ROM::Request(*extendedBasicROM);
+		if(extendedBasicROM.has_value()) request = request && ROM::Request(*extendedBasicROM, !has_disk_drive);
 
 		static constexpr auto DiskBASIC = ROM::Name::TandyCoCoDiskBASIC11;
 		if(has_disk_drive) {
@@ -443,7 +443,10 @@ public:
 
 		sam_.set_basic(roms.find(BasicROM)->second);
 		if(extendedBasicROM.has_value()) {
-			sam_.set_extended_basic(roms.find(*extendedBasicROM)->second);
+			const auto rom = roms.find(*extendedBasicROM);
+			if(rom != roms.end()) {
+				sam_.set_extended_basic(roms.find(*extendedBasicROM)->second);
+			}
 		}
 
 		if(alternateBasicROM.has_value()) {

--- a/Machines/Tandy/CoCo/CoCo.cpp
+++ b/Machines/Tandy/CoCo/CoCo.cpp
@@ -419,7 +419,7 @@ public:
 		auto request = ROM::Request(BasicROM);
 		if(alternateBasicROM.has_value()) request = request && ROM::Request(*alternateBasicROM);
 
-		static constexpr auto DiskBASIC = ROM::Name::TandyCoCoDiskBASIC21;
+		static constexpr auto DiskBASIC = ROM::Name::TandyCoCoDiskBASIC10;
 		if(has_disk_drive) {
 			request = request && ROM::Request(DiskBASIC);
 		}

--- a/Machines/Tandy/CoCo/CoCo.cpp
+++ b/Machines/Tandy/CoCo/CoCo.cpp
@@ -387,8 +387,7 @@ class ConcreteMachine:
 	public MachineTypes::MediaTarget,
 	public MachineTypes::ScanProducer,
 	public MachineTypes::TimedMachine,
-	public Utility::TypeRecipient<Tandy::CoCo::Keyboard::CharacterMapper>,
-	public DiskController::Delegate
+	public Utility::TypeRecipient<Tandy::CoCo::Keyboard::CharacterMapper>
 {
 public:
 	ConcreteMachine(const Analyser::Static::TandyCoCo::Target &target, const ROMMachine::ROMFetcher &rom_fetcher) :
@@ -457,7 +456,6 @@ public:
 
 		if(has_disk_drive) {
 			sam_.insert_cartridge(roms.find(DiskBASIC)->second);
-			disk_controller_.set_delegate(this);
 		}
 
 		insert_media(target.media);
@@ -489,8 +487,8 @@ public:
 		if constexpr (has_disk_drive) {
 			// Update after the fact due to the internal mechanics of WD177x posting; these signals from the WD should
 			// occur when it observes that the access cycle is over. It is now over because the next has begun.
-			m6809_.template set<CPU::M6809::Line::NMI>(nmi_);
-			m6809_.template set<CPU::M6809::Line::Halt>(halt_);
+			m6809_.template set<CPU::M6809::Line::NMI>(disk_controller_.nmi());
+			m6809_.template set<CPU::M6809::Line::Halt>(disk_controller_.halt());
 
 			// Multiply by 4.5 to get very close to 8Mhz for the controller.
 			cycles_16mhz_ += duration * 9;
@@ -1119,13 +1117,6 @@ private:
 
 	DiskController disk_controller_;
 	Cycles cycles_16mhz_;
-	bool nmi_ = false, halt_ = false;
-	void set_halt_nmi(const bool halt, const bool nmi) override {
-		// These flags have been supplied by the WD1770 based on its belief that the bus cycle is over.
-		// It isn't yet, so store them away to take effect once it is.
-		halt_ = halt;
-		nmi_ = nmi;
-	}
 };
 
 }

--- a/Machines/Tandy/CoCo/CoCo.cpp
+++ b/Machines/Tandy/CoCo/CoCo.cpp
@@ -274,6 +274,10 @@ struct SAM {
 		std::copy_n(rom.begin(), rom.size(), basic_.end() - rom.size());
 	}
 
+	void set_extended_basic(const std::vector<uint8_t> rom) {
+		std::copy_n(rom.begin(), rom.size(), basic_.begin());
+	}
+
 	void set_alternate_basic(const std::vector<uint8_t> rom) {
 		std::fill(alternate_basic_.begin(), alternate_basic_.end(), 0xff);
 		std::copy_n(rom.begin(), rom.size(), alternate_basic_.end() - rom.size());
@@ -409,6 +413,12 @@ public:
 			}
 			return is_64kb(target.memory_size) ? ROM::Name::Dragon64ROM1 : ROM::Name::Dragon32;
 		} ();
+		const auto extendedBasicROM = [&]() -> std::optional<ROM::Name> {
+			if(is_dragon_) {
+				return std::nullopt;
+			}
+			return ROM::Name::TandyExtendedBASIC10;
+		} ();
 		const auto alternateBasicROM = [&]() -> std::optional<ROM::Name> {
 			if(!is_dragon_ || !is_64kb(target.memory_size)) {
 				return std::nullopt;
@@ -418,8 +428,9 @@ public:
 
 		auto request = ROM::Request(BasicROM);
 		if(alternateBasicROM.has_value()) request = request && ROM::Request(*alternateBasicROM);
+		if(extendedBasicROM.has_value()) request = request && ROM::Request(*extendedBasicROM);
 
-		static constexpr auto DiskBASIC = ROM::Name::TandyCoCoDiskBASIC10;
+		static constexpr auto DiskBASIC = ROM::Name::TandyCoCoDiskBASIC11;
 		if(has_disk_drive) {
 			request = request && ROM::Request(DiskBASIC);
 		}
@@ -430,6 +441,10 @@ public:
 		}
 
 		sam_.set_basic(roms.find(BasicROM)->second);
+		if(extendedBasicROM.has_value()) {
+			sam_.set_extended_basic(roms.find(*extendedBasicROM)->second);
+		}
+
 		if(alternateBasicROM.has_value()) {
 			sam_.set_alternate_basic(roms.find(*alternateBasicROM)->second);
 		} else {
@@ -484,7 +499,7 @@ public:
 		}
 		time_since_audio_update_ += duration;
 
-		if(sam_.has_cartridge()) {
+		if(!has_disk_drive && sam_.has_cartridge()) {
 			// When a cartridge is inserted: "the clock signal (Q) is shorted to the cartridge interrupt pin."
 			pia1_.template set<Motorola::MC6821::Control::CB1>(true);
 			pia1_.template set<Motorola::MC6821::Control::CB1>(false);

--- a/Machines/Tandy/CoCo/CoCo.cpp
+++ b/Machines/Tandy/CoCo/CoCo.cpp
@@ -1114,7 +1114,8 @@ private:
 
 	DiskController disk_controller_;
 	Cycles cycles_16mhz_;
-	void set_halt_nmi(const bool halt, const bool nmi) {
+	void set_halt_nmi(const bool halt, const bool nmi) override {
+		// TODO: these should actually occur at the end of the cycle.
 		m6809_.template set<CPU::M6809::Line::NMI>(nmi);
 		m6809_.template set<CPU::M6809::Line::Halt>(halt);
 	}

--- a/Machines/Tandy/CoCo/CoCo.cpp
+++ b/Machines/Tandy/CoCo/CoCo.cpp
@@ -479,11 +479,6 @@ public:
 		const AddressT address,
 		CPU::M6809::data_t<read_write> value
 	) {
-		// Update after the fact due to the internal mechanics of WD177x posting; these signals from the WD should
-		// occur when it observes that the access cycle is over. It is now over because the next has begun.
-		m6809_.template set<CPU::M6809::Line::NMI>(nmi_);
-		m6809_.template set<CPU::M6809::Line::Halt>(halt_);
-
 		// TODO, maybe: pull the switch inside this SAM call outside the loop?
 		const auto delay = sam_.cycle_cost<bus_phase, read_write>(address, bus_phase_);
 		const auto duration = delay + CPU::M6809::duration<Cycles>(bus_phase);
@@ -492,6 +487,11 @@ public:
 		bus_phase_ &= 1;
 
 		if constexpr (has_disk_drive) {
+			// Update after the fact due to the internal mechanics of WD177x posting; these signals from the WD should
+			// occur when it observes that the access cycle is over. It is now over because the next has begun.
+			m6809_.template set<CPU::M6809::Line::NMI>(nmi_);
+			m6809_.template set<CPU::M6809::Line::Halt>(halt_);
+
 			// Multiply by 4.5 to get very close to 8Mhz for the controller.
 			cycles_16mhz_ += duration * 9;
 			disk_controller_.run_for(cycles_16mhz_.divide(2));

--- a/Machines/Tandy/CoCo/CoCo.cpp
+++ b/Machines/Tandy/CoCo/CoCo.cpp
@@ -419,6 +419,11 @@ public:
 		auto request = ROM::Request(BasicROM);
 		if(alternateBasicROM.has_value()) request = request && ROM::Request(*alternateBasicROM);
 
+		static constexpr auto DiskBASIC = ROM::Name::TandyCoCoDiskBASIC21;
+		if(has_disk_drive) {
+			request = request && ROM::Request(DiskBASIC);
+		}
+
 		auto roms = rom_fetcher(request);
 		if(!request.validate(roms)) {
 			throw ROMMachine::Error::MissingROMs;
@@ -429,6 +434,10 @@ public:
 			sam_.set_alternate_basic(roms.find(*alternateBasicROM)->second);
 		} else {
 			sam_.set_no_alternate_basic();
+		}
+
+		if(has_disk_drive) {
+			sam_.insert_cartridge(roms.find(DiskBASIC)->second);
 		}
 
 		insert_media(target.media);
@@ -456,6 +465,15 @@ public:
 
 		bus_phase_ += duration;
 		bus_phase_ &= 1;
+
+		if constexpr (has_disk_drive) {
+			// Piggy-back off the existing bus_phase_ counter to multiply the clock by 4.5,
+			// giving very close to the standard 8Mhz. Unless and until a real clock speed emerges.
+			disk_controller_.run_for(
+				duration * 4 + bus_phase_
+			);
+		}
+
 		if(m6847_ += duration) {
 			pia0_.template set<Motorola::MC6821::Control::CA1>(m6847_.get()->hsync());
 			pia0_.template set<Motorola::MC6821::Control::CB1>(m6847_.get()->fsync());
@@ -511,6 +529,12 @@ public:
 					case 0xff33:	case 0xff37:	case 0xff3b:	case 0xff3f:
 						access<0xff23, read_write>(pia1_, value);
 					break;
+
+					case 0xff40:	if(has_disk_drive) access<0xff40, read_write>(disk_controller_, value); break;
+					case 0xff48:	if(has_disk_drive) access<0xff48, read_write>(disk_controller_, value); break;
+					case 0xff49:	if(has_disk_drive) access<0xff49, read_write>(disk_controller_, value); break;
+					case 0xff4a:	if(has_disk_drive) access<0xff4a, read_write>(disk_controller_, value); break;
+					case 0xff4b:	if(has_disk_drive) access<0xff4b, read_write>(disk_controller_, value); break;
 
 					case 0xffc0:	sam_.access<0xffc0>();	break;		case 0xffc1:	sam_.access<0xffc1>();	break;
 					case 0xffc2:	sam_.access<0xffc2>();	break;		case 0xffc3:	sam_.access<0xffc3>();	break;

--- a/Machines/Tandy/CoCo/CoCo.cpp
+++ b/Machines/Tandy/CoCo/CoCo.cpp
@@ -479,6 +479,11 @@ public:
 		const AddressT address,
 		CPU::M6809::data_t<read_write> value
 	) {
+		// Update after the fact due to the internal mechanics of WD177x posting; these signals from the WD should
+		// occur when it observes that the access cycle is over. It is now over because the next has begun.
+		m6809_.template set<CPU::M6809::Line::NMI>(nmi_);
+		m6809_.template set<CPU::M6809::Line::Halt>(halt_);
+
 		// TODO, maybe: pull the switch inside this SAM call outside the loop?
 		const auto delay = sam_.cycle_cost<bus_phase, read_write>(address, bus_phase_);
 		const auto duration = delay + CPU::M6809::duration<Cycles>(bus_phase);
@@ -1114,10 +1119,12 @@ private:
 
 	DiskController disk_controller_;
 	Cycles cycles_16mhz_;
+	bool nmi_ = false, halt_ = false;
 	void set_halt_nmi(const bool halt, const bool nmi) override {
-		// TODO: these should actually occur at the end of the cycle.
-		m6809_.template set<CPU::M6809::Line::NMI>(nmi);
-		m6809_.template set<CPU::M6809::Line::Halt>(halt);
+		// These flags have been supplied by the WD1770 based on its belief that the bus cycle is over.
+		// It isn't yet, so store them away to take effect once it is.
+		halt_ = halt;
+		nmi_ = nmi;
 	}
 };
 

--- a/Machines/Tandy/CoCo/DiskController.cpp
+++ b/Machines/Tandy/CoCo/DiskController.cpp
@@ -61,8 +61,10 @@ const Storage::Disk::Disk *DiskController::disk(const std::string &name) {
 //	* DRQ informs HALT, if enabled.
 //
 
-bool DiskController::halt() const {
-	return get_data_request_line() && enable_halt_;
+bool DiskController::halt() {
+	const bool halt = !get_data_request_line() && enable_halt_;
+	if(halt) enable_halt_ = false;
+	return halt;
 }
 
 bool DiskController::nmi() const {

--- a/Machines/Tandy/CoCo/DiskController.cpp
+++ b/Machines/Tandy/CoCo/DiskController.cpp
@@ -24,6 +24,7 @@ void DiskController::set_control(const uint8_t value) {
 	//	b3: drive motors, 1 = on
 	//	b0–b2: drive selects
 
+	double_density_ = value & 0x20;
 	set_is_double_density(value & 0x20);
 	for_all_drives([&] (Storage::Disk::Drive &drive, size_t) {
 		drive.set_motor_on(value & 0x8);
@@ -60,3 +61,11 @@ const Storage::Disk::Disk *DiskController::disk(const std::string &name) {
 //	* not INTRQ hits a NOR gate with DDEN; NOR of that is piped to NMI; and
 //	* DRQ informs HALT, if enabled.
 //
+
+bool DiskController::halt() const {
+	return get_data_request_line();
+}
+
+bool DiskController::nmi() const {
+	return get_interrupt_request_line() && double_density_;
+}

--- a/Machines/Tandy/CoCo/DiskController.cpp
+++ b/Machines/Tandy/CoCo/DiskController.cpp
@@ -54,19 +54,27 @@ const Storage::Disk::Disk *DiskController::disk(const std::string &name) {
 	return result;
 }
 
+// Reading code used on the machine per Disk BASIC Unravelled II:
 //
-// TODO:
+// LD881	LDB FDCREG+3
+// 			STB ,X+
+// 			STA DSKREG
+// 			BRA LD881
 //
-//	* not INTRQ hits a NOR gate with DDEN; NOR of that is piped to NMI; and
-//	* DRQ informs HALT, if enabled.
+// There's no obvious reason to STA DSKREG (i.e. the control register) within that loop unless
+// something about the values previously set by it has mutated.
 //
+// The schematic appears to show that NMI clears the HALT enable bit, so I've placed code
+// appropriately. But I also found the ROM to work if halt() itself cleared the halt enable.
+//
+// Possibly more research to do here.
 
 bool DiskController::halt() {
-	const bool halt = !get_data_request_line() && enable_halt_;
-	if(halt) enable_halt_ = false;
-	return halt;
+	return !get_data_request_line() && enable_halt_;
 }
 
-bool DiskController::nmi() const {
-	return get_interrupt_request_line() && double_density_;
+bool DiskController::nmi() {
+	const bool nmi = get_interrupt_request_line() && double_density_;
+	if(nmi) enable_halt_ = false;
+	return nmi;
 }

--- a/Machines/Tandy/CoCo/DiskController.cpp
+++ b/Machines/Tandy/CoCo/DiskController.cpp
@@ -13,3 +13,14 @@ using namespace Tandy::CoCo;
 DiskController::DiskController() : WD::WD1770(P1773) {
 	emplace_drives(2, 8'000'000, 300, 2);
 }
+
+void DiskController::set_control(uint8_t) {
+	// TODO:
+	//
+	//	b7: halt flag, 1 = enabled
+	//	b6: drive select 3
+	//	b5: density, 1 = double
+	//	b4: write precompensation, 1 = enable
+	//	b3: drive motors, 1 = on
+	//	b0–b2: drive selects
+}

--- a/Machines/Tandy/CoCo/DiskController.cpp
+++ b/Machines/Tandy/CoCo/DiskController.cpp
@@ -57,29 +57,6 @@ const Storage::Disk::Disk *DiskController::disk(const std::string &name) {
 	return result;
 }
 
-// Reading code used on the machine per Disk BASIC Unravelled II:
-//
-// LD881	LDB FDCREG+3
-// 			STB ,X+
-// 			STA DSKREG
-// 			BRA LD881
-//
-// There's no obvious reason to STA DSKREG (i.e. the control register) within that loop unless
-// something about the values previously set by it has mutated.
-//
-// The schematic appears to show that NMI clears the HALT enable bit, so I've placed code
-// appropriately. But I also found the ROM to work if halt() itself cleared the halt enable.
-//
-// Possibly more research to do here.
-
-bool DiskController::halt() const {
-	return halt_;
-}
-
-bool DiskController::nmi() const {
-	return nmi_;
-}
-
 void DiskController::wd1770_did_change_output(WD::WD1770 &) {
 	update_halt_nmi();
 }
@@ -87,18 +64,6 @@ void DiskController::wd1770_did_change_output(WD::WD1770 &) {
 void DiskController::update_halt_nmi() {
 	enable_halt_ &= !get_interrupt_request_line();
 
-	const bool new_nmi = get_interrupt_request_line() && double_density_;
-	const bool new_halt = !get_data_request_line() && enable_halt_;
-
-	if(new_nmi != nmi_ || new_halt != halt_) {
-		halt_ = new_halt;
-		nmi_ = new_nmi;
-		if(delegate_) {
-			delegate_->set_halt_nmi(halt_, nmi_);
-		}
-	}
-}
-
-void DiskController::set_delegate(Delegate *const delegate) {
-	delegate_ = delegate;
+	nmi_ = get_interrupt_request_line() && double_density_;
+	halt_ = !get_data_request_line() && enable_halt_;
 }

--- a/Machines/Tandy/CoCo/DiskController.cpp
+++ b/Machines/Tandy/CoCo/DiskController.cpp
@@ -11,10 +11,10 @@
 using namespace Tandy::CoCo;
 
 DiskController::DiskController() : WD::WD1770(P1773) {
-	emplace_drives(2, 8'000'000, 300, 2);
+	emplace_drives(4, 8'000'000, 300, 2);
 }
 
-void DiskController::set_control(uint8_t) {
+void DiskController::set_control(const uint8_t value) {
 	// TODO:
 	//
 	//	b7: halt flag, 1 = enabled
@@ -23,4 +23,33 @@ void DiskController::set_control(uint8_t) {
 	//	b4: write precompensation, 1 = enable
 	//	b3: drive motors, 1 = on
 	//	b0–b2: drive selects
+
+	set_is_double_density(value & 0x20);
+	for_all_drives([&] (Storage::Disk::Drive &drive, size_t) {
+		drive.set_motor_on(value & 0x8);
+	});
+	set_drive((value & 7) | ((value >> 3) & 8));
+
+	// TODO: HALT connection.
+}
+
+void DiskController::set_disk(std::shared_ptr<Storage::Disk::Disk> disk, const size_t drive) {
+	get_drive(drive).set_disk(disk);
+}
+
+void DiskController::set_activity_observer(Activity::Observer *const observer) {
+	for_all_drives([observer] (Storage::Disk::Drive &drive, size_t index) {
+		drive.set_activity_observer(observer, "Drive " + std::to_string(index+1), true);
+	});
+}
+
+const Storage::Disk::Disk *DiskController::disk(const std::string &name) {
+	const Storage::Disk::Disk *result = nullptr;
+	for_all_drives( [&](Storage::Disk::Drive &drive, size_t) {
+		const auto disk = drive.disk();
+		if(disk && disk->represents(name)) {
+			result = disk;
+		}
+	});
+	return result;
 }

--- a/Machines/Tandy/CoCo/DiskController.cpp
+++ b/Machines/Tandy/CoCo/DiskController.cpp
@@ -12,6 +12,7 @@ using namespace Tandy::CoCo;
 
 DiskController::DiskController() : WD::WD1770(P1773) {
 	emplace_drives(4, 8'000'000, 300, 2);
+	WD1770::set_delegate(this);
 }
 
 void DiskController::set_control(const uint8_t value) {
@@ -31,6 +32,8 @@ void DiskController::set_control(const uint8_t value) {
 	});
 	set_drive((value & 7) | ((value >> 3) & 8));
 	enable_halt_ = value & 0x80;
+
+	update_halt_nmi();
 }
 
 void DiskController::set_disk(std::shared_ptr<Storage::Disk::Disk> disk, const size_t drive) {
@@ -69,12 +72,32 @@ const Storage::Disk::Disk *DiskController::disk(const std::string &name) {
 //
 // Possibly more research to do here.
 
-bool DiskController::halt() {
-	return !get_data_request_line() && enable_halt_;
+bool DiskController::halt() const {
+	return halt_;
 }
 
-bool DiskController::nmi() {
-	const bool nmi = get_interrupt_request_line() && double_density_;
-	if(nmi) enable_halt_ = false;
-	return nmi;
+bool DiskController::nmi() const {
+	return nmi_;
+}
+
+void DiskController::wd1770_did_change_output(WD::WD1770 &) {
+	update_halt_nmi();
+}
+
+void DiskController::update_halt_nmi() {
+	const bool new_nmi = get_interrupt_request_line() && double_density_;
+	if(new_nmi) enable_halt_ = false;
+	const bool new_halt = !get_data_request_line() && enable_halt_;
+
+	if(new_nmi != nmi_ || new_halt != halt_) {
+		halt_ = new_halt;
+		nmi_ = new_nmi;
+		if(delegate_) {
+			delegate_->set_halt_nmi(halt_, nmi_);
+		}
+	}
+}
+
+void DiskController::set_delegate(Delegate *const delegate) {
+	delegate_ = delegate;
 }

--- a/Machines/Tandy/CoCo/DiskController.cpp
+++ b/Machines/Tandy/CoCo/DiskController.cpp
@@ -85,8 +85,9 @@ void DiskController::wd1770_did_change_output(WD::WD1770 &) {
 }
 
 void DiskController::update_halt_nmi() {
+	enable_halt_ &= !get_interrupt_request_line();
+
 	const bool new_nmi = get_interrupt_request_line() && double_density_;
-	if(new_nmi) enable_halt_ = false;
 	const bool new_halt = !get_data_request_line() && enable_halt_;
 
 	if(new_nmi != nmi_ || new_halt != halt_) {

--- a/Machines/Tandy/CoCo/DiskController.cpp
+++ b/Machines/Tandy/CoCo/DiskController.cpp
@@ -30,8 +30,7 @@ void DiskController::set_control(const uint8_t value) {
 		drive.set_motor_on(value & 0x8);
 	});
 	set_drive((value & 7) | ((value >> 3) & 8));
-
-	// TODO: HALT connection.
+	enable_halt_ = value & 0x80;
 }
 
 void DiskController::set_disk(std::shared_ptr<Storage::Disk::Disk> disk, const size_t drive) {
@@ -63,7 +62,7 @@ const Storage::Disk::Disk *DiskController::disk(const std::string &name) {
 //
 
 bool DiskController::halt() const {
-	return get_data_request_line();
+	return get_data_request_line() && enable_halt_;
 }
 
 bool DiskController::nmi() const {

--- a/Machines/Tandy/CoCo/DiskController.cpp
+++ b/Machines/Tandy/CoCo/DiskController.cpp
@@ -1,0 +1,15 @@
+//
+//  DiskController.cpp
+//  Clock Signal
+//
+//  Created by Thomas Harte on 18/05/2026.
+//  Copyright © 2026 Thomas Harte. All rights reserved.
+//
+
+#include "DiskController.hpp"
+
+using namespace Tandy::CoCo;
+
+DiskController::DiskController() : WD::WD1770(P1773) {
+	emplace_drives(2, 8'000'000, 300, 2);
+}

--- a/Machines/Tandy/CoCo/DiskController.cpp
+++ b/Machines/Tandy/CoCo/DiskController.cpp
@@ -53,3 +53,10 @@ const Storage::Disk::Disk *DiskController::disk(const std::string &name) {
 	});
 	return result;
 }
+
+//
+// TODO:
+//
+//	* not INTRQ hits a NOR gate with DDEN; NOR of that is piped to NMI; and
+//	* DRQ informs HALT, if enabled.
+//

--- a/Machines/Tandy/CoCo/DiskController.hpp
+++ b/Machines/Tandy/CoCo/DiskController.hpp
@@ -42,6 +42,12 @@ public:
 	void set_activity_observer(Activity::Observer *);
 	void set_disk(std::shared_ptr<Storage::Disk::Disk>, size_t drive);
 	const Storage::Disk::Disk *disk(const std::string &);
+
+	bool halt() const;
+	bool nmi() const;
+
+private:
+	bool double_density_ = false;
 };
 
 }

--- a/Machines/Tandy/CoCo/DiskController.hpp
+++ b/Machines/Tandy/CoCo/DiskController.hpp
@@ -1,0 +1,21 @@
+//
+//  DiskController.hpp
+//  Clock Signal
+//
+//  Created by Thomas Harte on 18/05/2026.
+//  Copyright © 2026 Thomas Harte. All rights reserved.
+//
+
+#pragma once
+
+#include "Components/1770/1770.hpp"
+
+namespace Tandy::CoCo {
+
+class DiskController final: public WD::WD1770 {
+public:
+	DiskController();
+
+};
+
+}

--- a/Machines/Tandy/CoCo/DiskController.hpp
+++ b/Machines/Tandy/CoCo/DiskController.hpp
@@ -16,6 +16,25 @@ class DiskController final: public WD::WD1770 {
 public:
 	DiskController();
 
+	void set_control(uint8_t);
+
+	template <int address>
+	uint8_t read() {
+		if(address & 8) {
+			return WD::WD1770::read(address);
+		} else {
+			return 0xff;
+		}
+	}
+
+	template <int address>
+	void write(const uint8_t value) {
+		if(address & 8) {
+			WD::WD1770::write(address, value);
+		} else {
+			set_control(value);
+		}
+	}
 };
 
 }

--- a/Machines/Tandy/CoCo/DiskController.hpp
+++ b/Machines/Tandy/CoCo/DiskController.hpp
@@ -43,7 +43,7 @@ public:
 	void set_disk(std::shared_ptr<Storage::Disk::Disk>, size_t drive);
 	const Storage::Disk::Disk *disk(const std::string &);
 
-	bool halt() const;
+	bool halt();
 	bool nmi() const;
 
 private:

--- a/Machines/Tandy/CoCo/DiskController.hpp
+++ b/Machines/Tandy/CoCo/DiskController.hpp
@@ -44,19 +44,13 @@ public:
 	void set_disk(std::shared_ptr<Storage::Disk::Disk>, size_t drive);
 	const Storage::Disk::Disk *disk(const std::string &);
 
-	bool halt() const;
-	bool nmi() const;
-
-	struct Delegate {
-		virtual void set_halt_nmi(bool halt, bool nmi) = 0;
-	};
-	void set_delegate(Delegate *);
+	bool halt() const { return halt_; }
+	bool nmi() const { return nmi_; }
 
 private:
 	bool double_density_ = false;
 	bool enable_halt_ = false;
 
-	Delegate *delegate_ = nullptr;
 	bool nmi_ = false;
 	bool halt_ = false;
 

--- a/Machines/Tandy/CoCo/DiskController.hpp
+++ b/Machines/Tandy/CoCo/DiskController.hpp
@@ -48,6 +48,7 @@ public:
 
 private:
 	bool double_density_ = false;
+	bool enable_halt_ = false;
 };
 
 }

--- a/Machines/Tandy/CoCo/DiskController.hpp
+++ b/Machines/Tandy/CoCo/DiskController.hpp
@@ -9,6 +9,9 @@
 #pragma once
 
 #include "Components/1770/1770.hpp"
+#include "Activity/Observer.hpp"
+
+#include <string>
 
 namespace Tandy::CoCo {
 
@@ -35,6 +38,10 @@ public:
 			set_control(value);
 		}
 	}
+
+	void set_activity_observer(Activity::Observer *);
+	void set_disk(std::shared_ptr<Storage::Disk::Disk>, size_t drive);
+	const Storage::Disk::Disk *disk(const std::string &);
 };
 
 }

--- a/Machines/Tandy/CoCo/DiskController.hpp
+++ b/Machines/Tandy/CoCo/DiskController.hpp
@@ -15,9 +15,10 @@
 
 namespace Tandy::CoCo {
 
-class DiskController final: public WD::WD1770 {
+class DiskController final: private WD::WD1770, public WD::WD1770::Delegate {
 public:
 	DiskController();
+	using WD::WD1770::run_for;
 
 	void set_control(uint8_t);
 
@@ -43,12 +44,24 @@ public:
 	void set_disk(std::shared_ptr<Storage::Disk::Disk>, size_t drive);
 	const Storage::Disk::Disk *disk(const std::string &);
 
-	bool halt();
-	bool nmi();
+	bool halt() const;
+	bool nmi() const;
+
+	struct Delegate {
+		virtual void set_halt_nmi(bool halt, bool nmi) = 0;
+	};
+	void set_delegate(Delegate *);
 
 private:
 	bool double_density_ = false;
 	bool enable_halt_ = false;
+
+	Delegate *delegate_ = nullptr;
+	bool nmi_ = false;
+	bool halt_ = false;
+
+	void wd1770_did_change_output(WD::WD1770 &) final;
+	void update_halt_nmi();
 };
 
 }

--- a/Machines/Tandy/CoCo/DiskController.hpp
+++ b/Machines/Tandy/CoCo/DiskController.hpp
@@ -44,7 +44,7 @@ public:
 	const Storage::Disk::Disk *disk(const std::string &);
 
 	bool halt();
-	bool nmi() const;
+	bool nmi();
 
 private:
 	bool double_density_ = false;

--- a/Machines/Utility/ROMCatalogue.cpp
+++ b/Machines/Utility/ROMCatalogue.cpp
@@ -1099,6 +1099,22 @@ const std::vector<Description> &Description::all_roms() {
 		},
 
 		{
+			TandyCoCoDiskBASIC10,
+			"TandyCoCo",
+			"Disk BASIC 1.0",
+			"disk10.rom",
+			8_kb,
+			0xb4f9968eu
+		},
+		{
+			TandyCoCoDiskBASIC11,
+			"TandyCoCo",
+			"Disk BASIC 1.1",
+			"disk11.rom",
+			8_kb,
+			0x0b9c5415u
+		},
+		{
 			TandyCoCoDiskBASIC21,
 			"TandyCoCo",
 			"Disk BASIC 2.1",

--- a/Machines/Utility/ROMCatalogue.cpp
+++ b/Machines/Utility/ROMCatalogue.cpp
@@ -1098,6 +1098,15 @@ const std::vector<Description> &Description::all_roms() {
 			0xcbdc1ba2u
 		},
 
+		{
+			TandyCoCoDiskBASIC21,
+			"TandyCoCo",
+			"Disk BASIC 2.1",
+			Files{"Disk21.bin", "DISK21.ROM"},
+			16_kb,
+			0xdf9dd220u
+		},
+
 	//
 	// Thomson MO and TO machines.
 	//

--- a/Machines/Utility/ROMCatalogue.cpp
+++ b/Machines/Utility/ROMCatalogue.cpp
@@ -1099,6 +1099,23 @@ const std::vector<Description> &Description::all_roms() {
 		},
 
 		{
+			TandyExtendedBASIC10,
+			"TandyCoCo",
+			"Extended BASIC 1.0",
+			"extbas10.rom",
+			8_kb,
+			0xe031d076u
+		},
+		{
+			TandyExtendedBASIC11,
+			"TandyCoCo",
+			"Extended BASIC 1.1",
+			"extbas11.rom",
+			8_kb,
+			0xa82a6254u
+		},
+
+		{
 			TandyCoCoDiskBASIC10,
 			"TandyCoCo",
 			"Disk BASIC 1.0",

--- a/Machines/Utility/ROMCatalogue.hpp
+++ b/Machines/Utility/ROMCatalogue.hpp
@@ -188,6 +188,8 @@ enum Name {
 	TandyCoCoColourBasic13,
 	TandyCoCoColourBasic14,
 
+	TandyCoCoDiskBASIC21,
+
 	// Thomson MO and TO machines.
 	ThomsonMO5v1,
 	ThomsonMO5v11,

--- a/Machines/Utility/ROMCatalogue.hpp
+++ b/Machines/Utility/ROMCatalogue.hpp
@@ -188,6 +188,8 @@ enum Name {
 	TandyCoCoColourBasic13,
 	TandyCoCoColourBasic14,
 
+	TandyCoCoDiskBASIC10,
+	TandyCoCoDiskBASIC11,
 	TandyCoCoDiskBASIC21,
 
 	// Thomson MO and TO machines.

--- a/Machines/Utility/ROMCatalogue.hpp
+++ b/Machines/Utility/ROMCatalogue.hpp
@@ -188,6 +188,9 @@ enum Name {
 	TandyCoCoColourBasic13,
 	TandyCoCoColourBasic14,
 
+	TandyExtendedBASIC10,
+	TandyExtendedBASIC11,
+
 	TandyCoCoDiskBASIC10,
 	TandyCoCoDiskBASIC11,
 	TandyCoCoDiskBASIC21,

--- a/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
@@ -43,6 +43,9 @@
 		42EB812E2B4700B700429AF4 /* MemoryMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 42EB812C2B47008D00429AF4 /* MemoryMap.cpp */; };
 		42EB812F2B4700B800429AF4 /* MemoryMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 42EB812C2B47008D00429AF4 /* MemoryMap.cpp */; };
 		4B01710F2FB6ADA700302CEF /* QuickLoadCompositeDynamicCropOptions.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4B01710D2FB6ADA700302CEF /* QuickLoadCompositeDynamicCropOptions.xib */; };
+		4B0171122FBBA40F00302CEF /* DiskController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0171112FBBA40F00302CEF /* DiskController.cpp */; };
+		4B0171132FBBA40F00302CEF /* DiskController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0171112FBBA40F00302CEF /* DiskController.cpp */; };
+		4B0171142FBBA40F00302CEF /* DiskController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0171112FBBA40F00302CEF /* DiskController.cpp */; };
 		4B018B89211930DE002A3937 /* 65C02_extended_opcodes_test.bin in Resources */ = {isa = PBXBuildFile; fileRef = 4B018B88211930DE002A3937 /* 65C02_extended_opcodes_test.bin */; };
 		4B01A6881F22F0DB001FD6E3 /* Z80MemptrTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B01A6871F22F0DB001FD6E3 /* Z80MemptrTests.swift */; };
 		4B0333AF2094081A0050B93D /* AppleDSK.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B0333AD2094081A0050B93D /* AppleDSK.cpp */; };
@@ -1398,6 +1401,8 @@
 		42EB81272B23AAC300429AF4 /* IMD.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = IMD.hpp; sourceTree = "<group>"; };
 		42EB812C2B47008D00429AF4 /* MemoryMap.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MemoryMap.cpp; sourceTree = "<group>"; };
 		4B01710E2FB6ADA700302CEF /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/QuickLoadCompositeDynamicCropOptions.xib; sourceTree = "<group>"; };
+		4B0171102FBBA40F00302CEF /* DiskController.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = DiskController.hpp; sourceTree = "<group>"; };
+		4B0171112FBBA40F00302CEF /* DiskController.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = DiskController.cpp; sourceTree = "<group>"; };
 		4B018B88211930DE002A3937 /* 65C02_extended_opcodes_test.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; name = 65C02_extended_opcodes_test.bin; path = "Klaus Dormann/65C02_extended_opcodes_test.bin"; sourceTree = "<group>"; };
 		4B01A6871F22F0DB001FD6E3 /* Z80MemptrTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Z80MemptrTests.swift; sourceTree = "<group>"; };
 		4B03291F2D0923E300C51EB5 /* Video.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Video.hpp; sourceTree = "<group>"; };
@@ -3441,7 +3446,9 @@
 			isa = PBXGroup;
 			children = (
 				4B41EF6F2FA55F980086D909 /* CoCo.cpp */,
+				4B0171112FBBA40F00302CEF /* DiskController.cpp */,
 				4B41EF6E2FA55F980086D909 /* CoCo.hpp */,
+				4B0171102FBBA40F00302CEF /* DiskController.hpp */,
 				4B41EF842FAC26590086D909 /* Keyboard.hpp */,
 			);
 			path = CoCo;
@@ -6639,6 +6646,7 @@
 				4B9BE401203A0C0600FFAE60 /* MultiSpeaker.cpp in Sources */,
 				4BB505812B962DDF0031C43C /* Plus3.cpp in Sources */,
 				4B055AA61FAE85EF0060FFFF /* Parser.cpp in Sources */,
+				4B0171142FBBA40F00302CEF /* DiskController.cpp in Sources */,
 				4BF8D4D6251C11DD00BBE21B /* 65816Storage.cpp in Sources */,
 				4B055AEF1FAE9BF00060FFFF /* Typer.cpp in Sources */,
 				4B89453F201967B4007DE474 /* StaticAnalyser.cpp in Sources */,
@@ -6928,6 +6936,7 @@
 				4BEDA3BA25B25563000C2DBD /* Decoder.cpp in Sources */,
 				4BFEA2EF2682A7B900EBF94C /* Dave.cpp in Sources */,
 				4B4518A21F75FD1C00926311 /* G64.cpp in Sources */,
+				4B0171132FBBA40F00302CEF /* DiskController.cpp in Sources */,
 				4B0B23A62D6AC53B00153879 /* CSFileContentChangeObserver.m in Sources */,
 				4B89452C201967B4007DE474 /* Tape.cpp in Sources */,
 				4B448E811F1C45A00009ABD6 /* TZX.cpp in Sources */,
@@ -7402,6 +7411,7 @@
 				4B06AB0E2C6461700034D014 /* MultiMediaTarget.cpp in Sources */,
 				42437B332AC70833006DFED1 /* HDV.cpp in Sources */,
 				4B06AAE82C645FCD0034D014 /* RP5C01.cpp in Sources */,
+				4B0171122FBBA40F00302CEF /* DiskController.cpp in Sources */,
 				4B06AAEC2C645FF50034D014 /* Keyboard.cpp in Sources */,
 				4B06AAF02C6460240034D014 /* ReactiveDevice.cpp in Sources */,
 				4B7752C028217F3D0073E2C5 /* Line.cpp in Sources */,

--- a/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
+++ b/OSBindings/Mac/Clock Signal.xcodeproj/project.pbxproj
@@ -425,6 +425,9 @@
 		4B56173E2F44B384003CB7FE /* ROMLibrary.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B56173C2F44B384003CB7FE /* ROMLibrary.cpp */; };
 		4B5617402F44D533003CB7FE /* ROMCatalogue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B051C5826670A9300CA44E8 /* ROMCatalogue.cpp */; };
 		4B5617412F44D533003CB7FE /* ROMCatalogue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B051C5826670A9300CA44E8 /* ROMCatalogue.cpp */; };
+		4B56997C2FBE201E00D272F0 /* CoCoDSK.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B56997B2FBE201E00D272F0 /* CoCoDSK.cpp */; };
+		4B56997D2FBE201E00D272F0 /* CoCoDSK.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B56997B2FBE201E00D272F0 /* CoCoDSK.cpp */; };
+		4B56997E2FBE201E00D272F0 /* CoCoDSK.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B56997B2FBE201E00D272F0 /* CoCoDSK.cpp */; };
 		4B58601E1F806AB200AEE2E3 /* MFMSectorDump.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B58601C1F806AB200AEE2E3 /* MFMSectorDump.cpp */; };
 		4B59199C1DAC6C46005BB85C /* OricTAP.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B59199A1DAC6C46005BB85C /* OricTAP.cpp */; };
 		4B595FAD2086DFBA0083CAA8 /* AudioToggle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B595FAC2086DFBA0083CAA8 /* AudioToggle.cpp */; };
@@ -1759,6 +1762,8 @@
 		4B5617322F42ADB8003CB7FE /* MOOF.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MOOF.cpp; sourceTree = "<group>"; };
 		4B56173B2F44B384003CB7FE /* ROMLibrary.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = ROMLibrary.hpp; sourceTree = "<group>"; };
 		4B56173C2F44B384003CB7FE /* ROMLibrary.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ROMLibrary.cpp; sourceTree = "<group>"; };
+		4B56997A2FBE201E00D272F0 /* CoCoDSK.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = CoCoDSK.hpp; sourceTree = "<group>"; };
+		4B56997B2FBE201E00D272F0 /* CoCoDSK.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CoCoDSK.cpp; sourceTree = "<group>"; };
 		4B58601C1F806AB200AEE2E3 /* MFMSectorDump.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MFMSectorDump.cpp; sourceTree = "<group>"; };
 		4B58601D1F806AB200AEE2E3 /* MFMSectorDump.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = MFMSectorDump.hpp; sourceTree = "<group>"; };
 		4B59199A1DAC6C46005BB85C /* OricTAP.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OricTAP.cpp; sourceTree = "<group>"; };
@@ -3533,6 +3538,7 @@
 				4B45188D1F75FD1B00926311 /* AcornADF.cpp */,
 				4BC080C826A238CC00D03FD8 /* AmigaADF.cpp */,
 				4B0333AD2094081A0050B93D /* AppleDSK.cpp */,
+				4B56997B2FBE201E00D272F0 /* CoCoDSK.cpp */,
 				4B45188F1F75FD1B00926311 /* CPCDSK.cpp */,
 				4B4518911F75FD1B00926311 /* D64.cpp */,
 				4BAF2B4C2004580C00480230 /* DMK.cpp */,
@@ -3558,6 +3564,7 @@
 				4B45188E1F75FD1B00926311 /* AcornADF.hpp */,
 				4BC080C926A238CC00D03FD8 /* AmigaADF.hpp */,
 				4B0333AE2094081A0050B93D /* AppleDSK.hpp */,
+				4B56997A2FBE201E00D272F0 /* CoCoDSK.hpp */,
 				4B4518901F75FD1B00926311 /* CPCDSK.hpp */,
 				4B4518921F75FD1B00926311 /* D64.hpp */,
 				4BAF2B4D2004580C00480230 /* DMK.hpp */,
@@ -6595,6 +6602,7 @@
 				4B8318B322D3E540006DB630 /* Audio.cpp in Sources */,
 				4B055AAE1FAE85FD0060FFFF /* TrackSerialiser.cpp in Sources */,
 				4B6AAEAC230E40250078E864 /* SCSI.cpp in Sources */,
+				4B56997D2FBE201E00D272F0 /* CoCoDSK.cpp in Sources */,
 				4B055A981FAE85C50060FFFF /* Drive.cpp in Sources */,
 				4BD424E62193B5830097291A /* Shader.cpp in Sources */,
 				4BC080CB26A238CC00D03FD8 /* AmigaADF.cpp in Sources */,
@@ -6937,6 +6945,7 @@
 				4BFEA2EF2682A7B900EBF94C /* Dave.cpp in Sources */,
 				4B4518A21F75FD1C00926311 /* G64.cpp in Sources */,
 				4B0171132FBBA40F00302CEF /* DiskController.cpp in Sources */,
+				4B56997E2FBE201E00D272F0 /* CoCoDSK.cpp in Sources */,
 				4B0B23A62D6AC53B00153879 /* CSFileContentChangeObserver.m in Sources */,
 				4B89452C201967B4007DE474 /* Tape.cpp in Sources */,
 				4B448E811F1C45A00009ABD6 /* TZX.cpp in Sources */,
@@ -7226,6 +7235,7 @@
 				4B06AAE42C645FA50034D014 /* DiskIICard.cpp in Sources */,
 				4B04C899285E3DC800AA8FD6 /* 65816ComparativeTests.mm in Sources */,
 				4B06AAF92C64607C0034D014 /* AudioToggle.cpp in Sources */,
+				4B56997C2FBE201E00D272F0 /* CoCoDSK.cpp in Sources */,
 				4B01A6881F22F0DB001FD6E3 /* Z80MemptrTests.swift in Sources */,
 				4B778EFA23A5EB790000D260 /* DMK.cpp in Sources */,
 				4BEE1EC122B5E2FD000A26A6 /* Encoder.cpp in Sources */,

--- a/Processors/6809/6809.hpp
+++ b/Processors/6809/6809.hpp
@@ -208,7 +208,11 @@ struct Processor {
 		switch(line) {
 			case Line::PowerOnReset:	set_exception(Exception::PowerOnReset);				break;
 			case Line::Reset: 			set_exception(Exception::Reset);					break;
-			case Line::NMI: 			if(value) exceptions_ |= uint8_t(Exception::NMI);	break;
+			case Line::NMI:
+				// Capture raising edge only.
+				if(value && !nmi_) exceptions_ |= uint8_t(Exception::NMI);
+				nmi_ = value;
+			break;
 			case Line::IRQ: 			set_exception(Exception::IRQ);						break;
 			case Line::FIRQ: 			set_exception(Exception::FIRQ);						break;
 			case Line::MRDY:			mrdy_ = value;										break;
@@ -1365,6 +1369,7 @@ private:
 	};
 	uint8_t exceptions_ = uint8_t(Exception::PowerOnReset);
 	bool mrdy_ = false;
+	bool nmi_ = false;
 
 	// Transient storage.
 	Data::Writeable target_;

--- a/ROMImages/TandyCoCo/readme.txt
+++ b/ROMImages/TandyCoCo/readme.txt
@@ -6,8 +6,10 @@ One or more of:
 * Color Basic v1.0 (1980) (Tandy).rom;
 * Color Basic v1.1 (1980) (Tandy).rom;
 * Color Basic v1.2 (1982) (Tandy).rom;
-* Color Basic v1.3 (1982) (Tandy).rom; and
+* Color Basic v1.3 (1982) (Tandy).rom; or
 * Color Basic v1.4 (1985) (Tandy).rom.
 
 For accessing disks:
+* disk10.rom;
+* disk11.rom; or
 * Disk21.bin.

--- a/ROMImages/TandyCoCo/readme.txt
+++ b/ROMImages/TandyCoCo/readme.txt
@@ -8,3 +8,6 @@ One or more of:
 * Color Basic v1.2 (1982) (Tandy).rom;
 * Color Basic v1.3 (1982) (Tandy).rom; and
 * Color Basic v1.4 (1985) (Tandy).rom.
+
+For accessing disks:
+* Disk21.bin.

--- a/Storage/Disk/DiskImage/Formats/CoCoDSK.cpp
+++ b/Storage/Disk/DiskImage/Formats/CoCoDSK.cpp
@@ -1,0 +1,34 @@
+//
+//  CoCoDSK.cpp
+//  Clock Signal
+//
+//  Created by Thomas Harte on 20/05/2026.
+//  Copyright © 2026 Thomas Harte. All rights reserved.
+//
+
+#include "CoCoDSK.hpp"
+
+namespace {
+constexpr int SectorsPerTrack = 18;
+constexpr int SectorSize = 1;
+}
+
+using namespace Storage::Disk;
+
+CoCoDSK::CoCoDSK(const std::string &file_name) : MFMSectorDump(file_name) {
+	// Complete validation at present: is this a multiple of the track size?
+	if(file_.stats().st_size % (SectorsPerTrack * SectorSize)) throw Error::InvalidFormat;
+	set_geometry(SectorsPerTrack, SectorSize, 1, Encodings::MFM::Density::Double);
+}
+
+HeadPosition CoCoDSK::maximum_head_position() const {
+	return HeadPosition(int(file_.stats().st_size / (SectorsPerTrack * SectorSize)));
+}
+
+int CoCoDSK::head_count() const {
+	return 1;
+}
+
+long CoCoDSK::get_file_offset_for_position(const Track::Address address) const {
+	return address.position.as_int() * SectorsPerTrack * (128 << SectorSize);
+}

--- a/Storage/Disk/DiskImage/Formats/CoCoDSK.cpp
+++ b/Storage/Disk/DiskImage/Formats/CoCoDSK.cpp
@@ -11,18 +11,19 @@
 namespace {
 constexpr int SectorsPerTrack = 18;
 constexpr int SectorSize = 1;
+constexpr int TrackSize = SectorsPerTrack * (128 << SectorSize);
 }
 
 using namespace Storage::Disk;
 
 CoCoDSK::CoCoDSK(const std::string &file_name) : MFMSectorDump(file_name) {
 	// Complete validation at present: is this a multiple of the track size?
-	if(file_.stats().st_size % (SectorsPerTrack * SectorSize)) throw Error::InvalidFormat;
+	if(file_.stats().st_size % TrackSize) throw Error::InvalidFormat;
 	set_geometry(SectorsPerTrack, SectorSize, 1, Encodings::MFM::Density::Double);
 }
 
 HeadPosition CoCoDSK::maximum_head_position() const {
-	return HeadPosition(int(file_.stats().st_size / (SectorsPerTrack * SectorSize)));
+	return HeadPosition(int(file_.stats().st_size / TrackSize));
 }
 
 int CoCoDSK::head_count() const {
@@ -30,5 +31,5 @@ int CoCoDSK::head_count() const {
 }
 
 long CoCoDSK::get_file_offset_for_position(const Track::Address address) const {
-	return address.position.as_int() * SectorsPerTrack * (128 << SectorSize);
+	return address.position.as_int() * TrackSize;
 }

--- a/Storage/Disk/DiskImage/Formats/CoCoDSK.cpp
+++ b/Storage/Disk/DiskImage/Formats/CoCoDSK.cpp
@@ -19,7 +19,7 @@ using namespace Storage::Disk;
 CoCoDSK::CoCoDSK(const std::string &file_name) : MFMSectorDump(file_name) {
 	// Complete validation at present: is this a multiple of the track size?
 	if(file_.stats().st_size % TrackSize) throw Error::InvalidFormat;
-	set_geometry(SectorsPerTrack, SectorSize, 1, Encodings::MFM::Density::Double);
+	set_geometry(SectorsPerTrack, SectorSize, 1, Encodings::MFM::Density::Double, 5);
 }
 
 HeadPosition CoCoDSK::maximum_head_position() const {

--- a/Storage/Disk/DiskImage/Formats/CoCoDSK.hpp
+++ b/Storage/Disk/DiskImage/Formats/CoCoDSK.hpp
@@ -1,0 +1,29 @@
+//
+//  CoCoDSK.hpp
+//  Clock Signal
+//
+//  Created by Thomas Harte on 20/05/2026.
+//  Copyright © 2026 Thomas Harte. All rights reserved.
+//
+
+#pragma once
+
+#include "MFMSectorDump.hpp"
+
+namespace Storage::Disk {
+
+class CoCoDSK: public MFMSectorDump {
+public:
+	CoCoDSK(const std::string &file_name);
+
+	HeadPosition maximum_head_position() const final;
+	int head_count() const final;
+
+private:
+	long get_file_offset_for_position(Track::Address address) const final;
+
+	int head_count_;
+	int track_count_;
+};
+
+}

--- a/Storage/Disk/DiskImage/Formats/FD.cpp
+++ b/Storage/Disk/DiskImage/Formats/FD.cpp
@@ -40,7 +40,7 @@ FD::FD(const std::string &file_name) : MFMSectorDump(file_name) {
 		break;
 	}
 
-	set_geometry(sectors_per_track, sector_size, 1, Encodings::MFM::Density::Double);
+	set_geometry(sectors_per_track, sector_size, 1, Encodings::MFM::Density::Double, 3);
 }
 
 HeadPosition FD::maximum_head_position() const {

--- a/Storage/Disk/DiskImage/Formats/MFMSectorDump.cpp
+++ b/Storage/Disk/DiskImage/Formats/MFMSectorDump.cpp
@@ -18,12 +18,14 @@ void MFMSectorDump::set_geometry(
 	const int sectors_per_track,
 	const uint8_t sector_size,
 	const uint8_t first_sector,
-	const Encodings::MFM::Density density
+	const Encodings::MFM::Density density,
+	const int ideal_sector_spacing
 ) {
 	sectors_per_track_ = sectors_per_track;
 	sector_size_ = sector_size;
 	density_ = density;
 	first_sector_ = first_sector;
+	ideal_sector_spacing_ = ideal_sector_spacing;
 }
 
 std::unique_ptr<Track> MFMSectorDump::track_at_position(const Track::Address address) const {
@@ -47,7 +49,9 @@ std::unique_ptr<Track> MFMSectorDump::track_at_position(const Track::Address add
 		uint8_t(address.head),
 		first_sector_,
 		sector_size_,
-		density_);
+		density_,
+		ideal_sector_spacing_
+	);
 }
 
 void MFMSectorDump::set_tracks(const std::map<Track::Address, std::unique_ptr<Track>> &tracks) {

--- a/Storage/Disk/DiskImage/Formats/MFMSectorDump.hpp
+++ b/Storage/Disk/DiskImage/Formats/MFMSectorDump.hpp
@@ -30,7 +30,13 @@ public:
 
 protected:
 	mutable Storage::FileHolder file_;
-	void set_geometry(int sectors_per_track, uint8_t sector_size, uint8_t first_sector, Encodings::MFM::Density);
+	void set_geometry(
+		int sectors_per_track,
+		uint8_t sector_size,
+		uint8_t first_sector,
+		Encodings::MFM::Density,
+		int ideal_sector_spacing = 1
+	);
 
 private:
 	virtual int head_count() const = 0;
@@ -41,6 +47,7 @@ private:
 	uint8_t sector_size_ = 0;
 	Encodings::MFM::Density density_ = Encodings::MFM::Density::Single;
 	uint8_t first_sector_ = 0;
+	int ideal_sector_spacing_ = 0;
 };
 
 }

--- a/Storage/Disk/DiskImage/Formats/Utility/ImplicitSectors.cpp
+++ b/Storage/Disk/DiskImage/Formats/Utility/ImplicitSectors.cpp
@@ -52,7 +52,6 @@ std::unique_ptr<Track> Storage::Disk::track_for_sectors(
 		new_sector.address.track = track;
 		new_sector.address.side = side;
 		new_sector.address.sector = uint8_t(first_sector + logical);
-//		printf("Wrote %d from offset %d\n", uint8_t(first_sector + logical), int(byte_size * logical));
 		new_sector.size = size;
 
 		new_sector.samples.emplace_back();

--- a/Storage/Disk/DiskImage/Formats/Utility/ImplicitSectors.cpp
+++ b/Storage/Disk/DiskImage/Formats/Utility/ImplicitSectors.cpp
@@ -15,39 +15,52 @@
 #include "Storage/Disk/Track/TrackSerialiser.hpp"
 
 #include <cstring>
+#include <limits>
 
 using namespace Storage::Disk;
 
 std::unique_ptr<Track> Storage::Disk::track_for_sectors(
 	const uint8_t *const source,
-	int number_of_sectors,
-	uint8_t track,
-	uint8_t side,
-	uint8_t first_sector,
-	uint8_t size,
-	Storage::Encodings::MFM::Density density
+	const int number_of_sectors,
+	const uint8_t track,
+	const uint8_t side,
+	const uint8_t first_sector,
+	const uint8_t size,
+	const Storage::Encodings::MFM::Density density,
+	const int ideal_sector_spacing
 ) {
 	std::vector<Storage::Encodings::MFM::Sector> sectors;
+	sectors.reserve(size_t(number_of_sectors));
+
+	// Brute-force an attempt at interleaving.
+	static constexpr auto Unassigned = std::numeric_limits<size_t>::max();
+	std::vector<size_t> slots(size_t(number_of_sectors), Unassigned);
+	size_t slot = 0;
+	for(int sector = 0; sector < number_of_sectors; sector++) {
+		while(slots[slot % size_t(number_of_sectors)] != Unassigned) ++slot;
+		slot %= size_t(number_of_sectors);
+		slots[slot] = size_t(sector);
+		slot += size_t(ideal_sector_spacing);
+	}
 
 	const size_t byte_size = size_t(128 << size);
-	size_t source_pointer = 0;
 	for(int sector = 0; sector < number_of_sectors; sector++) {
 		sectors.emplace_back();
+		const auto logical = slots[size_t(sector)];
 
 		Storage::Encodings::MFM::Sector &new_sector = sectors.back();
 		new_sector.address.track = track;
 		new_sector.address.side = side;
-		new_sector.address.sector = first_sector;
-		first_sector++;
+		new_sector.address.sector = uint8_t(first_sector + logical);
+//		printf("Wrote %d from offset %d\n", uint8_t(first_sector + logical), int(byte_size * logical));
 		new_sector.size = size;
 
 		new_sector.samples.emplace_back();
 		new_sector.samples[0].insert(
 			new_sector.samples[0].begin(),
-			source + source_pointer,
-			source + source_pointer + byte_size
+			source + logical * byte_size,
+			source + (logical + 1) * byte_size
 		);
-		source_pointer += byte_size;
 	}
 
 	if(!sectors.empty()) {

--- a/Storage/Disk/DiskImage/Formats/Utility/ImplicitSectors.hpp
+++ b/Storage/Disk/DiskImage/Formats/Utility/ImplicitSectors.hpp
@@ -23,8 +23,10 @@ std::unique_ptr<Track> track_for_sectors(
 	uint8_t side,
 	uint8_t first_sector,
 	uint8_t size,
-	Storage::Encodings::MFM::Density density
+	Storage::Encodings::MFM::Density density,
+	int ideal_sector_spacing = 1
 );
+
 void decode_sectors(
 	const Track &track,
 	uint8_t *destination,

--- a/cmake/CLK_SOURCES.cmake
+++ b/cmake/CLK_SOURCES.cmake
@@ -207,6 +207,7 @@ set(CLK_SOURCES
 	Storage/Disk/DiskImage/Formats/AcornADF.cpp
 	Storage/Disk/DiskImage/Formats/AmigaADF.cpp
 	Storage/Disk/DiskImage/Formats/AppleDSK.cpp
+	Storage/Disk/DiskImage/Formats/CoCoDSK.cpp
 	Storage/Disk/DiskImage/Formats/CPCDSK.cpp
 	Storage/Disk/DiskImage/Formats/D64.cpp
 	Storage/Disk/DiskImage/Formats/DMK.cpp

--- a/cmake/CLK_SOURCES.cmake
+++ b/cmake/CLK_SOURCES.cmake
@@ -153,6 +153,7 @@ set(CLK_SOURCES
 	Machines/Sinclair/ZX8081/Video.cpp
 	Machines/Sinclair/ZX8081/ZX8081.cpp
 	Machines/Sinclair/ZXSpectrum/ZXSpectrum.cpp
+	Machines/Tandy/CoCo/DiskController.cpp
 	Machines/Tandy/CoCo/CoCo.cpp
 	Machines/Thomson/MO/CD90-640.cpp
 	Machines/Thomson/MO/MO.cpp


### PR DESCRIPTION
This also:
* introduces the option of interleaved sectoring for implicit sector file formats and utilises it to improve Thomson loading speeds as well as pick a good baseline for the Tandy; and
* corrects an NMI signalling issue with the 6809.