### PR TITLE
Avoid potential divide-by-zero.

### DIFF
--- a/Numeric/StringSimilarity.hpp
+++ b/Numeric/StringSimilarity.hpp
@@ -38,9 +38,11 @@ inline double similarity(std::string_view first, std::string_view second) {
 
 	const auto first_pairs = pairs(first);
 	const auto second_pairs = pairs(second);
+	if(!first_pairs.size() && !second_pairs.size()) {
+		return 0.0;
+	}
 
 	const auto denominator = static_cast<double>(first_pairs.size() + second_pairs.size());
-
 	std::size_t numerator = 0;
 	auto first_it = first_pairs.begin();
 	auto second_it = second_pairs.begin();

--- a/Numeric/StringSimilarity.hpp
+++ b/Numeric/StringSimilarity.hpp
@@ -38,7 +38,7 @@ inline double similarity(std::string_view first, std::string_view second) {
 
 	const auto first_pairs = pairs(first);
 	const auto second_pairs = pairs(second);
-	if(!first_pairs.size() && !second_pairs.size()) {
+	if(first_pairs.empty() || second_pairs.empty()) {
 		return 0.0;
 	}
 


### PR DESCRIPTION
Resolves a potential crash when analysing Archimedes disks.